### PR TITLE
[codex] Add Flywheel bead skills for Claude and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # skills
 
-A collection of [Claude Code](https://claude.com/claude-code) skills.
+A collection of skills for [Claude Code](https://claude.com/claude-code) and
+[OpenAI Codex](https://github.com/openai/codex).
+
+The Flywheel bead skills in this repo intentionally stick to the shared
+agent-skills format so they can work in both tools.
 
 ## Available skills
 
@@ -12,6 +16,62 @@ Runs an iterative Codex review/fix/re-review loop on your current branch. Detect
 /codex-review-loop              # up to 6 passes (default)
 /codex-review-loop 3            # up to 3 passes
 /codex-review-loop 5 focus on error handling  # 5 passes, focused review
+```
+
+Best fit: Claude Code explicit invocation. This skill shells out to `codex
+review` and is most natural when run as a slash command from Claude Code.
+
+### plan-to-beads-transfer
+
+Translates a stable spec, PRD, or markdown plan into actual `br` beads with
+self-contained descriptions, explicit dependencies, and verification
+obligations.
+
+Claude Code:
+
+```text
+/plan-to-beads-transfer docs/PLAN.md
+```
+
+Codex:
+
+```text
+Use the plan-to-beads-transfer skill on docs/PLAN.md.
+```
+
+### bead-polish-loop
+
+Runs repeated bead-graph refinement rounds for coverage, deduplication,
+dependency repair, sizing, priority, and verification completeness until the
+graph converges.
+
+Claude Code:
+
+```text
+/bead-polish-loop
+```
+
+Codex:
+
+```text
+Use the bead-polish-loop skill on the current bead graph.
+```
+
+### second-model-bead-audit
+
+Provides an independent audit of an existing bead graph against the plan, with
+blocking findings first and exact bead-level fixes when obvious.
+
+Claude Code:
+
+```text
+/second-model-bead-audit docs/PLAN.md
+```
+
+Codex:
+
+```text
+Use the second-model-bead-audit skill and give me a launch verdict.
 ```
 
 ## Install
@@ -28,22 +88,32 @@ cd skills
 ./install.sh
 ```
 
-Install a specific skill only:
+By default, `install.sh` installs into `~/.claude/skills`. Use `--target
+codex` or `--target both` to install into Codex as well.
+
+Install specific skills:
 
 ```bash
 ./install.sh codex-review-loop
+./install.sh --target codex plan-to-beads-transfer bead-polish-loop second-model-bead-audit
+./install.sh --target both plan-to-beads-transfer bead-polish-loop second-model-bead-audit
 ```
 
 ## Uninstall
 
 ```bash
 ./install.sh --uninstall
+./install.sh --target both --uninstall
 ```
 
 ## Prerequisites
 
-- [Claude Code](https://claude.com/claude-code)
-- [OpenAI Codex CLI](https://github.com/openai/codex) (`codex` binary on PATH) for codex-review-loop
+- [Claude Code](https://claude.com/claude-code) for Claude installation targets
+- [OpenAI Codex CLI](https://github.com/openai/codex) for Codex installation targets
+- `codex` on `PATH` for `codex-review-loop`
+- `br` and `bv` on `PATH`, plus a repo that uses `.beads/`, for
+  `plan-to-beads-transfer`, `bead-polish-loop`, and
+  `second-model-bead-audit`
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -1,47 +1,70 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s nullglob
 
 # skills installer
-# Clones (or updates) the repo and symlinks skills into ~/.claude/skills/
+# Clones (or updates) the repo and symlinks skills into Claude and/or Codex.
 
 REPO_URL="https://github.com/douglaz/skills.git"
 DEFAULT_INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/claude-skills"
-SKILLS_DIR="$HOME/.claude/skills"
+CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+CODEX_SKILLS_DIR="$HOME/.agents/skills"
 
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS] [SKILL_NAME...]
 
-Install Claude Code skills from douglaz/skills.
+Install Claude Code and Codex skills from douglaz/skills.
 
 If no skill names are given, all skills are installed.
 If skill names are given, only those skills are installed.
 
 Options:
   --dir DIR    Install to DIR instead of $DEFAULT_INSTALL_DIR
+  --target T   Install into claude, codex, or both (default: claude)
   --uninstall  Remove skill symlinks and optionally the cloned repo
   -h, --help   Show this help
 
 Examples:
-  $(basename "$0")                    # install all skills
-  $(basename "$0") codex-review-loop  # install only codex-review-loop
-  $(basename "$0") --uninstall        # remove all skills
+  $(basename "$0")                                 # install all skills to Claude
+  $(basename "$0") --target codex plan-to-beads-transfer
+  $(basename "$0") --target both bead-polish-loop second-model-bead-audit
+  $(basename "$0") --target both --uninstall       # remove installed symlinks
 EOF
 }
 
 install_dir="$DEFAULT_INSTALL_DIR"
 uninstall=false
+target="claude"
 skills=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dir)       install_dir="$2"; shift 2 ;;
+    --target)    target="$2"; shift 2 ;;
     --uninstall) uninstall=true; shift ;;
     -h|--help)   usage; exit 0 ;;
     -*)          echo "Unknown option: $1" >&2; usage; exit 1 ;;
     *)           skills+=("$1"); shift ;;
   esac
 done
+
+case "$target" in
+  claude)
+    target_dirs=("$CLAUDE_SKILLS_DIR")
+    ;;
+  codex)
+    target_dirs=("$CODEX_SKILLS_DIR")
+    ;;
+  both)
+    target_dirs=("$CLAUDE_SKILLS_DIR" "$CODEX_SKILLS_DIR")
+    ;;
+  *)
+    echo "Unknown target: $target" >&2
+    usage
+    exit 1
+    ;;
+esac
 
 # Discover available skills in the repo
 discover_skills() {
@@ -53,22 +76,33 @@ discover_skills() {
   printf '%s\n' "${found[@]}"
 }
 
+remove_symlinks_from_dir() {
+  local dir="$1"
+  local removed=0
+  local target_path
+
+  [[ -d "$dir" ]] || {
+    echo "No target directory at $dir"
+    return
+  }
+
+  for link in "$dir"/*; do
+    [[ -L "$link" ]] || continue
+    target_path=$(readlink "$link")
+    if [[ "$target_path" == "$install_dir"* ]]; then
+      rm "$link"
+      echo "Removed symlink: $link"
+      ((removed += 1))
+    fi
+  done
+
+  [[ $removed -eq 0 ]] && echo "No symlinks found in $dir pointing to $install_dir"
+}
+
 if $uninstall; then
-  # Find all symlinks in SKILLS_DIR that point into install_dir
-  removed=0
-  if [[ -d "$SKILLS_DIR" ]]; then
-    for link in "$SKILLS_DIR"/*/; do
-      link="${link%/}"
-      [[ -L "$link" ]] || continue
-      target=$(readlink "$link")
-      if [[ "$target" == "$install_dir"* ]]; then
-        rm "$link"
-        echo "Removed symlink: $link"
-        ((removed++))
-      fi
-    done
-  fi
-  [[ $removed -eq 0 ]] && echo "No symlinks found pointing to $install_dir"
+  for target_dir in "${target_dirs[@]}"; do
+    remove_symlinks_from_dir "$target_dir"
+  done
 
   if [[ -d "$install_dir" ]]; then
     read -rp "Also remove cloned repo at $install_dir? [y/N] " answer
@@ -100,34 +134,44 @@ if [[ ${#skills[@]} -eq 0 ]]; then
   exit 1
 fi
 
-# Ensure target directory exists
-mkdir -p "$SKILLS_DIR"
+# Ensure target directories exist
+for target_dir in "${target_dirs[@]}"; do
+  mkdir -p "$target_dir"
+done
 
-# Symlink each skill
+# Symlink each skill into each selected target
 for skill in "${skills[@]}"; do
   skill_source="$install_dir/skills/$skill"
-  symlink_target="$SKILLS_DIR/$skill"
 
   if [[ ! -d "$skill_source" ]]; then
     echo "WARNING: skill '$skill' not found at $skill_source, skipping"
     continue
   fi
 
-  if [[ -L "$symlink_target" ]]; then
-    current=$(readlink "$symlink_target")
-    if [[ "$current" == "$skill_source" ]]; then
-      echo "  $skill: already linked"
+  for target_dir in "${target_dirs[@]}"; do
+    symlink_target="$target_dir/$skill"
+
+    if [[ -L "$symlink_target" ]]; then
+      current=$(readlink "$symlink_target")
+      if [[ "$current" == "$skill_source" ]]; then
+        echo "  $skill [$target_dir]: already linked"
+      else
+        ln -sfn "$skill_source" "$symlink_target"
+        echo "  $skill [$target_dir]: updated symlink"
+      fi
+    elif [[ -e "$symlink_target" ]]; then
+      echo "  $skill [$target_dir]: WARNING - $symlink_target exists and is not a symlink, skipping"
     else
-      ln -sfn "$skill_source" "$symlink_target"
-      echo "  $skill: updated symlink"
+      ln -s "$skill_source" "$symlink_target"
+      echo "  $skill [$target_dir]: installed"
     fi
-  elif [[ -e "$symlink_target" ]]; then
-    echo "  $skill: WARNING - $symlink_target exists and is not a symlink, skipping"
-  else
-    ln -s "$skill_source" "$symlink_target"
-    echo "  $skill: installed"
-  fi
+  done
 done
 
 echo ""
-echo "Done! Installed ${#skills[@]} skill(s). Use /<skill-name> in Claude Code."
+echo "Done! Installed ${#skills[@]} skill(s) to:"
+for target_dir in "${target_dirs[@]}"; do
+  echo "  - $target_dir"
+done
+echo "Claude Code: use /<skill-name>."
+echo "Codex: mention the skill by name in your request."

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: bead-polish-loop
+description: Refines an existing bead graph through repeated review-and-revise rounds for coverage, deduplication, dependency repair, sizing, priority, and verification completeness until the graph converges. Use when a bead batch already exists but still feels vague, duplicated, over-broad, or dependency-wrong. Do not use for first-draft planning or ordinary code review.
+compatibility: Requires br and bv on PATH and a repo that uses .beads/.
+---
+
+Polish the bead graph until it is launch-ready, not just plausible.
+
+## Use this skill when
+
+- a fresh batch of beads was just created from a plan
+- a large feature slice was added to an existing graph
+- the graph feels vague, duplicated, over-broad, or dependency-wrong
+- you want to improve the graph before implementation starts
+
+## Do not use this skill when
+
+- the project still needs plan-level work more than bead-level work
+- the user is asking for implementation rather than graph refinement
+- there are no meaningful beads yet to inspect
+
+## Required outputs for each invocation
+
+1. A refined bead graph, with actual `br` updates when changes are justified.
+2. A concise round report: what changed, what remains risky, and whether to continue.
+3. A convergence judgment: major-change mode, refinement mode, or near-converged.
+
+## Recommended loop shape
+
+- small projects: at least 3 full rounds
+- normal projects: 4 to 6 rounds
+- high-stakes work: keep going while fresh rounds still find meaningful issues
+
+Do not stop because you hit a number. Stop because the changes became small,
+local, and mostly corrective.
+
+## Per-round workflow
+
+1. Reread `AGENTS.md`, then load the current graph and relevant plan/spec.
+2. Establish a baseline:
+   - `br list --limit 0 --json -a`
+   - `bv --robot-triage`
+   - `bv --robot-plan`
+   - `bv --robot-suggest`
+   - optionally `bv --robot-insights` and `bv --robot-priority`
+3. Run these passes in order.
+
+### Pass A. Duplicate and overlap detection
+
+- look for exact duplicates, near-duplicates, and beads with heavily overlapping ownership
+- prefer one canonical survivor when two beads are effectively the same job
+- use [references/dedupe-heuristics.md](references/dedupe-heuristics.md)
+
+### Pass B. Coverage audit
+
+- check plan -> beads and beads -> plan
+- make sure every workflow, constraint, failure path, and verification obligation still lands somewhere
+- split or add beads if coverage is thin
+
+### Pass C. Quality rewrite
+
+Score material beads with [references/polish-rubric.md](references/polish-rubric.md). Rewrite low-scoring beads so they become self-contained and testable.
+
+### Pass D. Dependency and launchability repair
+
+- fix missing, reversed, or over-constraining dependencies
+- inspect for cycles, bottlenecks, and unhealthy ready-frontier shape
+- prefer a graph that allows multiple independent agents to proceed safely
+
+### Pass E. Test and observability completeness
+
+Make sure the graph names how work will be verified. If the project is
+user-facing or operationally sensitive, insist on explicit unit and integration/e2e
+obligations and useful logging or diagnostics.
+
+### Pass F. Sizing and priority cleanup
+
+- split oversized beads that hide multiple deliverables
+- merge tiny beads only when the merge sharpens execution rather than blurring it
+- tighten priority where the graph and plan disagree
+
+4. Apply only justified changes with `br`.
+5. Flush mutations with `br sync --flush-only`.
+6. Record a round summary:
+   - beads added, rewritten, merged, closed, or reprioritized
+   - major risks still open
+   - whether another round is warranted
+7. Score convergence with [references/convergence-scorecard.md](references/convergence-scorecard.md).
+
+## Stop conditions
+
+Prefer to stop when most of these are true:
+
+- no major uncovered plan elements remain
+- no obvious duplicate or near-duplicate beads remain
+- no dependency anomalies block understanding of the frontier
+- low-quality beads are now rare and localized
+- two consecutive rounds make only small, corrective edits
+- convergence score is high enough that another round is likely low yield
+
+## Escalation rules
+
+- If the graph keeps expanding, step back into plan space.
+- If the graph oscillates between two shapes, reframe the decomposition instead of polishing forever.
+- If the current session stops finding subtle issues, start a fresh session and rerun this skill.
+- For a final independent check, hand the graph to the `second-model-bead-audit` skill.
+
+## Command palette
+
+```bash
+br list --limit 0 --json -a
+br show <id> --json
+br update <id> --description "..."
+br close <id> --reason "merged into ..."
+br dep add <issue> <depends-on>
+br dep remove <issue> <depends-on>
+bv --robot-triage
+bv --robot-plan
+bv --robot-suggest
+bv --robot-insights
+bv --robot-priority
+br sync --flush-only
+```
+
+## Common failure patterns to avoid
+
+- polishing only titles while leaving descriptions vague
+- deduplicating solely by title similarity
+- changing priorities without checking graph impact
+- assuming a big graph is complete because it is verbose
+- oversimplifying and silently deleting functionality or test obligations
+- treating the first decent pass as final
+
+## Additional resources
+
+- For scoring bead quality, see [references/polish-rubric.md](references/polish-rubric.md).
+- For convergence decisions, see [references/convergence-scorecard.md](references/convergence-scorecard.md).
+- For dedup rules, see [references/dedupe-heuristics.md](references/dedupe-heuristics.md).

--- a/skills/bead-polish-loop/references/convergence-scorecard.md
+++ b/skills/bead-polish-loop/references/convergence-scorecard.md
@@ -1,0 +1,59 @@
+# Convergence Scorecard
+
+Load this file when deciding whether to keep polishing.
+
+Use three signals. Score each from 0.0 to 1.0.
+
+## 1. Output size shrinking (weight 0.35)
+
+Ask:
+- are the round summaries getting shorter?
+- are fewer beads needing major rewrites?
+
+Guide:
+- 0.0 = still expanding a lot
+- 0.5 = mixed
+- 1.0 = clearly shrinking
+
+## 2. Change velocity slowing (weight 0.35)
+
+Ask:
+- are you making fewer structural changes each round?
+- are new critical findings dropping?
+
+Guide:
+- 0.0 = major graph surgery still happening
+- 0.5 = moderate cleanup still happening
+- 1.0 = mostly corrective edits only
+
+## 3. Content similarity increasing (weight 0.30)
+
+Ask:
+- do successive rounds mostly agree on the graph shape?
+- are you seeing confirmation of the same stable structure rather than new rethinks?
+
+Guide:
+- 0.0 = oscillating or reframing repeatedly
+- 0.5 = partial stability
+- 1.0 = strong stability
+
+## Weighted score
+
+```text
+score = 0.35 * size + 0.35 * velocity + 0.30 * similarity
+```
+
+## Decision guide
+
+- `< 0.50`: not close; keep iterating
+- `0.50 - 0.74`: improving, but still not launch-ready by convergence alone
+- `0.75 - 0.89`: usually good enough if translation and quality gates pass
+- `>= 0.90`: likely diminishing returns
+
+## Red flags
+
+Stop and reframe instead of polishing harder if you see:
+
+- oscillation between two decompositions
+- graph growth that keeps adding complexity without clarifying ownership
+- plateau at obviously low quality

--- a/skills/bead-polish-loop/references/dedupe-heuristics.md
+++ b/skills/bead-polish-loop/references/dedupe-heuristics.md
@@ -1,0 +1,52 @@
+# Dedupe Heuristics
+
+Load this file during the duplicate pass.
+
+## Exact duplicate signals
+
+Two beads are probably duplicates if most of these are true:
+
+- same deliverable or same acceptance signal
+- same affected files or same subsystem
+- same user workflow and same failure path
+- one adds no meaningful extra rationale or constraints
+
+## Near-duplicate signals
+
+Two beads may need merging or re-scoping if:
+
+- one is a thin slice of the other with no independent claim value
+- both own the same test obligation
+- both depend on the same predecessor and unblock the same successor
+- the distinction is title-deep but not execution-deep
+
+## Survivor selection rules
+
+Keep the canonical survivor that has the best combination of:
+
+- richer rationale
+- clearer verification
+- better dependency placement
+- more precise scope boundaries
+- correct priority
+
+Merge missing strengths from the loser into the survivor before closing the
+loser.
+
+## When not to merge
+
+Do not merge merely because two beads are related. Keep them separate when:
+
+- they can be claimed independently
+- they land on different dependency tracks
+- they protect different user or operator outcomes
+- merging would create a vague umbrella bead
+
+## Good closure pattern
+
+If bead B is merged into bead A:
+
+1. enrich bead A with anything worth keeping from B
+2. close B with a clear reason
+3. update dependencies that pointed at B
+4. rerun the frontier check

--- a/skills/bead-polish-loop/references/polish-rubric.md
+++ b/skills/bead-polish-loop/references/polish-rubric.md
@@ -1,0 +1,57 @@
+# Bead Polish Rubric
+
+Load this file when scoring or rewriting beads.
+
+Score each category 0, 1, or 2.
+
+## Categories
+
+### 1. WHAT
+- 0: unclear or generic task wording
+- 1: roughly clear, but still broad or ambiguous
+- 2: concrete outcome or deliverable is clear
+
+### 2. WHY
+- 0: no user/product/operational reason stated
+- 1: implied reason, but weak
+- 2: clear rationale and value
+
+### 3. HOW / KEY CONSTRAINTS
+- 0: no guidance on important constraints or interfaces
+- 1: partial notes, but future agents still have to guess
+- 2: major constraints and tricky edges are explicit
+
+### 4. DEPENDENCIES / ORDERING
+- 0: ordering is implicit or wrong
+- 1: some sequencing hints, but incomplete
+- 2: dependencies are explicit and sensible
+
+### 5. VERIFICATION
+- 0: no explicit validation path
+- 1: says "add tests" but lacks specifics
+- 2: names concrete unit/integration/e2e or equivalent checks
+
+### 6. OBSERVABILITY / OPERATIONS
+- 0: no diagnostics for work that obviously needs them
+- 1: vague mention of logs/monitoring
+- 2: explicit logging, metrics, or diagnostics where relevant
+
+### 7. BOUNDARIES / NON-GOALS
+- 0: bead could sprawl indefinitely
+- 1: partial boundaries
+- 2: clear scope and non-goals
+
+## Interpretation
+
+- 12-14: strong bead
+- 9-11: usable but should still be tightened if the area is important
+- 0-8: rewrite before launch
+
+## Rewrite priority
+
+When time is limited, rewrite beads in this order:
+
+1. low score + high priority
+2. low score + on critical dependency chain
+3. low score + broad user-visible impact
+4. everything else

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: plan-to-beads-transfer
+description: Converts a stable spec, PRD, or markdown plan into actual `br` beads with rich self-contained descriptions, explicit dependencies, and verification obligations. Use when a feature plan is approved and needs to become an execution graph, or when a major plan revision means the bead graph must be refreshed. Do not use for implementation, loose brainstorming, or unstable architecture work.
+compatibility: Requires br and bv on PATH and a repo that uses .beads/.
+---
+
+Turn a stable plan into executable beads without losing meaning.
+
+## Use this skill when
+
+- a markdown plan or spec is already detailed enough to guide execution
+- the user wants actual `br` beads, not pseudo-tasks in markdown
+- a feature batch was approved and now needs a dependency-aware bead graph
+- an existing plan changed enough that the bead graph must be refreshed
+
+## Do not use this skill when
+
+- the architecture is still actively undecided
+- the work is tiny enough for an ephemeral TODO and should not become permanent project memory
+- the user wants code written now instead of task graph setup
+- the current request is really a plan-writing or idea-generation request
+
+## Required outputs
+
+1. Actual beads created or updated with `br`.
+2. Explicit dependency links.
+3. A short coverage report that maps plan areas to bead IDs.
+4. A short note listing unresolved contradictions or questions, if any remain.
+
+## Workflow
+
+1. Reread `AGENTS.md`, the relevant plan/spec files, and any repo-local best-practices docs.
+2. Decide whether the plan is translation-ready. If major workflows, constraints, failure paths, sequencing, or test expectations are still vague, stop and report plan gaps instead of creating brittle beads.
+3. Ground in the current graph before creating anything new:
+   - `br list --limit 0 --json -a`
+   - `bv --robot-triage`
+   - `bv --robot-plan`
+   - optionally `bv --robot-search --search "..."` when checking overlap with existing work
+4. Build a coverage map from the plan. Every material item should appear somewhere in the map:
+   - user workflows and success paths
+   - failure paths and operational flows
+   - constraints and non-goals
+   - migrations, compatibility edges, rollout details, or docs work if the plan calls for them
+   - verification obligations: unit, integration, e2e, logging, observability
+5. Choose the graph shape before creating beads:
+   - epics for major user-visible surfaces or architectural slices
+   - tasks for independently claimable work packets
+   - subtasks only when they sharpen sequencing or reduce ambiguity
+   - avoid giant umbrella beads that mix unrelated surfaces
+6. Create or revise actual beads only with `br`. Do not leave pseudo-beads in markdown.
+7. For each created or revised bead, make the description self-contained. Use the template in [references/bead-description-template.md](references/bead-description-template.md).
+8. Add explicit dependencies with `br dep add`. Prefer dependencies that preserve a healthy ready frontier instead of over-constraining the graph.
+9. Run a transfer audit in both directions:
+   - plan -> beads: every important plan element lands somewhere
+   - beads -> plan: every bead has a clear reason to exist in the plan or approved delta
+10. Split, merge, rewrite, or close beads until the graph can stand on its own.
+11. Flush the bead state with `br sync --flush-only` after mutations.
+
+## Quality bar
+
+A good transfer means a fresh agent can claim a bead and execute it without reopening the original plan just to understand the goal.
+
+Each material bead should say:
+
+- what outcome changes for the user, system, or operator
+- why the work exists
+- boundaries and non-goals
+- dependencies or ordering assumptions
+- how the result will be verified
+- any critical gotchas the next agent would otherwise rediscover the hard way
+
+## Command palette
+
+```bash
+br list --limit 0 --json -a
+br create "Title" --type task --priority 2 --description "..."
+br create "Epic" --type epic --priority 1 --description "..."
+br create "Subtask" --parent <epic-id> --priority 2 --description "..."
+br update <id> --description "..."
+br dep add <issue> <depends-on>
+bv --robot-triage
+bv --robot-plan
+bv --robot-search --search "query"
+br sync --flush-only
+```
+
+## Common failure patterns to avoid
+
+- collapsing a rich plan into terse TODOs
+- omitting test or observability obligations because they are "obvious"
+- creating duplicate beads without reading the existing graph first
+- creating beads that only make sense if the original plan stays open nearby
+- encoding sequencing in prose without explicit dependencies
+- overusing parent/child depth when ordinary dependencies would be clearer
+
+## Additional resources
+
+- For the bead description structure, see [references/bead-description-template.md](references/bead-description-template.md).
+- For the translation coverage pass, see [references/coverage-matrix-template.md](references/coverage-matrix-template.md).

--- a/skills/plan-to-beads-transfer/references/bead-description-template.md
+++ b/skills/plan-to-beads-transfer/references/bead-description-template.md
@@ -1,0 +1,56 @@
+# Bead Description Template
+
+Load this file when you are creating or rewriting bead descriptions.
+
+Use this structure when the bead is material enough that future agents could
+misread its purpose. Shorter beads can compress the wording, but they should
+still preserve the same information.
+
+```markdown
+## Outcome
+What behavior, capability, or user-visible/system-visible result should exist
+after this bead is done?
+
+## Why this exists
+Why does the project need this? What user, product, or operational goal does it
+serve?
+
+## Scope
+What is in scope for this bead?
+
+## Non-goals
+What is explicitly not part of this bead?
+
+## Key implementation notes
+Important interfaces, data flows, sequencing assumptions, migration details, or
+tricky constraints that the next agent must not miss.
+
+## Dependencies / ordering
+What must already exist, and what will this unblock?
+
+## Verification
+- Unit tests:
+- Integration or e2e tests:
+- Logging / observability / diagnostics:
+- Acceptance signal:
+
+## Spec refs
+List the relevant plan sections, filenames, or approved deltas.
+```
+
+## Compression rules
+
+You may compress headings into paragraphs for tiny beads, but never omit:
+
+- outcome
+- why
+- dependencies or ordering
+- verification
+
+## Good writing rules
+
+- Prefer concrete behavior over generic implementation verbs.
+- Mention failure handling when the plan calls for it.
+- Spell out the decisive test or validation signal.
+- Include gotchas if a future agent would likely make the same mistake without
+  them.

--- a/skills/plan-to-beads-transfer/references/coverage-matrix-template.md
+++ b/skills/plan-to-beads-transfer/references/coverage-matrix-template.md
@@ -1,0 +1,28 @@
+# Plan-to-Beads Coverage Matrix Template
+
+Load this file during the transfer audit.
+
+Use a simple table or checklist like this while translating the plan:
+
+| Plan element | Why it matters | Covered by bead IDs | Gap? | Notes |
+|---|---|---|---|---|
+| Upload success path | Core user flow | br-101, br-104 | No | Parser and UI split across two beads |
+| Upload failure handling | Operator visibility | br-102 | No | Includes retry surface |
+| Auth boundary | Security-critical constraint | br-107 | Maybe | Need explicit admin-only acceptance checks |
+| E2E coverage | Ship gate requirement | br-111 | No | Must include logging |
+
+## What must appear in the matrix
+
+- primary user workflows
+- admin/operator workflows
+- error and retry paths
+- constraints and security boundaries
+- migration or rollout obligations
+- test and diagnostics obligations
+
+## Decision rules
+
+- If one plan element maps to no bead, add or revise a bead.
+- If one bead maps to no approved plan element or approved delta, challenge the bead.
+- If one bead owns too many unrelated plan elements, split it.
+- If two beads map to the same narrow obligation, inspect for duplication.

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: second-model-bead-audit
+description: Audits a bead graph against the plan with an independent second opinion, checking coverage gaps, duplicate ownership, weak descriptions, dependency mistakes, and missing verification obligations before implementation starts. Use when another agent already created or polished the beads and you want a launch verdict with exact fixes. Prefer read-only review unless the user explicitly asks for bead edits.
+compatibility: Requires br and bv on PATH and a repo that uses .beads/.
+---
+
+Provide a second-model audit of the bead graph without inheriting the first
+model's blind spots.
+
+## Default posture
+
+Stay in read-only audit mode unless the user explicitly asks you to apply fixes.
+
+## Use this skill when
+
+- Claude or another agent already created/refined beads and the user wants Codex or another model to review them
+- the project is important enough that a second-model check is worth the time
+- the graph feels plausible but you want an independent launch verdict
+
+## Do not use this skill when
+
+- there is no real bead graph yet
+- the user wants implementation instead of review
+- the request is actually a planning task, not a bead audit
+
+## Required outputs
+
+1. A launch verdict: fail, conditional pass, or pass.
+2. A structured report with blocking findings first.
+3. Exact bead-level fixes or proposed `br` actions where possible.
+4. Clear distinction between hard blockers, important improvements, and optional nits.
+
+## Workflow
+
+1. Reread `AGENTS.md`, then read the relevant plan/spec and current bead graph.
+2. Ground in reality:
+   - `br list --limit 0 --json -a`
+   - `bv --robot-triage`
+   - `bv --robot-plan`
+   - `bv --robot-suggest`
+   - optionally `bv --robot-insights`, `bv --robot-priority`, and `br show <id> --json`
+3. Re-derive the judgment independently. Do not assume the existing graph is correct because another strong model made it.
+4. Audit the graph across these categories:
+   - plan coverage
+   - duplicate or overlapping ownership
+   - vague or under-specified beads
+   - dependency correctness and frontier health
+   - priority and sequencing fit
+   - verification obligations, including unit/integration/e2e and useful diagnostics where relevant
+   - user-visible and operator-visible risks that are still unowned
+5. Use the template in [references/review-report-template.md](references/review-report-template.md).
+6. If you are asked to apply fixes, mutate only the clearly justified ones with `br`, then flush with `br sync --flush-only`.
+
+## Review standards
+
+A good audit is not a rubber stamp. It should be willing to say:
+
+- the graph is missing work even though it looks large
+- two beads should merge even though their titles differ
+- one bead is overloaded and should split
+- the graph is not launch-ready because testing or failure-handling is still implicit
+
+## Command palette
+
+```bash
+br list --limit 0 --json -a
+br show <id> --json
+bv --robot-triage
+bv --robot-plan
+bv --robot-suggest
+bv --robot-insights
+bv --robot-priority
+```
+
+## Common failure patterns to avoid
+
+- praising the graph without independently checking plan coverage
+- nitpicking style while missing missing-work risks
+- collapsing all findings into one severity bucket
+- suggesting implementation changes when the graph itself is the problem
+- editing beads by default when the user asked for a review
+
+## Additional resources
+
+- For the report structure, see [references/review-report-template.md](references/review-report-template.md).

--- a/skills/second-model-bead-audit/references/review-report-template.md
+++ b/skills/second-model-bead-audit/references/review-report-template.md
@@ -1,0 +1,50 @@
+# Second-Model Bead Audit Report Template
+
+Load this file when writing the final review.
+
+```markdown
+# Bead Graph Audit
+
+## Launch verdict
+- Fail / Conditional pass / Pass
+- One-sentence reason
+
+## Blocking findings
+- [B1] Finding
+  - Why it matters
+  - Affected bead IDs
+  - Recommended fix
+
+## Important improvements
+- [I1] Finding
+  - Why it matters
+  - Affected bead IDs
+  - Recommended fix
+
+## Optional nits
+- [N1] Finding
+  - Suggested cleanup
+
+## Coverage notes
+- Plan elements still weakly represented or missing
+- Any beads with no clear plan backing
+
+## Dependency notes
+- Incorrect, missing, or over-constraining dependencies
+- Bottlenecks, cycles, or frontier-shape issues
+
+## Verification notes
+- Missing or weak unit/integration/e2e obligations
+- Missing diagnostics or logging where they are needed
+
+## Suggested br actions
+```bash
+# exact commands when you can state them confidently
+```
+```
+
+## Severity rules
+
+- Blocking = do not start implementation yet.
+- Important = should be fixed before a large swarm launch, but might not block a tiny scoped effort.
+- Nit = nice cleanup with low leverage.


### PR DESCRIPTION
## Summary
- import the Flywheel bead workflow skills: `plan-to-beads-transfer`, `bead-polish-loop`, and `second-model-bead-audit`
- keep the imported skills in a shared/open `SKILL.md` format so they remain portable across Claude Code and Codex
- update the repo README and installer so Codex is a first-class install target with `--target claude|codex|both`

## Why
- bring the reviewed Flywheel bead workflow into the shared skills repo
- support both Claude Code and Codex instead of treating Codex as a manual afterthought

## Impact
- users can install the new bead skills from this repo and invoke them from either tool
- `install.sh` can now symlink skills into `~/.claude/skills`, `~/.agents/skills`, or both

## Validation
- `bash -n install.sh`
- `./install.sh --help`
- reviewed the imported skill and reference files to keep them concise and in the shared agent-skills format