### PR TITLE
Document setsid launch guidance for rb-lite

### DIFF
--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -238,6 +238,35 @@ ready bead if the queue is not empty, and the exact reason the loop stopped.
    `.rb-lite/runs/<timestamp>-<pid>` in the repo). A `/tmp/...` run-dir
    is convenient when you don't want artifacts in the repo tree.
 
+   **Long background runs on a shared box — launch under `setsid`.** A
+   multi-hour run launched as a plain `… &` child of your shell stays in
+   the shell's process group, so it dies if that group is torn down — the
+   harness cleaning up a finished tool-call's process group, a terminal/
+   `SIGHUP` teardown, or a `kill -- -<pgid>` sweep. `setsid` puts rb-lite
+   in its own session/process group, insulating it from that whole class:
+
+   ```bash
+   setsid rb-lite run \
+     --implementer claude,codex \
+     --task-file /tmp/rb-<short-tag>-task.md \
+     --base origin/main \
+     --run-dir /tmp/rb-<short-tag>-run \
+     > /tmp/rb-<short-tag>.log 2>&1 < /dev/null &
+   ```
+
+   This is a cheap hedge, **not** full protection: `setsid` changes only
+   session/group membership, so it does NOT stop a name-pattern kill
+   (`pkill -f rb-lite`, `killall rb-lite`), a direct `kill <pid>`, or the
+   OOM killer — those match by command line / name / PID regardless of
+   session (see "When the loop misbehaves"). The durable protection is
+   recoverability: rb-lite is resumable and leaves its diff in the tree,
+   and you verify the landed diff anyway (step 10.5), so a mid-run kill
+   costs time, not correctness. Observed on a busy shared box: a `nohup …
+   &` run was swept at ~36 min while `setsid …` runs of the same workload
+   completed cleanly (~1–4 h) — consistent with a group/SIGHUP-class
+   teardown, though it does not rule out that a `pkill` sweep simply
+   missed the later runs' window.
+
 9. **Read the JSON summary.** rb-lite always prints a single-line JSON
    object as the last line of stdout, on success and failure. Pipe to
    `jq` if available; otherwise grep the line. The schema is in the
@@ -677,6 +706,16 @@ The JSON schema (every exit, last stdout line):
   (`pgrep`/`kill <pid>`). Current rb-lite forwards TERM/INT/HUP/QUIT to the active
   child process. If you used SIGKILL, or if implementer/reviewer children remain
   after TERM/INT/HUP/QUIT forwarding, kill the exact orphaned child PIDs separately.
+  **`setsid` does NOT save you from this case.** Launching under `setsid` (step 8)
+  only insulates the *group/SIGHUP* class (process-group teardown, terminal HUP); a
+  `pkill -f rb-lite` matches rb-lite's own argv regardless of session, so it kills a
+  `setsid`'d run just the same. A resource scope (`systemd-run --scope`, a cgroup)
+  can help with lifecycle and resource containment, but it is not protection from
+  a same-user broad `pkill`, direct PID kill, or OOM kill. For a determined
+  name/PID/OOM sweep, recoverability (relaunch — the run is resumable, the diff is
+  in the tree) is the real defense; stronger isolation means a separate user, PID
+  namespace/container, or tighter operational discipline. Use `setsid` for the
+  group/SIGHUP class, not for this.
 - **A run balloons — many rounds, a huge module, edits sprawling into other files.**
   This bead was high-blast-radius and ran unsupervised. Don't keep relaying findings;
   discard and apply the re-scope + file-lock + watch-each-round recovery playbook in


### PR DESCRIPTION
## Summary
Document when to launch long background `rb-lite` runs under `setsid`, including a concrete invocation that detaches the run from the calling shell's process group.

## Lineage / context
This updates the orchestration skill after observing long `nohup ... &` runs get swept on a shared box while comparable `setsid ... &` runs completed.

## Trade-offs accepted
`setsid` is documented as a narrow hedge for process-group and SIGHUP teardown only. The guidance explicitly says it does not protect against same-user `pkill`, direct PID kills, or OOM kills.

## Test plan
- [x] `git diff --check`
- [x] Docs-only review of the final diff
- [ ] CI green
- [ ] Codex bot review