### PR TITLE
docs(review-loops): over-specification handling and skeptical audit

### DIFF
--- a/skills/codex-review-loop/SKILL.md
+++ b/skills/codex-review-loop/SKILL.md
@@ -45,8 +45,13 @@ This skill may be suggested proactively, but do not start running it unless the
 user explicitly asked for it or clearly agreed.
 
 Default stance: treat Codex findings as review hypotheses that deserve
-verification. The goal is to resolve or properly escalate findings, not to win
-an argument with the reviewer.
+verification, not mandates. The goal is to resolve or properly escalate
+findings, not to win an argument with the reviewer — and not to credulously
+implement every one. A finding can be valid *as stated* yet not worth building
+(over-specification): the loop only ever pushes toward *adding*, so you supply
+the counter-pressure toward simplicity. Accepting every finding for several
+passes, or a loop that keeps spawning new findings as fast as it fixes them, is
+a signal to step back, not to keep going.
 
 ## Inputs
 
@@ -60,8 +65,10 @@ Parse the user's request for arguments. In Claude Code, these arrive via
 
 Clamp `MAX_PASSES` to `1..15`. Six is the default because most real review
 loops converge within 1-3 passes; beyond six, repeated findings usually mean an
-unresolved root cause, missing validation, a false positive, or a larger design
-issue.
+unresolved root cause, missing validation, a false positive, a larger design
+issue, or a loop that is generating new findings as fast as it fixes them (each
+fix adds review surface). The last case is a cue to run a skeptical audit
+(§ 4a), not to keep spending passes.
 
 ## Workflow
 
@@ -184,10 +191,13 @@ Otherwise:
 1. Group related findings before editing. Prefer fixing the root cause once over
    patching each comment independently.
 
-2. Classify each finding as `FIX`, `DEFER`, or `REJECT` using the rules in
-   [references/disposition-rules.md](references/disposition-rules.md). The key
-   principle: `FIX` is the default, `REJECT` requires concrete counter-evidence,
-   and `DEFER` is for plausible findings that need broader work.
+2. Classify each finding as `FIX`, `DEFER`, `REJECT`, or `CUT/SIMPLIFY` using the
+   rules in [references/disposition-rules.md](references/disposition-rules.md).
+   The key principle: `FIX` is the default, `REJECT` requires concrete
+   counter-evidence (the finding is wrong), `DEFER` is for plausible findings
+   that need broader work, and `CUT/SIMPLIFY` is for findings that are valid as
+   stated but add mechanism no real correctness/security/data-loss requirement
+   needs — apply the over-specification test there before building.
 
 3. After edits, run the narrowest useful verification you can find from repo
    guidance:
@@ -215,6 +225,8 @@ Otherwise:
    - [P2] <why it remains open>
    Rejected with evidence:
    - [P3] <why it is disproven>
+   Cut/simplified (over-specification):
+   - [P2] <what was not built or shrunk, and what already covers the case>
    Validation: <command/result or "no targeted verifier found">
    ```
 
@@ -229,6 +241,38 @@ Stop early and surface the issue if any of these happen:
 - validation fails and the cause is unclear
 - max passes reached
 
+Stop normal passes and run a **skeptical audit** (§ 4a) instead when the loop
+stops converging:
+
+- findings stay roughly constant or rise across passes, and each pass's findings
+  are clearly *ripples of the previous pass's fixes* (a new mechanism you added
+  last pass now has its own flagged edge cases) — a fractal tail, not progress
+- you have made many fixes with **zero `REJECT` and zero `CUT`** — a sign you are
+  implementing every hypothesis credulously
+- findings are getting more peripheral / deeper into edge-case handling while the
+  core has been clean for several passes
+
+More normal passes will not converge these; they grow the change. The audit is
+the corrective.
+
+### 4a. Skeptical audit (the inverted pass)
+
+When § 4's convergence signals fire, run one inverted review instead of another
+normal pass. Point Codex at the *opposite* question: not "what's wrong?" but
+"what here is **not required for correctness** and could be cut, simplified, or
+deferred?" A useful prompt names the load-bearing core to leave alone and asks
+the reviewer to hunt over-specification aggressively, with, per item: what it is,
+why it isn't strictly required (what already covers the case), and a
+recommendation of CUT / SIMPLIFY / MARK-OPTIONAL.
+
+Then **reconcile, don't obey** — accepting every cut is the same credulity in
+reverse. Run the audit's recommendations through your own judgment and the
+over-specification test, push back where a flagged mechanism is actually
+load-bearing, and apply the agreed cuts/simplifications. If a real product or
+architecture trade-off rides on how aggressively to cut, ask the user (the
+choice changes what the artifact *is*). Re-verify after the cuts that the core is
+intact and no dangling references to removed mechanisms remain.
+
 ### 5. Finish
 
 Report:
@@ -242,6 +286,7 @@ Review dir: <REVIEW_DIR>
 Fixed: P0=W P1=X P2=Y P3=Z
 Deferred: <count or none>
 Rejected with evidence: <count or none>
+Cut/simplified (over-specification): <count or none>
 Remaining: <count or none>
 Validation run: <short summary>
 ```
@@ -252,6 +297,7 @@ Also provide:
 - a short list of any remaining findings
 - any deferred items
 - any rejected items with the evidence used
+- any cut/simplified items with the over-specification rationale
 
 Keep `review.txt` as a copy of the latest pass for compatibility:
 

--- a/skills/codex-review-loop/references/disposition-rules.md
+++ b/skills/codex-review-loop/references/disposition-rules.md
@@ -4,7 +4,8 @@ Load this file when classifying findings during the fix-and-validate phase.
 
 ## Classification
 
-Before editing, classify each finding as `FIX`, `DEFER`, or `REJECT`.
+Before editing, classify each finding as `FIX`, `DEFER`, `REJECT`, or
+`CUT/SIMPLIFY`.
 
 - **FIX**: default outcome. The finding is plausible, in scope, and can be
   addressed safely in this loop.
@@ -12,7 +13,14 @@ Before editing, classify each finding as `FIX`, `DEFER`, or `REJECT`.
   a broader refactor, product decision, policy call, or cross-team
   coordination. Keep it open. Do not call it a false positive.
 - **REJECT**: allowed only when you have direct counter-evidence from code,
-  tests, docs, or the diff.
+  tests, docs, or the diff. (The finding is *wrong*.)
+- **CUT/SIMPLIFY**: the finding may be correct *as stated*, but implementing it
+  (or the proposed shape of it) adds mechanism, handling, config, abstraction,
+  or hardening that no real correctness, security, or data-loss requirement
+  needs. Don't build it as asked — skip it, build a smaller version, or mark it
+  optional/deferred. This is a *scope* decision, not a claim the finding is
+  false, so it doesn't need REJECT's counter-evidence — but it must pass the
+  over-specification test below. (The finding is *not worth building*.)
 
 ## REJECT evidence bar
 
@@ -37,6 +45,48 @@ Do not reject a finding for any of these reasons:
 - the change might be intentional, but you have no proof
 - CI, lint, typecheck, or tests might catch it later
 - unrelated validation passed after your edits
+
+These are invalid for `REJECT` *and* for `CUT/SIMPLIFY`. `CUT` is not "this is
+annoying to write" — that's churn, and churn is not a reason. `CUT` is "omitting
+this leaves no real hole." The two are different claims; keep them separate.
+
+## The over-specification test (for CUT / SIMPLIFY)
+
+Apply to any finding that proposes new mechanism, handling, hardening, config,
+or abstraction. Ask: **if I simply don't do this, what actually breaks — a real
+correctness / security / data-loss / broken-trust problem, or merely an
+operational inconvenience or a not-strictly-needed nicety?**
+
+- Real correctness / security / data-loss / trust break → `FIX` (or `DEFER` if
+  the safe fix is broad).
+- Only operational, defense-in-depth, or "would be nicer" → `CUT`, `SIMPLIFY`,
+  or `MARK-OPTIONAL`. Name what already covers the case (an existing path, a
+  simpler choice, the user's stated threat model) or why the case doesn't
+  matter, and record it like a rejection.
+
+Watch the asymmetry: a review loop almost always pushes toward *adding*. Nothing
+in it pushes back toward simplicity unless you do. A finding that is "valid" yet
+grows the change without earning its keep is still over-specification, and
+shipping it makes the result worse, not better — more to build, test, and keep
+correct.
+
+When a `FIX` is warranted but the proposed remedy is heavier than the problem,
+`SIMPLIFY`: make the smallest change that closes the real hole, not the largest
+the finding implies.
+
+## Meta-signals across passes
+
+- **Zero `REJECT` and zero `CUT` across many findings is a red flag.** A healthy
+  loop disputes some findings. If you have accepted everything for several
+  passes, you are probably being too credulous — re-read your recent fixes for
+  over-specification before running another pass.
+- **Each fix is new review surface.** Fixing a finding by *adding* a mechanism
+  creates that mechanism's own edge cases, which the next pass will dutifully
+  flag. If the loop keeps generating roughly as many findings as it resolves and
+  they are getting more peripheral, that is a fractal tail, not convergence.
+  Stop adding. Run a skeptical / over-specification audit (an inverted pass that
+  hunts what to *cut*, not what to add) and reconcile, rather than spending more
+  normal passes.
 
 ## Priority guidance
 
@@ -68,6 +118,15 @@ For each finding you `REJECT`:
 
 If you cannot point to concrete evidence, do not reject it. Leave it as
 `FIX` or `DEFER`.
+
+For each finding you `CUT/SIMPLIFY`:
+
+1. Record the over-specification test result in `"$PASS_NOTES"`: what would
+   break if omitted (nothing real), and what already covers the case.
+2. If you `SIMPLIFY` rather than skip, make the minimal change and note why the
+   smaller shape is sufficient.
+3. Surface cuts in the finish report alongside rejections, so the user can see
+   what was deliberately not built.
 
 ## Recurrence rule
 

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -549,6 +549,42 @@ actively. This is a primary failure mode, not a nicety.
   the implementation grown past it? When they diverge, cut back to the goal — and
   treat the proxies as the cue to run that comparison, not as the verdict itself.
 
+## The fractal tail, and challenging the panel
+
+The ratchet has a sharper failure mode than just "deeper edge cases." When the
+implementer *fixes* a finding by **adding** a mechanism, that mechanism becomes
+new review surface, so the next round flags *its* edge cases. The loop then
+generates roughly as many findings as it resolves: a fractal tail, not
+convergence. The tell is findings holding steady or rising while each round's
+findings are visibly ripples of the last round's additions, and the core has
+been clean for several rounds.
+
+- **The implementer may challenge the panel, with evidence.** Reviewer findings
+  are hypotheses, not orders. A finding can be a false positive, *or* valid as
+  stated but not worth building (over-specification: it adds build/test surface
+  without preventing a real correctness, security, or data-loss problem). Decline
+  those instead of reflexively implementing, and record why, using the
+  over-specification test: "if I don't do this, what actually breaks, a real
+  correctness problem or only an operational inconvenience?" A round where the
+  implementer declines findings *with documented reasons* is a legitimate stop
+  (exit 13 `consensus_failure`), not a stall to override. Read the implementer's
+  reasons before siding with the panel.
+- **Zero rejections across many rounds is a red flag.** If the implementer has
+  accepted every finding for several rounds, it's probably being too credulous
+  and the change is over-built. That's the cue to run a skeptical pass.
+- **Add a skeptical reviewer for counter-pressure.** Every default reviewer hunts
+  *what's wrong*, which is to say *what to add*. None hunt *what's over-built*. For
+  anything past a small bead, add a fourth reviewer to `.rb-lite-reviewers` that
+  runs the inverted lens, so the panel pushes back against scope creep instead of
+  only feeding it (see "Customizing the panel").
+- **Periodic skeptical audit.** When the fractal tail shows up, or before merging
+  a large run, stop relaying and run one inverted audit yourself: walk what the run
+  added and label each mechanism *required-for-correctness* versus
+  *defense-in-depth / operational*. Cut, simplify, or mark-optional the latter.
+  Reconcile its output through your own judgment (accepting every cut is the same
+  credulity in reverse), then re-verify the core is intact with no dangling
+  references to anything you removed.
+
 ## Bounding a high-blast-radius bead
 
 Some beads invite sprawl: the core is genuinely hard, or it sits next to several
@@ -614,8 +650,16 @@ root before running, with one shell command per line:
 codex review --base "$BASE"
 set -o pipefail; claude -p "Review the diff vs $BASE. Tag findings P0/P1/P2/P3. Output 'No findings.' if clean." --permission-mode acceptEdits --output-format json --allowedTools "Bash,Edit,Write,Read,Glob,Grep,WebSearch,WebFetch,Task,TaskOutput,TaskStop,Monitor" | jq -er 'if .is_error then error(.result // "claude reviewer returned is_error") else (.result // empty) end'
 if [[ -e node_modules/@google/gemini-cli || -L node_modules/@google/gemini-cli || -e node_modules/.bin/gemini || -L node_modules/.bin/gemini ]]; then printf "%s\n" "rb-lite: refusing to run Gemini reviewer because this repository has a local Gemini CLI package/bin that npx could prefer; customize this reviewer only if intentional" >&2; exit 1; fi; npx -y @google/gemini-cli --policy "$RUN_DIR/gemini-policy.toml" --approval-mode yolo -p "Review the diff vs $BASE. Tag findings P0/P1/P2/P3. Output 'No findings.' if clean."
+# Skeptical reviewer: hunts over-specification instead of bugs, so the panel has counter-pressure against scope creep
+set -o pipefail; claude -p "Review the diff vs $BASE for OVER-SPECIFICATION, not bugs. Flag any mechanism, handling, config, or abstraction that is NOT required for correctness, security, or data-safety and could be cut, simplified, or deferred. For each, give: what it is, why it isn't strictly required (what already covers the case), and a recommendation. Tag each finding 'P2: CUT', 'P2: SIMPLIFY', or 'P2: DEFER'. Do not flag missing behavior or bugs; another reviewer owns that. Output 'No findings.' if the diff is already minimal for its goal." --permission-mode acceptEdits --output-format json --allowedTools "Bash,Read,Glob,Grep" | jq -er 'if .is_error then error(.result // "skeptic reviewer returned is_error") else (.result // empty) end'
 (my-linter --json || true) | wrap-as-p-tags
 ```
+
+The skeptical reviewer is the practical form of "add a fourth reviewer for
+counter-pressure" above: its `CUT` / `SIMPLIFY` / `DEFER` findings tell the
+implementer to *remove* surface, balancing the three default reviewers that only
+ever push to add. Worth adding for any non-trivial bead; skip it for a tiny,
+already-bounded one.
 
 Reviewer commands run **concurrently**, get `BASE`/`RUN_DIR`/`ROUND`/
 `REVIEWER_INDEX` in env, and have stdin closed. The panel succeeds with
@@ -643,7 +687,7 @@ The reviewer contract is strict:
 | `10` | `implementer_failed` | Implementer subprocess returned non-zero (incl. timeout 124/137) or hit max-iters before stabilizing | Look at `implementer-round-N-iter-K.stderr` for the most recent iter |
 | `11` | `review_panel_failed` | Zero reviewers exited 0 | Check `reviewer-round-N-K.stderr` for all reviewers; usually missing CLI/auth or `jq` failure |
 | `12` | `max_rounds_hit` | Burned all `--max-rounds` without convergence | Inspect the latest review files; either bump `--max-rounds`, lower `--min-findings-severity` to skip nits, or address the remaining findings manually |
-| `13` | `consensus_failure` | Implementer kept declining to act on findings for `--max-noop-rounds` consecutive rounds | Read the latest review; the implementer is signaling it disagrees. Apply the fix manually if you side with reviewers, or override `--max-noop-rounds` if you side with the implementer |
+| `13` | `consensus_failure` | Implementer kept declining to act on findings for `--max-noop-rounds` consecutive rounds | Read the latest review **and the implementer's recorded reasons** — it's signaling it disagrees. If its rejections are evidence-backed (false positives or over-specification), this is a legitimate stop, not a failure. Apply the fix manually if you side with reviewers, or accept the run if you side with the implementer |
 | `70` | `internal_error` | Internal invariant violation or unhandled shell failure | Read `log.txt` and the most recent stderr files; this is rare |
 
 The JSON schema (every exit, last stdout line):
@@ -675,10 +719,15 @@ The JSON schema (every exit, last stdout line):
   wrong with the severity floor (it should have stopped). Otherwise,
   consider raising `--min-findings-severity P1` to ignore P2s, or stop
   manually and apply the remaining items.
-- **Implementer "stabilized at iteration 1" repeatedly.** That's the
-  implementer declining to act. The consensus-failure stop will catch
-  it after `--max-noop-rounds` (default 2) — exit 13. Don't lower this
-  unless you understand the trade-off.
+- **Implementer "stabilized at iteration 1" repeatedly.** The implementer is
+  declining to act. The consensus-failure stop catches it after
+  `--max-noop-rounds` (default 2) — exit 13. Before overriding, read *why* it
+  declined: a stuck implementer and one legitimately rejecting findings as false
+  positives or over-specification both look like a no-op round, but only the first
+  is a problem. If the latest `review-round-*.md` plus the implementer's own
+  output show documented, evidence-backed rejections, exit 13 is the right
+  outcome, not a failure to force past. Don't lower `--max-noop-rounds` unless you
+  understand the trade-off.
 - **Implementer dies (exit 10) — rogue self-terminate or transient API
   failure.** Two recurring causes: the implementer signals/kills its own
   process tree (exit 143 / SIGTERM, with a self-experimentation note in


### PR DESCRIPTION
## Summary

Encode a recurring failure mode of review loops: they only ever push toward *adding*, so without counter-pressure a change accretes speculative hardening round over round and the loop never converges. These edits give both review-loop skills the tools to push back.

## Details

**`codex-review-loop`**
- New `CUT/SIMPLIFY` disposition, distinct from `REJECT`. `REJECT` = "the finding is wrong" (needs counter-evidence). `CUT` = "valid as stated, but adds mechanism no real correctness/security/data-loss requirement needs."
- The **over-specification test**: "if I don't do this, what actually breaks, a real correctness problem or only an operational inconvenience?" Plus an explicit note that "annoying to write" is not a cut reason.
- **Meta-signals**: zero `REJECT` and zero `CUT` across many passes is a red flag of credulity; each fix is new review surface, so a steady finding count is a fractal tail, not convergence.
- New **§4a skeptical audit** (inverted pass that hunts what to cut) and a non-convergence stop condition that routes to it.

**`orchestrating-with-rb-lite`**
- New section "The fractal tail, and challenging the panel": the implementer may challenge findings with evidence, the zero-rejection red flag, adding a skeptical reviewer, and a periodic skeptical audit.
- A ready-to-paste skeptical reviewer in the panel example.
- Exit 13 reframed so a *documented* rejection reads as a legitimate stop, not a stall to force past.

## Testing

Docs-only. No code paths changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified review-loop guidance to make decisions more consistent and easier to interpret.
  * Added a new `CUT/SIMPLIFY` outcome for cases where changes can be reduced without harming behavior.
  * Introduced a skeptical audit pass for situations where repeated review rounds stop producing meaningful progress.
  * Expanded end-of-run reporting to include counts and reasons for simplified or cut items, along with other outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->