### PR TITLE
Improve skill descriptions, handoffs, and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Codex:
 Use the second-model-bead-audit skill and give me a launch verdict.
 ```
 
+### orchestrating-with-ralph-burning
+
+Uses `ralph-burning` as the default structured workflow for substantial
+implementation work: requirements, project creation, flow selection, run
+start/resume, and canonical status inspection.
+
+Claude Code:
+
+```text
+/orchestrating-with-ralph-burning implement retry-safe daemon lease cleanup
+```
+
+Codex:
+
+```text
+Use the orchestrating-with-ralph-burning skill to implement this with ralph-burning.
+```
+
 ## Install
 
 ```bash
@@ -95,8 +113,8 @@ Install specific skills:
 
 ```bash
 ./install.sh codex-review-loop
-./install.sh --target codex plan-to-beads-transfer bead-polish-loop second-model-bead-audit
-./install.sh --target both plan-to-beads-transfer bead-polish-loop second-model-bead-audit
+./install.sh --target codex plan-to-beads-transfer bead-polish-loop second-model-bead-audit orchestrating-with-ralph-burning
+./install.sh --target both plan-to-beads-transfer bead-polish-loop second-model-bead-audit orchestrating-with-ralph-burning
 ```
 
 ## Uninstall
@@ -114,6 +132,8 @@ Install specific skills:
 - `br` and `bv` on `PATH`, plus a repo that uses `.beads/`, for
   `plan-to-beads-transfer`, `bead-polish-loop`, and
   `second-model-bead-audit`
+- `ralph-burning` on `PATH`, or `nix run github:douglaz/ralph-burning -- ...`,
+  for `orchestrating-with-ralph-burning`
 
 ## License
 

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -1,10 +1,26 @@
 ---
 name: bead-polish-loop
-description: Refines an existing bead graph through repeated review-and-revise rounds for coverage, deduplication, dependency repair, sizing, priority, and verification completeness until the graph converges. Use when a bead batch already exists but still feels vague, duplicated, over-broad, or dependency-wrong. Do not use for first-draft planning or ordinary code review.
+description: >-
+  Refines an existing bead graph through repeated review-and-revise rounds for
+  coverage, deduplication, dependency repair, sizing, priority, and verification
+  completeness until the graph converges. Use when a bead batch already exists
+  but still feels vague, duplicated, over-broad, or dependency-wrong. Also use
+  when the user says things like "clean up the beads", "the graph looks rough",
+  "review the beads before we start building", "tighten up the tasks", "these
+  beads need work", or "make the graph launch-ready". Do not use for first-draft
+  planning, ordinary code review, or when no beads exist yet.
 compatibility: Requires br and bv on PATH and a repo that uses .beads/.
 ---
 
 Polish the bead graph until it is launch-ready, not just plausible.
+
+## Tool dependencies
+
+This skill requires `br` (beads_rust) and `bv` (bead viewer) on `PATH`.
+If either command is missing, stop and tell the user. If commands fail with
+unexpected errors, check whether the CLI version matches the expected subcommand
+signatures in the command palette below — flag version mismatches to the user
+rather than guessing at alternative syntax.
 
 ## Use this skill when
 
@@ -130,6 +146,22 @@ br sync --flush-only
 - assuming a big graph is complete because it is verbose
 - oversimplifying and silently deleting functionality or test obligations
 - treating the first decent pass as final
+
+## Pipeline context
+
+This skill is the **second step** in the bead lifecycle:
+
+1. **plan-to-beads-transfer** — create beads from a stable plan
+2. **bead-polish-loop** (you are here) — refine the graph through iterative review rounds
+3. **second-model-bead-audit** — independent launch-readiness verdict
+
+Before using this skill, beads should already exist — typically created by
+`plan-to-beads-transfer` or manually. If there is no graph yet, redirect to
+`plan-to-beads-transfer` first.
+
+After convergence, recommend `second-model-bead-audit` for high-stakes projects,
+or proceed directly to implementation if the graph is clean and the project scope
+is small.
 
 ## Additional resources
 

--- a/skills/codex-review-loop/SKILL.md
+++ b/skills/codex-review-loop/SKILL.md
@@ -6,8 +6,11 @@ description: >-
   disproven, fixes accepted items, validates the changed code, and repeats
   until clean or the pass limit is reached. Use when the user asks to "codex
   review loop", "review and fix", "review until clean", "iterate on codex
-  review", or right before opening a PR or running `/ship`. Does not commit,
-  open a PR, or reject findings without concrete evidence.
+  review", "let's get this PR clean", "fix what codex found", "run codex and
+  fix everything", or right before opening a PR or running `/ship`. Also
+  suggest proactively after substantial implementation work or when a single
+  codex review surfaced issues. Does not commit, open a PR, or reject findings
+  without concrete evidence.
 argument-hint: "[max-passes] [focus instructions]"
 allowed-tools:
   - Bash
@@ -22,6 +25,14 @@ allowed-tools:
 # /codex-review-loop
 
 Drive a tight Codex review loop without bloating Claude's own context.
+
+## Tool dependencies
+
+This skill requires the `codex` CLI on `PATH`. If the binary is missing, stop
+and tell the user to install it. The skill uses `codex review` with flags like
+`--base`, `-c 'model_reasoning_effort="xhigh"'`, and `--enable web_search_cached`.
+If a flag is not recognized, retry without it and note the incompatibility — the
+Codex CLI may have changed between versions.
 Persist full Codex output to files, keep chat summaries short, and only ask the
 user when a finding needs a real product or architecture decision.
 
@@ -164,64 +175,12 @@ Otherwise:
 1. Group related findings before editing. Prefer fixing the root cause once over
    patching each comment independently.
 
-2. Before editing, classify each finding as `FIX`, `DEFER`, or `REJECT`.
-   - `FIX`: default outcome. The finding is plausible, in scope, and can be
-     addressed safely in this loop.
-   - `DEFER`: the finding still looks real or plausible, but the safe fix needs
-     a broader refactor, product decision, policy call, or cross-team
-     coordination. Keep it open. Do not call it a false positive.
-   - `REJECT`: allowed only when you have direct counter-evidence from code,
-     tests, docs, or the diff.
+2. Classify each finding as `FIX`, `DEFER`, or `REJECT` using the rules in
+   [references/disposition-rules.md](references/disposition-rules.md). The key
+   principle: `FIX` is the default, `REJECT` requires concrete counter-evidence,
+   and `DEFER` is for plausible findings that need broader work.
 
-3. The bar for `REJECT` is high. Reject only when you can point to specific
-   evidence for at least one of these:
-   - the issue is already handled by current code or tests
-   - the behavior is explicitly intended by user instructions, repo docs, or
-     nearby code comments
-   - the reported problem is pre-existing in `DIFF_BASE` and unrelated to this
-     branch's changes
-   - the finding depends on an outdated or incorrect assumption about the
-     framework, API, or code path
-
-4. Do not reject a finding for any of these reasons:
-   - it is "only" P2 or P3
-   - you could not reproduce it quickly
-   - the fix feels inconvenient, noisy, or higher churn than you want
-   - the change might be intentional, but you have no proof
-   - CI, lint, typecheck, or tests might catch it later
-   - unrelated validation passed after your edits
-
-5. Priority guidance:
-   - P0/P1: fix unless you can directly disprove the finding.
-   - P2/P3: fix when the issue is concrete and the remedy is low or medium risk.
-     If the finding remains plausible but the fix is broader or riskier, mark it
-     `DEFER` and surface it at the end instead of dismissing it.
-   - Subjective style-only feedback can be skipped only when no project rule,
-     concrete bug risk, or user preference supports it.
-   - Missing validation, missing tests for changed behavior, unhandled enum or
-     state cases, missing error handling, and missing guards are not "subjective"
-     just because they are lower priority.
-
-6. For each finding you `FIX` or `DEFER`:
-   - read the referenced code and nearby context
-   - inspect any claimed safeguard, test, or doc before deciding
-   - make the smallest correct fix when fixing
-   - re-read the edited code
-   - note the disposition and evidence in `"$PASS_NOTES"`
-
-7. For each finding you `REJECT`:
-   - record a one-line rationale plus concrete file or test evidence in
-     `"$PASS_NOTES"`
-   - mention it in chat only if it affects the pass outcome
-
-   If you cannot point to concrete evidence, do not reject it. Leave it as
-   `FIX` or `DEFER`.
-
-8. If a materially identical finding reappears on the next pass after you
-   rejected it, assume your rejection may have been wrong. Re-verify from
-   scratch before calling it a persistent false positive.
-
-9. After edits, run the narrowest useful verification you can find from repo
+3. After edits, run the narrowest useful verification you can find from repo
    guidance:
    - nearby tests for touched behavior
    - targeted lint/typecheck commands for touched files
@@ -237,7 +196,7 @@ Otherwise:
    Passing validation supports a fix, but it does not by itself prove that a
    rejected finding was false.
 
-10. Print a brief disposition summary in chat:
+4. Print a brief disposition summary in chat:
 
    ```text
    PASS N ACTIONS

--- a/skills/codex-review-loop/references/disposition-rules.md
+++ b/skills/codex-review-loop/references/disposition-rules.md
@@ -1,0 +1,76 @@
+# Finding Disposition Rules
+
+Load this file when classifying findings during the fix-and-validate phase.
+
+## Classification
+
+Before editing, classify each finding as `FIX`, `DEFER`, or `REJECT`.
+
+- **FIX**: default outcome. The finding is plausible, in scope, and can be
+  addressed safely in this loop.
+- **DEFER**: the finding still looks real or plausible, but the safe fix needs
+  a broader refactor, product decision, policy call, or cross-team
+  coordination. Keep it open. Do not call it a false positive.
+- **REJECT**: allowed only when you have direct counter-evidence from code,
+  tests, docs, or the diff.
+
+## REJECT evidence bar
+
+The bar for `REJECT` is high. Reject only when you can point to specific
+evidence for at least one of these:
+
+- the issue is already handled by current code or tests
+- the behavior is explicitly intended by user instructions, repo docs, or
+  nearby code comments
+- the reported problem is pre-existing in `DIFF_BASE` and unrelated to this
+  branch's changes
+- the finding depends on an outdated or incorrect assumption about the
+  framework, API, or code path
+
+## Invalid rejection reasons
+
+Do not reject a finding for any of these reasons:
+
+- it is "only" P2 or P3
+- you could not reproduce it quickly
+- the fix feels inconvenient, noisy, or higher churn than you want
+- the change might be intentional, but you have no proof
+- CI, lint, typecheck, or tests might catch it later
+- unrelated validation passed after your edits
+
+## Priority guidance
+
+- **P0/P1**: fix unless you can directly disprove the finding.
+- **P2/P3**: fix when the issue is concrete and the remedy is low or medium risk.
+  If the finding remains plausible but the fix is broader or riskier, mark it
+  `DEFER` and surface it at the end instead of dismissing it.
+- **Subjective style-only feedback** can be skipped only when no project rule,
+  concrete bug risk, or user preference supports it.
+- Missing validation, missing tests for changed behavior, unhandled enum or
+  state cases, missing error handling, and missing guards are not "subjective"
+  just because they are lower priority.
+
+## Per-finding workflow
+
+For each finding you `FIX` or `DEFER`:
+
+1. Read the referenced code and nearby context
+2. Inspect any claimed safeguard, test, or doc before deciding
+3. Make the smallest correct fix when fixing
+4. Re-read the edited code
+5. Note the disposition and evidence in `"$PASS_NOTES"`
+
+For each finding you `REJECT`:
+
+1. Record a one-line rationale plus concrete file or test evidence in
+   `"$PASS_NOTES"`
+2. Mention it in chat only if it affects the pass outcome
+
+If you cannot point to concrete evidence, do not reject it. Leave it as
+`FIX` or `DEFER`.
+
+## Recurrence rule
+
+If a materially identical finding reappears on the next pass after you
+rejected it, assume your rejection may have been wrong. Re-verify from
+scratch before calling it a persistent false positive.

--- a/skills/orchestrating-with-ralph-burning/SKILL.md
+++ b/skills/orchestrating-with-ralph-burning/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: orchestrating-with-ralph-burning
+description: >-
+  Uses `ralph-burning` to turn an implementation request into a structured
+  requirements, project, and run workflow with durable state. Use when the user
+  says "use ralph", "use ralph-burning", "implement this with ralph", "bootstrap
+  a run", "orchestrate this", "set up a project for this", or when a feature
+  request is complex enough that a resumable, auditable workflow is safer than
+  ad hoc coding — roughly anything that would take more than a few files of
+  changes. Also use when the user wants to resume a failed or paused run, or
+  check on ralph project status. Prefer `ralph-burning` over legacy `ralph`
+  unless the user explicitly asks for v1 or `multibackend-orchestration`. Do
+  not use for tiny direct edits, pure explanations, or when the user explicitly
+  wants manual coding without orchestration.
+compatibility: Requires `ralph-burning` on `PATH` or `nix run github:douglaz/ralph-burning -- ...`.
+---
+
+Use `ralph-burning` as the default orchestration path for substantial work, not
+as an afterthought.
+
+## Tool dependencies
+
+This skill requires `ralph-burning`. Resolution order: first `command -v
+ralph-burning`, then `nix run github:douglaz/ralph-burning --`. The nix fallback
+works but is slower on first invocation due to download/build. If subcommands
+fail with unexpected errors, check whether the CLI version matches the expected
+signatures in the command recipes reference — flag version mismatches to the user
+rather than guessing at alternative syntax.
+
+## Use this skill when
+
+- the user explicitly asks to use `ralph` or `ralph-burning`
+- the request is large enough that you would otherwise produce a long plan
+- resumability, auditability, backend routing, or structured review matter
+- you want a more reliable path than a long ad hoc coding session
+
+## Do not use this skill when
+
+- the task is a tiny direct patch or a quick factual answer
+- the user explicitly wants manual edits without orchestration
+- the work is purely exploratory and not ready to become a project/run
+- `ralph-burning` is unavailable both on `PATH` and through the public nix run path
+
+## Required outputs
+
+1. A clear choice: use `ralph-burning`, or explain why not.
+2. The selected flow and entry path.
+3. The project ID and run status when a project or run was created.
+4. A concise next-step summary grounded in `ralph-burning` state.
+
+## Default stance
+
+- Prefer `ralph-burning` over legacy `ralph`.
+- Treat bare "ralph" requests as `ralph-burning` unless the user clearly means
+  v1 or `multibackend-orchestration`.
+- Prefer durable state over chat-only planning.
+- Prefer `run resume` over restarting failed or paused work.
+
+## Workflow
+
+1. Reread the local `AGENTS.md` chain and confirm the request is orchestration-sized.
+2. Resolve the binary before doing anything else.
+   - First try `command -v ralph-burning`.
+   - If that fails, prefer invoking through
+     `nix run github:douglaz/ralph-burning --`.
+   - If none of those paths works, stop and explain that the tool is
+     unavailable.
+3. Confirm the workspace state.
+   - If `.ralph-burning/` is missing, run the resolved `ralph-burning` binary
+     with `init`.
+   - If you expect to start work soon, run the resolved binary with
+     `backend check`.
+4. Choose the flow up front.
+   - `quick_dev`: scoped code change, low coordination cost
+   - `standard`: larger or riskier multi-stage implementation
+   - `docs_change`: docs-only work
+   - `ci_improvement`: CI or automation work
+5. Choose the entry path.
+   - Raw idea, no stable prompt: `project bootstrap --idea ...`
+   - Need clarification rounds and a stronger seed: `requirements draft --idea ...`
+   - Stable prompt file already exists: `project create --prompt ... --flow ...`
+   - Existing failed or paused run: `run resume`
+6. Keep the orchestration state authoritative.
+   - Use `run status`, `run history`, and `run tail` instead of inferring from
+     loose artifacts or memory.
+   - Use `project show` when you need the canonical project record.
+7. Report back briefly.
+   - Say which binary you used.
+   - Say which flow and entry path you chose.
+   - Give the resulting project ID and current run status.
+   - Give the next command or next state transition.
+
+## Entry-path rules
+
+### 1. Raw idea -> fast start
+
+Use `project bootstrap` when the user wants execution momentum and the idea is
+already good enough for a quick requirements pass.
+
+- Default to `quick_dev` for contained implementation work.
+- Default to `standard` for larger features, higher risk, or when multiple
+  stages should be preserved explicitly.
+- Add `--start` only when the user clearly wants execution now.
+
+### 2. Raw idea -> higher certainty
+
+Use `requirements draft` when the request is important enough to justify
+clarification rounds and a stronger project seed.
+
+After answers are collected and the requirements run completes:
+
+- create the project with `project create --from-requirements <run-id>`
+- then `run start` if execution should begin now
+
+### 3. Stable prompt/spec already exists
+
+Use `project create` directly when a durable prompt file already exists and the
+user does not need the requirements pipeline first.
+
+### 4. Existing project/run
+
+If the workspace already contains the relevant project:
+
+- `project select <id>`
+- `run start` only for `not_started`
+- `run resume` for `failed` or `paused`
+
+## Reliability rules
+
+- Never mix `.ralph` and `.ralph-burning` state in the same workflow.
+- Do not guess a run state from artifacts when `run.json` or `run status`
+  can answer it directly.
+- Do not restart a run just because it failed once; inspect and prefer resume.
+- Do not choose legacy `ralph` unless the user explicitly asks for v1 behavior.
+- Keep the chat concise; let `ralph-burning` carry the durable context.
+
+## Additional resource
+
+- For flow selection, preflight, and command recipes, see
+  [references/flow-and-command-recipes.md](references/flow-and-command-recipes.md).

--- a/skills/orchestrating-with-ralph-burning/references/flow-and-command-recipes.md
+++ b/skills/orchestrating-with-ralph-burning/references/flow-and-command-recipes.md
@@ -50,16 +50,16 @@ above. Do not default back to v1.
 Fast path:
 
 ```bash
-$RALPH project bootstrap --idea "$IDEA" --flow quick_dev --start
+$RALPH project bootstrap --idea "$IDEA" --flow quick_dev
 ```
 
 Safer multi-stage path:
 
 ```bash
-$RALPH project bootstrap --idea "$IDEA" --flow standard --start
+$RALPH project bootstrap --idea "$IDEA" --flow standard
 ```
 
-Use `--start` only when execution should begin immediately.
+Add `--start` only when the user clearly wants execution to begin immediately.
 
 ## 5. Run requirements first
 

--- a/skills/orchestrating-with-ralph-burning/references/flow-and-command-recipes.md
+++ b/skills/orchestrating-with-ralph-burning/references/flow-and-command-recipes.md
@@ -1,0 +1,157 @@
+# Flow and Command Recipes
+
+Use these recipes as defaults. Adjust only when the repo's `AGENTS.md`,
+workspace config, or user intent requires something else.
+
+## 1. Resolve the binary
+
+Preferred:
+
+```bash
+RALPH=$(command -v ralph-burning)
+```
+
+If that fails, prefer the public nix-run wrapper:
+
+```bash
+RALPH='nix run github:douglaz/ralph-burning --'
+```
+
+If none of those paths works, stop and tell the user the tool is unavailable.
+
+## 2. Workspace preflight
+
+Initialize only when the workspace does not exist yet:
+
+```bash
+$RALPH init
+```
+
+Check backend readiness before starting execution-heavy work:
+
+```bash
+$RALPH backend check
+$RALPH backend show-effective
+```
+
+## 3. Flow selection
+
+- `quick_dev`: contained feature, bugfix, or refactor
+- `standard`: substantial feature, risky change, or work that benefits from
+  explicit planning, QA, review, completion, and resume boundaries
+- `docs_change`: docs-only request
+- `ci_improvement`: CI, automation, or workflow hardening
+
+If the user says only "use ralph", prefer `ralph-burning` plus one of the flows
+above. Do not default back to v1.
+
+## 4. Bootstrap from an idea
+
+Fast path:
+
+```bash
+$RALPH project bootstrap --idea "$IDEA" --flow quick_dev --start
+```
+
+Safer multi-stage path:
+
+```bash
+$RALPH project bootstrap --idea "$IDEA" --flow standard --start
+```
+
+Use `--start` only when execution should begin immediately.
+
+## 5. Run requirements first
+
+Use this when the idea is still underspecified and you want a stronger seed.
+
+Quick mode:
+
+```bash
+$RALPH requirements quick --idea "$IDEA"
+$RALPH requirements show <run-id>
+$RALPH project create --from-requirements <run-id>
+```
+
+Full staged mode with clarification rounds:
+
+```bash
+$RALPH requirements draft --idea "$IDEA"
+$RALPH requirements show <run-id>
+$RALPH requirements answer <run-id>
+$RALPH requirements show <run-id>
+$RALPH project create --from-requirements <run-id>
+```
+
+`project create --from-requirements` selects the created project automatically.
+
+## 6. Create directly from a prompt file
+
+Use this when a stable prompt/spec file already exists.
+
+```bash
+$RALPH project create \
+  --id "$PROJECT_ID" \
+  --name "$PROJECT_NAME" \
+  --prompt "$PROMPT_FILE" \
+  --flow standard
+```
+
+Then:
+
+```bash
+$RALPH project select "$PROJECT_ID"
+$RALPH run start
+```
+
+## 7. Inspect and continue
+
+Use canonical state, not artifact guesswork.
+
+```bash
+$RALPH project list
+$RALPH project show
+$RALPH run status
+$RALPH run status --json
+$RALPH run history --stage implementation
+$RALPH run tail --last 20
+```
+
+If execution is already in progress and tmux mode is enabled:
+
+```bash
+$RALPH run attach
+```
+
+## 8. Resume instead of restarting
+
+For failed or paused runs:
+
+```bash
+$RALPH run resume
+```
+
+Inspect first when needed:
+
+```bash
+$RALPH run status --json
+$RALPH run history --verbose
+```
+
+## 9. Good operator summary
+
+After using `ralph-burning`, report these four things:
+
+1. Which binary you used.
+2. Which flow and entry path you chose.
+3. Which project ID and run status now exist.
+4. What the next command or next state transition is.
+
+Example:
+
+```text
+Using nix run github:douglaz/ralph-burning --.
+Chose flow quick_dev via project bootstrap.
+Created and selected project retry-safe-lease-cleanup; run is running in review.
+Next useful check: nix run github:douglaz/ralph-burning -- run status --json
+```

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -1,10 +1,26 @@
 ---
 name: plan-to-beads-transfer
-description: Converts a stable spec, PRD, or markdown plan into actual `br` beads with rich self-contained descriptions, explicit dependencies, and verification obligations. Use when a feature plan is approved and needs to become an execution graph, or when a major plan revision means the bead graph must be refreshed. Do not use for implementation, loose brainstorming, or unstable architecture work.
+description: >-
+  Converts a stable spec, PRD, or markdown plan into actual `br` beads with
+  rich self-contained descriptions, explicit dependencies, and verification
+  obligations. Use when a feature plan is approved and needs to become an
+  execution graph, when the user says "break this plan into tasks", "create
+  beads from this spec", "turn this into work items", "the plan is done, let's
+  set up execution", or when a major plan revision means the bead graph must be
+  refreshed. Do not use for implementation, loose brainstorming, or unstable
+  architecture work.
 compatibility: Requires br and bv on PATH and a repo that uses .beads/.
 ---
 
 Turn a stable plan into executable beads without losing meaning.
+
+## Tool dependencies
+
+This skill requires `br` (beads_rust) and `bv` (bead viewer) on `PATH`.
+If either command is missing, stop and tell the user. If commands fail with
+unexpected errors, check whether the CLI version matches the expected subcommand
+signatures in the command palette below — flag version mismatches to the user
+rather than guessing at alternative syntax.
 
 ## Use this skill when
 
@@ -92,6 +108,19 @@ br sync --flush-only
 - creating beads that only make sense if the original plan stays open nearby
 - encoding sequencing in prose without explicit dependencies
 - overusing parent/child depth when ordinary dependencies would be clearer
+
+## Pipeline context
+
+This skill is the **first step** in the bead lifecycle:
+
+1. **plan-to-beads-transfer** (you are here) — create beads from a stable plan
+2. **bead-polish-loop** — refine the graph through iterative review rounds
+3. **second-model-bead-audit** — independent launch-readiness verdict
+
+After completing a transfer, the graph is usually good enough to understand but
+not yet launch-ready. Recommend `bead-polish-loop` as the next step unless the
+transfer was small and clean. For high-stakes work, also recommend
+`second-model-bead-audit` before implementation begins.
 
 ## Additional resources
 

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -1,11 +1,28 @@
 ---
 name: second-model-bead-audit
-description: Audits a bead graph against the plan with an independent second opinion, checking coverage gaps, duplicate ownership, weak descriptions, dependency mistakes, and missing verification obligations before implementation starts. Use when another agent already created or polished the beads and you want a launch verdict with exact fixes. Prefer read-only review unless the user explicitly asks for bead edits.
+description: >-
+  Audits a bead graph against the plan with an independent second opinion,
+  checking coverage gaps, duplicate ownership, weak descriptions, dependency
+  mistakes, and missing verification obligations before implementation starts.
+  Use when another agent already created or polished the beads and you want a
+  launch verdict with exact fixes, or when the user says "sanity check the
+  beads", "audit the graph", "give me a second opinion on these beads", "are
+  the beads ready to build?", or "review the bead graph before we start". Also
+  works as a self-audit when no second model is available. Prefer read-only
+  review unless the user explicitly asks for bead edits.
 compatibility: Requires br and bv on PATH and a repo that uses .beads/.
 ---
 
 Provide a second-model audit of the bead graph without inheriting the first
 model's blind spots.
+
+## Tool dependencies
+
+This skill requires `br` (beads_rust) and `bv` (bead viewer) on `PATH`.
+If either command is missing, stop and tell the user. If commands fail with
+unexpected errors, check whether the CLI version matches the expected subcommand
+signatures in the command palette below — flag version mismatches to the user
+rather than guessing at alternative syntax.
 
 ## Default posture
 
@@ -79,6 +96,26 @@ bv --robot-priority
 - collapsing all findings into one severity bucket
 - suggesting implementation changes when the graph itself is the problem
 - editing beads by default when the user asked for a review
+
+## Pipeline context
+
+This skill is the **final check** in the bead lifecycle:
+
+1. **plan-to-beads-transfer** — create beads from a stable plan
+2. **bead-polish-loop** — refine the graph through iterative review rounds
+3. **second-model-bead-audit** (you are here) — independent launch-readiness verdict
+
+Before using this skill, the graph should already have been through at least one
+round of polishing (via `bead-polish-loop` or manual review). Auditing a raw,
+unpolished transfer will produce a long list of issues that polishing would have
+caught — use `bead-polish-loop` first in that case.
+
+After the audit:
+- **Pass**: proceed to implementation.
+- **Conditional pass**: fix the noted conditions (often via a quick
+  `bead-polish-loop` round), then proceed.
+- **Fail**: return to `bead-polish-loop` to address blocking findings before
+  re-auditing.
 
 ## Additional resources
 


### PR DESCRIPTION
## Summary
- **Broader descriptions**: All 5 skills now include natural-language trigger phrases (e.g., "clean up the beads", "let's get this PR clean", "break this plan into tasks") so they activate on casual user requests, not just tool-specific jargon
- **Cross-skill handoffs**: Added "Pipeline context" sections to the 3 bead-lifecycle skills showing the transfer → polish → audit flow with guidance on when to hand off
- **Extracted disposition rules**: Moved the FIX/DEFER/REJECT classification rules from codex-review-loop into `references/disposition-rules.md`, reducing SKILL.md from 327 to 286 lines
- **Tool dependency sections**: All 5 skills now have explicit guidance on handling missing binaries and CLI version mismatches
- **New skill**: Added `orchestrating-with-ralph-burning` and updated README

## Test plan
- [ ] Verify each skill triggers on the new natural-language phrases
- [ ] Confirm codex-review-loop still correctly loads disposition rules from the reference file
- [ ] Check that bead pipeline handoff suggestions appear at the right times