### PR TITLE
[codex] add lnd payments skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ Codex:
 Use the complexity-reducer skill to reduce ceremony in this code while preserving behavior.
 ```
 
+### lnd-payments
+
+Operates a Kubernetes-hosted lnd node through `kubectl exec` and `lncli` for
+Lightning invoice decode, receive, pay dry-run/send, watch, and payment tracking
+workflows. Node-specific selectors live outside the public skill in XDG config
+or environment variables.
+
+Claude Code:
+
+```text
+/lnd-payments pay this invoice lnbc...
+```
+
+Codex:
+
+```text
+Use the lnd-payments skill to decode this invoice and dry-run payment.
+```
+
 ### plan-to-beads-transfer
 
 Translates a stable spec, PRD, or markdown plan into actual `br` beads with

--- a/skills/lnd-payments/SKILL.md
+++ b/skills/lnd-payments/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: lnd-payments
+description: >-
+  Send and receive Bitcoin Lightning payments with an lnd node reached through
+  kubectl exec and lncli. Use when the user wants to pay a Lightning/BOLT11
+  invoice, decode an invoice or Lightning QR image, create a receive invoice
+  optionally as a QR code, watch a receive invoice until settlement, inspect
+  outgoing payment status/fees/routes/preimages, or check an lnd node's sync and
+  channel balance. Use for Kubernetes-hosted lnd nodes configured through
+  environment variables or XDG config files.
+---
+
+# lnd-payments
+
+Operate a Kubernetes-hosted lnd node by exec-ing `lncli` inside the configured
+workload. Use `scripts/lnpay` instead of hand-writing `kubectl exec` commands.
+
+Paying an invoice spends real bitcoin and is irreversible. Always decode and
+show amount, description, destination, and expiry before sending. The `pay`
+command is a dry run until `--yes` is supplied.
+
+## Configuration
+
+Keep private node details outside this public skill. Configure the runtime with
+environment variables or XDG config files. Effective precedence is:
+
+1. Explicit environment variables.
+2. `LNPAY_CONFIG=/path/to/config.env`.
+3. `${XDG_CONFIG_HOME:-$HOME/.config}/lnpay/profiles/$LNPAY_PROFILE.env`.
+4. `${XDG_CONFIG_HOME:-$HOME/.config}/lnpay/config.env`.
+
+When `LNPAY_CONFIG` is not set, the script loads `config.env` first, then the
+selected profile, so profile values can override shared defaults.
+
+Required values:
+
+```bash
+LN_CONTEXT=my-kube-context
+LN_NAMESPACE=my-lnd-namespace
+LN_TARGET=deploy/my-lnd
+```
+
+Optional values:
+
+```bash
+LN_CONTAINER=lnd
+LN_LOCAL_ALIAS=my-node
+LNPAY_FEE_LIMIT_PERCENT=2
+LNPAY_PAY_TIMEOUT=60
+LNPAY_TRACK_TIMEOUT=30
+LNPAY_WATCH_TIMEOUT=1800
+LNPAY_WATCH_INTERVAL=8
+```
+
+For compatibility, `LN_DEPLOY=my-lnd` may be used instead of `LN_TARGET`; the
+script converts it to `deploy/my-lnd` at that config source's precedence. Prefer
+`LN_TARGET` for public examples because it can also point at another Kubernetes
+workload form.
+
+Do not store macaroons, TLS keys, kubeconfigs, payment history, invoices, or
+preimages in this skill or in public config examples. The config should only
+contain selectors that tell `kubectl` where to run `lncli`.
+
+## CLI
+
+Run `scripts/lnpay <command>` using this skill's absolute path. Examples below
+use `scripts/lnpay` from the skill directory.
+
+```bash
+scripts/lnpay config                    show loaded config, without secrets
+scripts/lnpay node                      sync status + spendable/inbound balance
+scripts/lnpay receive <sats> [--memo M] create an invoice to receive sats
+      [--qr PATH] [--ansi] [--expiry S] [--json]
+scripts/lnpay decode <bolt11|lightning:...>
+                                        show what an invoice will pay
+      [--json]
+scripts/lnpay decode-qr <image>         read a bolt11 out of a Lightning QR
+scripts/lnpay pay <bolt11|lightning:...|@image>
+                                        pay invoice, dry-run until --yes
+      [--amt S] [--fee-limit N] [--timeout S] [--yes]
+scripts/lnpay track <payment_hash|bolt11>
+                                        status, fee, preimage, route aliases
+      [--timeout S] [--json]
+scripts/lnpay watch <payment_hash|bolt11>
+                                        poll until a receive invoice settles
+      [--timeout S] [--interval S]
+```
+
+The CLI is non-interactive: commands exit non-zero on failure, `--json` returns
+`lncli` JSON for `decode` and `track`, `receive --json` adds a hex
+`payment_hash`, and other commands print key/value lines.
+
+Start by running `scripts/lnpay config` and `scripts/lnpay node` to verify the
+configured node is reachable, synced, and has enough spendable local balance for
+sends.
+
+## Receiving
+
+Use `scripts/lnpay receive <sats> --memo "<memo>" --qr /tmp/invoice.png` to
+create a receive invoice and QR code. QR generation uppercases the invoice for
+compact QR alphanumeric mode, then round-trip verifies the image with `zbarimg`.
+
+For a terminal QR preview, add `--ansi`; when combined with `--json`, the ANSI QR
+is written to stderr so stdout stays parseable. lnd's default invoice expiry is
+used unless `--expiry <seconds>` is supplied. The displayed `payment_hash` is hex
+and can be passed directly to `scripts/lnpay watch`.
+
+## Sending
+
+Invoices can be bare BOLT11 strings for any network (`lnbc`, `lntb`,
+`lnbcrt`, etc.), `lightning:` URIs, BIP21 `bitcoin:...?lightning=...` URIs, or
+Lightning QR images passed as `@/path/to/image`. Non-BOLT11 QR payloads fail
+closed, including LNURL or plain `bitcoin:` address QRs without `lightning=`.
+
+Workflow:
+
+1. Run `scripts/lnpay pay <invoice>` without `--yes`.
+2. Relay the decoded amount, description, destination, expiry, and fee ceiling.
+3. Ask the user to confirm the decoded invoice and fee ceiling.
+4. After confirmation, run `scripts/lnpay pay <invoice> --yes`.
+5. After success, run `scripts/lnpay track <invoice>` or
+   `scripts/lnpay track <payment_hash>` to verify the settled payment and
+   collect actual fee, preimage, payment index, and route aliases.
+
+Amountless invoices require `--amt <sats>`.
+
+The default fee ceiling is `LNPAY_FEE_LIMIT_PERCENT` of the amount, with a floor
+of 5 sats. This is a maximum, not the expected fee. Report failed attempts
+before retrying with a higher `--fee-limit`.
+
+## Tracking
+
+Use `scripts/lnpay track <payment_hash|bolt11>` when the user asks whether a
+payment succeeded, what fee was paid, what preimage was returned, or what route
+was used. It wraps `lncli trackpayment --json` and resolves hop aliases via
+`getnodeinfo`.
+
+`trackpayment` exposes only `--json` in checked lnd CLI releases; do not pass
+`--no_inflight_updates`. `no_inflight_updates` is a router RPC field, not a
+documented `lncli trackpayment` flag. `payinvoice`/`sendpayment` expose the
+positive `--inflight_updates` flag for send streams when used with `--json`.
+
+When reporting fees, distinguish `fee-limit` from actual `fee_sat`/`fee_msat`.
+When reporting a route, include the configured local alias if present, then each
+successful HTLC part and each hop alias, with pubkeys/channel IDs when audit
+detail is useful.
+
+## Watching
+
+Use `scripts/lnpay watch <payment_hash|bolt11> --timeout 1800 --interval 8` to
+poll a receive invoice until `SETTLED`, `CANCELED`, expiry, or timeout. Run long
+watches in the background rather than blocking the session.
+
+## Dependencies
+
+- `kubectl` with access to the configured context.
+- `python3`.
+- `qrencode` for QR generation and `zbarimg` for QR decoding; the script uses
+  system binaries when available, otherwise it tries `nix shell nixpkgs#...`.
+- `timeout` for bounded `trackpayment` calls.
+
+## Troubleshooting
+
+- Missing config: run `lnpay config`; set `LN_CONTEXT`, `LN_NAMESPACE`, and
+  `LN_TARGET`, or create the XDG config file.
+- `exec` fails: verify the Kubernetes target with `kubectl --context
+  "$LN_CONTEXT" -n "$LN_NAMESPACE" get pods`.
+- Wallet locked or lnd starting: surface that to the user; this skill does not
+  hold unlock material.
+- `decodepayreq failed`: the invoice may be truncated, wrong-network, expired,
+  or the QR may contain a non-Lightning payload.
+- Payment stuck or failed with no route: check `lnpay node` for outbound
+  balance, then consider a higher explicit `--fee-limit`.

--- a/skills/lnd-payments/evals/evals.json
+++ b/skills/lnd-payments/evals/evals.json
@@ -1,0 +1,36 @@
+{
+  "skill_name": "lnd-payments",
+  "note": "This skill can operate nodes with real funds. Automated evals should avoid live sends unless they use a disposable test node and explicit user approval. Safe paths include config inspection, node status, decode, decode-qr, receive on test nodes, pay dry-run, and tracking known historical payments.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "generate a 5000 sat invoice as a qr code",
+      "expected_output": "Confirms configuration, creates an invoice with `scripts/lnpay receive 5000 --qr <path>`, round-trip verifies the QR image, and surfaces the bolt11 plus hex payment_hash.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "pay this invoice [photo of a Lightning QR code]",
+      "expected_output": "Decodes the QR with `scripts/lnpay decode-qr` or `scripts/lnpay pay @image`, shows amount/description/destination/expiry, stops at dry-run, asks for explicit confirmation, then verifies confirmed successful sends with `scripts/lnpay track <invoice>`.",
+      "files": ["a phone photo of a BOLT11 QR"]
+    },
+    {
+      "id": 3,
+      "prompt": "is our lightning node healthy and how much can it send?",
+      "expected_output": "Runs `lnpay config` and `lnpay node`; reports sync state, active channels, spendable local balance, and inbound remote balance.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "watch that invoice and tell me when it gets paid",
+      "expected_output": "Runs `scripts/lnpay watch <payment_hash|bolt11>` in the background; on settlement reports SETTLED and amount received, or reports timeout/canceled state.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "what route did that lightning payment use?",
+      "expected_output": "Runs `scripts/lnpay track <payment_hash|bolt11>`; reports local node alias if configured, every successful HTLC part, route aliases, pubkeys/channel IDs, actual fee, preimage, and payment index when available.",
+      "files": []
+    }
+  ]
+}

--- a/skills/lnd-payments/scripts/lnpay
+++ b/skills/lnd-payments/scripts/lnpay
@@ -1,0 +1,629 @@
+#!/usr/bin/env bash
+# lnpay - send and receive Bitcoin Lightning payments through an lnd node that
+# is reached by running lncli inside a Kubernetes workload.
+set -euo pipefail
+
+err() { echo "lnpay: $*" >&2; }
+die() { err "$*"; exit 1; }
+
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/lnpay"
+LNPAY_LOADED_CONFIGS=()
+LNPAY_CONFIG_ERROR=""
+LNPAY_CONFIG_ERROR_FATAL=0
+
+CONFIG_ENV_NAMES=(
+  LN_CONTEXT
+  LN_NAMESPACE
+  LN_TARGET
+  LN_DEPLOY
+  LN_CONTAINER
+  LN_LOCAL_ALIAS
+  LN_DEFAULT_FEE_PCT
+  LNPAY_FEE_LIMIT_PERCENT
+  LNPAY_PROFILE
+  LNPAY_PAY_TIMEOUT
+  LNPAY_TRACK_TIMEOUT
+  LNPAY_WATCH_TIMEOUT
+  LNPAY_WATCH_INTERVAL
+)
+
+load_one_config() {
+  local path="$1"
+  [ -f "$path" ] || return 0
+
+  local line key value
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -z "$line" ] && continue
+    case "$line" in "#"*) continue;; esac
+    case "$line" in export\ *) line="${line#export }";; esac
+    case "$line" in *=*) ;; *) die "invalid config line in $path: $line";; esac
+
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$key" in
+      LN_CONTEXT|LN_NAMESPACE|LN_TARGET|LN_DEPLOY|LN_CONTAINER|LN_LOCAL_ALIAS|LN_DEFAULT_FEE_PCT|LNPAY_FEE_LIMIT_PERCENT|LNPAY_PROFILE|LNPAY_PAY_TIMEOUT|LNPAY_TRACK_TIMEOUT|LNPAY_WATCH_TIMEOUT|LNPAY_WATCH_INTERVAL)
+        ;;
+      *)
+        die "unknown config key in $path: $key"
+        ;;
+    esac
+    case "$value" in
+      \"*\") value="${value#\"}"; value="${value%\"}";;
+      \'*\') value="${value#\'}"; value="${value%\'}";;
+    esac
+    printf -v "$key" '%s' "$value"
+    if [ "$key" = "LN_DEPLOY" ] && [ -n "$value" ]; then
+      LN_TARGET="deploy/$value"
+    fi
+  done < "$path"
+
+  LNPAY_LOADED_CONFIGS+=("$path")
+}
+
+validate_profile_name() {
+  [ -z "${LNPAY_PROFILE:-}" ] && return 0
+  case "$LNPAY_PROFILE" in
+    *[!A-Za-z0-9_-]*)
+      die "invalid LNPAY_PROFILE '$LNPAY_PROFILE' - use letters, numbers, underscore, or hyphen"
+      ;;
+  esac
+}
+
+load_config() {
+  declare -A env_overrides=()
+  local name profile_path
+  for name in "${CONFIG_ENV_NAMES[@]}"; do
+    if [ "${!name+x}" = "x" ]; then
+      env_overrides["$name"]="${!name}"
+    fi
+  done
+
+  if [ -n "${LNPAY_CONFIG:-}" ]; then
+    if [ -f "$LNPAY_CONFIG" ]; then
+      load_one_config "$LNPAY_CONFIG"
+    else
+      LNPAY_CONFIG_ERROR="LNPAY_CONFIG points to missing file: $LNPAY_CONFIG"
+    fi
+  else
+    load_one_config "$CONFIG_HOME/config.env"
+    if [ "${env_overrides[LNPAY_PROFILE]+x}" = "x" ]; then
+      printf -v LNPAY_PROFILE '%s' "${env_overrides[LNPAY_PROFILE]}"
+    fi
+	    validate_profile_name
+	    if [ -n "${LNPAY_PROFILE:-}" ]; then
+	      profile_path="$CONFIG_HOME/profiles/$LNPAY_PROFILE.env"
+	      if [ -f "$profile_path" ]; then
+	        load_one_config "$profile_path"
+	      else
+	        LNPAY_CONFIG_ERROR="LNPAY_PROFILE points to missing file: $profile_path"
+	        LNPAY_CONFIG_ERROR_FATAL=1
+	      fi
+	    fi
+	  fi
+
+  for name in "${CONFIG_ENV_NAMES[@]}"; do
+    case "$name" in LN_TARGET|LN_DEPLOY) continue;; esac
+    [ "${env_overrides[$name]+x}" = "x" ] || continue
+    printf -v "$name" '%s' "${env_overrides[$name]}"
+  done
+  if [ "${env_overrides[LN_DEPLOY]+x}" = "x" ]; then
+    printf -v LN_DEPLOY '%s' "${env_overrides[LN_DEPLOY]}"
+    [ -n "$LN_DEPLOY" ] && LN_TARGET="deploy/$LN_DEPLOY"
+  fi
+  if [ "${env_overrides[LN_TARGET]+x}" = "x" ]; then
+    printf -v LN_TARGET '%s' "${env_overrides[LN_TARGET]}"
+  fi
+  validate_profile_name
+
+  LN_CONTAINER="${LN_CONTAINER:-lnd}"
+  LNPAY_FEE_LIMIT_PERCENT="${LNPAY_FEE_LIMIT_PERCENT:-${LN_DEFAULT_FEE_PCT:-2}}"
+  LNPAY_PAY_TIMEOUT="${LNPAY_PAY_TIMEOUT:-60}"
+  LNPAY_TRACK_TIMEOUT="${LNPAY_TRACK_TIMEOUT:-30}"
+  LNPAY_WATCH_TIMEOUT="${LNPAY_WATCH_TIMEOUT:-1800}"
+  LNPAY_WATCH_INTERVAL="${LNPAY_WATCH_INTERVAL:-8}"
+}
+
+require_node_config() {
+  local missing=()
+  [ -n "${LN_CONTEXT:-}" ] || missing+=("LN_CONTEXT")
+  [ -n "${LN_NAMESPACE:-}" ] || missing+=("LN_NAMESPACE")
+  [ -n "${LN_TARGET:-}" ] || missing+=("LN_TARGET")
+
+	  if [ -n "$LNPAY_CONFIG_ERROR" ] && { [ "$LNPAY_CONFIG_ERROR_FATAL" = 1 ] || [ "${#missing[@]}" -gt 0 ]; }; then
+	    die "$LNPAY_CONFIG_ERROR"
+	  fi
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    die "missing config: ${missing[*]}. Set env vars, LNPAY_CONFIG, or create $CONFIG_HOME/config.env"
+  fi
+}
+
+kubectl_lncli() {
+  require_node_config
+  local args=(--context "$LN_CONTEXT" -n "$LN_NAMESPACE" exec "$LN_TARGET")
+  [ -n "${LN_CONTAINER:-}" ] && args+=(-c "$LN_CONTAINER")
+  args+=(-- lncli "$@")
+  kubectl "${args[@]}"
+}
+
+kubectl_lncli_timeout() {
+  local seconds="$1"; shift
+  require_node_config
+  local args=(--context "$LN_CONTEXT" -n "$LN_NAMESPACE" exec "$LN_TARGET")
+  [ -n "${LN_CONTAINER:-}" ] && args+=(-c "$LN_CONTAINER")
+  args+=(-- lncli "$@")
+  timeout "${seconds}s" kubectl "${args[@]}"
+}
+
+lncli() {
+  kubectl_lncli "$@"
+}
+
+with_tool() {
+  local pkg="$1" bin="$2"; shift 2
+  [ "${1:-}" = "--" ] && shift
+  if command -v "$bin" >/dev/null 2>&1; then
+    "$bin" "$@"
+  elif command -v nix >/dev/null 2>&1; then
+    nix shell "nixpkgs#$pkg" --command "$bin" "$@"
+  else
+    die "need '$bin' - install $pkg, or install nix so it can be fetched on demand"
+  fi
+}
+
+jget() {
+  python3 -c '
+import sys, json
+key = sys.argv[1]
+try:
+    print(json.load(sys.stdin).get(key, ""))
+except Exception:
+    print("")
+' "$1"
+}
+
+add_json_field() {
+  python3 -c '
+import sys, json
+key = sys.argv[1]
+value = sys.argv[2]
+d = json.load(sys.stdin)
+d[key] = value
+print(json.dumps(d))
+' "$1" "$2"
+}
+
+node_alias() {
+  local pubkey="${1:-}" out
+  [ -n "$pubkey" ] || return 0
+  out="$(lncli getnodeinfo "$pubkey" 2>/dev/null || true)"
+  printf '%s' "$out" | python3 -c '
+import sys, json
+try:
+    print(json.load(sys.stdin).get("node", {}).get("alias", ""))
+except Exception:
+    print("")
+'
+}
+
+payment_rows() {
+  python3 -c '
+import sys, json
+s = sys.stdin.read()
+dec = json.JSONDecoder()
+objs = []
+i = 0
+while i < len(s):
+    while i < len(s) and s[i].isspace():
+        i += 1
+    if i >= len(s):
+        break
+    obj, i = dec.raw_decode(s, i)
+    objs.append(obj)
+if not objs:
+    raise SystemExit("no JSON payment update found")
+d = objs[-1]
+for k in ("payment_hash", "status", "value_sat", "fee_sat", "fee_msat",
+          "payment_preimage", "failure_reason", "payment_index"):
+    print("field\t%s\t%s" % (k, d.get(k, "")))
+htlcs = d.get("htlcs") or []
+parts = [h for h in htlcs if h.get("status") == "SUCCEEDED"]
+if not parts and htlcs:
+    parts = [htlcs[-1]]
+for part_idx, part in enumerate(parts, 1):
+    route = part.get("route") or {}
+    print("part\t%d\t%s\t%s\t%s" % (
+        part_idx,
+        part.get("status", ""),
+        route.get("total_amt", ""),
+        route.get("total_fees", ""),
+    ))
+    for hop_idx, hop in enumerate(route.get("hops") or [], 1):
+        print("hop\t%d\t%d\t%s\t%s\t%s\t%s" % (
+            part_idx,
+            hop_idx,
+            hop.get("pub_key", ""),
+            hop.get("chan_id", ""),
+            hop.get("amt_to_forward", ""),
+            hop.get("fee", ""),
+        ))
+'
+}
+
+extract_bolt11() {
+  python3 -c '
+import sys
+from urllib.parse import parse_qsl, urlsplit
+s = sys.argv[1].strip()
+for p in ("lightning:", "LIGHTNING:"):
+    if s.startswith(p):
+        print(s[len(p):].strip().lower()); sys.exit()
+for k, v in parse_qsl(urlsplit(s).query, keep_blank_values=True):
+    if k.lower() == "lightning" and v:
+        print(v.strip().lower()); sys.exit()
+print(s.strip().lower())
+' "$1"
+}
+
+is_invoice_target() {
+  case "$1" in
+    [lL][nN]*|[lL][iI][gG][hH][tT][nN][iI][nN][gG]:*|[bB][iI][tT][cC][oO][iI][nN]:*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_bolt11() {
+  case "$1" in
+    [lL][nN][bB][cC]*|[lL][nN][tT][bB]*|[lL][nN][bB][cC][rR][tT]*|[lL][nN][sS][bB]*)
+      return 0
+      ;;
+    *) return 1;;
+  esac
+}
+
+cmd_config() {
+  if [ "${#LNPAY_LOADED_CONFIGS[@]}" -eq 0 ]; then
+    echo "config_files: none"
+  else
+    printf 'config_files: %s\n' "${LNPAY_LOADED_CONFIGS[*]}"
+  fi
+  [ -z "$LNPAY_CONFIG_ERROR" ] || echo "config_error: $LNPAY_CONFIG_ERROR"
+  echo "profile: ${LNPAY_PROFILE:-}"
+  echo "context: ${LN_CONTEXT:-}"
+  echo "namespace: ${LN_NAMESPACE:-}"
+  echo "target: ${LN_TARGET:-}"
+  echo "container: ${LN_CONTAINER:-}"
+  echo "local_alias: ${LN_LOCAL_ALIAS:-}"
+  echo "fee_limit_percent: $LNPAY_FEE_LIMIT_PERCENT"
+  echo "pay_timeout: $LNPAY_PAY_TIMEOUT"
+  echo "track_timeout: $LNPAY_TRACK_TIMEOUT"
+  echo "watch_timeout: $LNPAY_WATCH_TIMEOUT"
+  echo "watch_interval: $LNPAY_WATCH_INTERVAL"
+}
+
+cmd_node() {
+  require_node_config
+  echo "context=$LN_CONTEXT ns=$LN_NAMESPACE target=$LN_TARGET container=${LN_CONTAINER:-}"
+  lncli getinfo | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print("alias:           ", d.get("alias"))
+print("pubkey:          ", d.get("identity_pubkey"))
+print("synced_to_chain: ", d.get("synced_to_chain"))
+print("synced_to_graph: ", d.get("synced_to_graph"))
+print("active_channels: ", d.get("num_active_channels"))
+print("block_height:    ", d.get("block_height"))'
+  lncli channelbalance | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print("spendable_local: ", d.get("local_balance", {}).get("sat"), "sat")
+print("inbound_remote:  ", d.get("remote_balance", {}).get("sat"), "sat")'
+}
+
+need_value() {
+  [ "$#" -ge 2 ] || die "$1 requires a value"
+}
+
+cmd_receive() {
+  local sats="" memo="lnpay invoice" qr="" ansi=0 expiry="" json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --memo) need_value "$@"; memo="$2"; shift 2;;
+      --qr) need_value "$@"; qr="$2"; shift 2;;
+      --ansi) ansi=1; shift;;
+      --expiry) need_value "$@"; expiry="$2"; shift 2;;
+      --json) json=1; shift;;
+      -*) die "unknown flag: $1";;
+      *) [ -z "$sats" ] && { sats="$1"; shift; } || die "unexpected arg: $1";;
+    esac
+  done
+  [ -n "$sats" ] || die "usage: lnpay receive <sats> [--memo M] [--qr PATH] [--ansi] [--expiry SECONDS] [--json]"
+
+  local addargs=(addinvoice --amt "$sats" --memo "$memo")
+  [ -n "$expiry" ] && addargs+=(--expiry "$expiry")
+  local out; out="$(lncli "${addargs[@]}")" || die "addinvoice failed"
+
+  local bolt11 dec payment_hash upper
+  bolt11="$(printf '%s' "$out" | jget payment_request)"
+  [ -n "$bolt11" ] || die "no payment_request returned"
+  dec="$(lncli decodepayreq "$bolt11")" || die "decodepayreq failed after addinvoice"
+  payment_hash="$(printf '%s' "$dec" | jget payment_hash)"
+  [ -n "$payment_hash" ] || die "no payment_hash returned"
+  upper="$(printf '%s' "$bolt11" | tr 'a-z' 'A-Z')"
+
+  if [ -n "$qr" ]; then
+    printf '%s' "$upper" | with_tool qrencode qrencode -- -o "$qr" -s 8 -m 4 -l M
+    local back
+    back="$(with_tool zbar zbarimg -- --quiet --raw "$qr" | tr 'A-Z' 'a-z' | tr -d '[:space:]')"
+    [ "$back" = "$bolt11" ] || die "QR round-trip verify failed for $qr"
+  fi
+  if [ "$ansi" = 1 ]; then
+    if [ "$json" = 1 ]; then
+      printf '%s' "$upper" | with_tool qrencode qrencode -- -t ANSIUTF8 -l M >&2
+    else
+      printf '%s' "$upper" | with_tool qrencode qrencode -- -t ANSIUTF8 -l M
+    fi
+  fi
+
+  if [ "$json" = 1 ]; then
+    printf '%s\n' "$out" | add_json_field payment_hash "$payment_hash"
+  else
+    echo "amount_sats:  $sats"
+    echo "memo:         $memo"
+    echo "payment_hash: $payment_hash"
+    [ -n "$qr" ] && echo "qr_png:       $qr (round-trip verified)"
+    echo "bolt11:       $bolt11"
+  fi
+}
+
+cmd_decode() {
+  local inv="" json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json=1; shift;;
+      *) inv="$1"; shift;;
+    esac
+  done
+  [ -n "$inv" ] || die "usage: lnpay decode <bolt11|lightning:...> [--json]"
+  inv="$(extract_bolt11 "$inv")"
+  local out; out="$(lncli decodepayreq "$inv")" || die "decodepayreq failed - not a valid invoice?"
+  if [ "$json" = 1 ]; then
+    printf '%s\n' "$out"
+  else
+    echo "amount_sats:  $(printf '%s' "$out" | jget num_satoshis)"
+    echo "description:  $(printf '%s' "$out" | jget description)"
+    echo "destination:  $(printf '%s' "$out" | jget destination)"
+    echo "expiry_secs:  $(printf '%s' "$out" | jget expiry)"
+    echo "payment_hash: $(printf '%s' "$out" | jget payment_hash)"
+  fi
+}
+
+cmd_decode_qr() {
+  local img="${1:-}"
+  [ -n "$img" ] || die "usage: lnpay decode-qr <image>"
+  [ -f "$img" ] || die "no such file: $img"
+  local raw inv
+  raw="$(with_tool zbar zbarimg -- --quiet --raw "$img")" || die "no QR code found in $img"
+  inv="$(extract_bolt11 "$raw")"
+  is_bolt11 "$inv" || die "QR payload is not a BOLT11 Lightning invoice"
+  printf '%s\n' "$inv"
+}
+
+cmd_pay() {
+  local target="" amt="" fee_limit="" yes=0 timeout="$LNPAY_PAY_TIMEOUT"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --amt) need_value "$@"; amt="$2"; shift 2;;
+      --fee-limit) need_value "$@"; fee_limit="$2"; shift 2;;
+      --timeout) need_value "$@"; timeout="$2"; shift 2;;
+      --yes|-y) yes=1; shift;;
+      -*) die "unknown flag: $1";;
+      *) [ -z "$target" ] && { target="$1"; shift; } || die "unexpected arg: $1";;
+    esac
+  done
+  [ -n "$target" ] || die "usage: lnpay pay <bolt11|lightning:...|@image> [--amt S] [--fee-limit N] [--yes]"
+
+  local inv
+  if [ "${target:0:1}" = "@" ]; then
+    inv="$(cmd_decode_qr "${target:1}")" || die "could not read invoice from QR"
+  else
+    inv="$(extract_bolt11 "$target")"
+  fi
+
+  local dec; dec="$(lncli decodepayreq "$inv")" || die "decodepayreq failed - not a valid invoice?"
+  local n_amt n_msat desc dest exp
+  n_amt="$(printf '%s' "$dec" | jget num_satoshis)"
+  n_msat="$(printf '%s' "$dec" | jget num_msat)"
+  desc="$(printf '%s' "$dec" | jget description)"
+  dest="$(printf '%s' "$dec" | jget destination)"
+  exp="$(printf '%s' "$dec" | jget expiry)"
+  n_amt="${n_amt:-0}"
+  if [ -z "$n_msat" ]; then
+    n_msat="$(python3 -c 'import sys; print(int(sys.argv[1]) * 1000)' "$n_amt")"
+  fi
+
+  local amountless=0
+  [ "$n_msat" = "0" ] && amountless=1
+  [ "$amountless" = 0 ] && [ -n "$amt" ] && die "--amt is only valid for amountless invoices"
+
+  local pay_amt="$n_amt"
+  [ "$amountless" = 1 ] && pay_amt="$amt"
+
+  echo "Invoice"
+  echo "amount_sats:  ${n_amt}${amt:+ (will pay $amt)}"
+  [ "$n_msat" != "$(( n_amt * 1000 ))" ] && echo "amount_msat:  $n_msat"
+  echo "description:  $desc"
+  echo "destination:  $dest"
+  echo "expiry_secs:  $exp"
+
+  [ "$amountless" = 1 ] && [ -z "$amt" ] && die "amountless invoice - supply --amt <sats>"
+
+  if [ -z "$fee_limit" ]; then
+    fee_limit="$(python3 -c 'import math,sys; a=int(sys.argv[1]); p=float(sys.argv[2]); print(max(5, math.ceil(a*p/100)))' "$pay_amt" "$LNPAY_FEE_LIMIT_PERCENT")"
+  fi
+
+  if [ "$yes" != 1 ]; then
+    local pay_label="${pay_amt} sats"
+    [ "$amountless" = 0 ] && [ "$n_msat" != "$(( n_amt * 1000 ))" ] && pay_label="${n_msat} msat"
+    echo "DRY RUN - nothing sent. Re-run with --yes to pay ${pay_label} (fee limit ${fee_limit})."
+    return 0
+  fi
+
+  local payargs=(payinvoice --force --timeout "${timeout}s" --fee_limit "$fee_limit")
+  [ "$amountless" = 1 ] && payargs+=(--amt "$amt")
+  payargs+=("$inv")
+  lncli "${payargs[@]}"
+}
+
+cmd_track() {
+  local target="" timeout="$LNPAY_TRACK_TIMEOUT" json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --timeout) need_value "$@"; timeout="$2"; shift 2;;
+      --json) json=1; shift;;
+      -*) die "unknown flag: $1";;
+      *) target="$1"; shift;;
+    esac
+  done
+  [ -n "$target" ] || die "usage: lnpay track <payment_hash|bolt11|lightning:...> [--timeout S] [--json]"
+
+  local rhash="$target"
+  if is_invoice_target "$target"; then
+    local inv
+    inv="$(extract_bolt11 "$target")"
+    rhash="$(lncli decodepayreq "$inv" | jget payment_hash)"
+  fi
+  [ -n "$rhash" ] || die "could not determine payment hash"
+
+  local out code=0
+  out="$(kubectl_lncli_timeout "$timeout" trackpayment --json "$rhash" 2>&1)" || code=$?
+  if [ "$code" = 124 ]; then
+    die "trackpayment timed out after ${timeout}s; payment may still be in flight"
+  elif [ "$code" != 0 ]; then
+    printf '%s\n' "$out" >&2
+    die "trackpayment failed"
+  fi
+
+  if [ "$json" = 1 ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+
+  local rows
+  rows="$(printf '%s' "$out" | payment_rows)" || die "could not parse trackpayment JSON"
+  [ -n "${LN_LOCAL_ALIAS:-}" ] && printf '%-17s %s\n' "local_alias:" "$LN_LOCAL_ALIAS"
+  while IFS=$'\t' read -r kind a b c d e f; do
+    case "$kind" in
+      field)
+        printf '%-17s %s\n' "${a}:" "$b"
+        ;;
+      part)
+        printf 'part_%s:           status=%s total_amt_sat=%s total_fee_sat=%s\n' \
+          "$a" "$b" "$c" "$d"
+        ;;
+      hop)
+        local alias
+        alias="$(node_alias "$c")"
+        [ -n "$alias" ] || alias="(unknown)"
+        printf 'part_%s_hop_%s:     alias=%s pubkey=%s channel=%s forward_sat=%s fee_sat=%s\n' \
+          "$a" "$b" "$alias" "$c" "$d" "$e" "$f"
+        ;;
+    esac
+  done <<< "$rows"
+}
+
+cmd_watch() {
+  local target="" timeout="$LNPAY_WATCH_TIMEOUT" interval="$LNPAY_WATCH_INTERVAL"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --timeout) need_value "$@"; timeout="$2"; shift 2;;
+      --interval) need_value "$@"; interval="$2"; shift 2;;
+      *) target="$1"; shift;;
+    esac
+  done
+  [ -n "$target" ] || die "usage: lnpay watch <payment_hash|bolt11|lightning:...> [--timeout S] [--interval S]"
+
+  local rhash="$target"
+  if is_invoice_target "$target"; then
+    rhash="$(lncli decodepayreq "$(extract_bolt11 "$target")" | jget payment_hash)"
+  fi
+  [ -n "$rhash" ] || die "could not determine payment hash"
+
+  local deadline=$(( $(date +%s) + timeout )) last=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local out state paid
+    out="$(lncli lookupinvoice "$rhash" 2>&1)" || die "lookupinvoice failed: $out"
+    state="$(printf '%s' "$out" | jget state)"
+    paid="$(printf '%s' "$out" | jget amt_paid_sat)"
+    if [ "$state" != "$last" ]; then
+      echo "[$(date +%H:%M:%S)] state=${state:-?} amt_paid_sat=${paid:-0}"
+      last="$state"
+    fi
+    case "$state" in
+      SETTLED) echo "RESULT: SETTLED - received ${paid} sats"; return 0;;
+      CANCELED) echo "RESULT: CANCELED/expired"; return 0;;
+    esac
+    sleep "$interval"
+  done
+  echo "RESULT: still ${last:-OPEN} after ${timeout}s - stopped watching (invoice may still be valid)"
+}
+
+usage() {
+  cat <<EOF
+lnpay - send and receive Lightning payments via kubectl exec + lncli
+
+Commands:
+  lnpay config                            show loaded config, without secrets
+  lnpay node                              node sync status + spendable balance
+  lnpay receive <sats> [--memo M]         create an invoice to receive sats
+        [--qr PATH] [--ansi] [--expiry S] [--json]
+  lnpay decode <bolt11|lightning:...>     show what an invoice will pay
+        [--json]
+  lnpay decode-qr <image>                 read a bolt11 out of a QR image
+  lnpay pay <bolt11|lightning:...|@image> pay invoice, dry-run until --yes
+        [--amt S] [--fee-limit N] [--timeout S] [--yes]
+  lnpay track <payment_hash|bolt11>       status, fee, preimage, route aliases
+        [--timeout S] [--json]
+  lnpay watch <payment_hash|bolt11>       poll until a receive invoice settles
+        [--timeout S] [--interval S]
+
+Config:
+  Required: LN_CONTEXT, LN_NAMESPACE, and LN_TARGET (or LN_DEPLOY).
+  Optional: LN_CONTAINER, LN_LOCAL_ALIAS, LNPAY_FEE_LIMIT_PERCENT,
+            LNPAY_PAY_TIMEOUT, LNPAY_TRACK_TIMEOUT, LNPAY_WATCH_TIMEOUT.
+
+Effective config precedence:
+  1. explicit environment variables
+  2. LNPAY_CONFIG=/path/to/config.env
+  3. ${CONFIG_HOME}/profiles/\$LNPAY_PROFILE.env
+  4. ${CONFIG_HOME}/config.env
+
+Without LNPAY_CONFIG, config.env is loaded first and the selected profile is
+loaded after it so profile values can override shared defaults.
+EOF
+}
+
+load_config
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  config) cmd_config "$@";;
+  node) cmd_node "$@";;
+  receive) cmd_receive "$@";;
+  decode) cmd_decode "$@";;
+  decode-qr) cmd_decode_qr "$@";;
+  pay) cmd_pay "$@";;
+  track) cmd_track "$@";;
+  watch) cmd_watch "$@";;
+  ""|help|-h|--help) usage;;
+  *) err "unknown command: $cmd"; usage; exit 2;;
+esac


### PR DESCRIPTION
## Summary
Add a public-safe `lnd-payments` skill for operating Kubernetes-hosted lnd nodes through `kubectl exec` and `lncli`.

The skill includes a generic `lnpay` helper for config inspection, node status, invoice receive/decode, payment dry-run/send, payment tracking, and invoice settlement watching. Node-specific selectors are loaded from environment variables or XDG config files, keeping private infrastructure details out of the public skill.

## Lineage / context
This extracts the reusable parts of a local LND payment workflow into a public skill while moving private node configuration to `~/.config/lnpay` outside the repository.

## Trade-offs accepted
- The helper assumes Kubernetes-hosted lnd and does not try to support direct local or remote RPC modes.
- Config files intentionally store only Kubernetes selectors; credentials, macaroons, TLS material, invoices, and payment history remain out of scope.
- Live send evals are documented but not automated because this skill can operate nodes with real funds.

## Test plan
- [x] `bash -n skills/lnd-payments/scripts/lnpay`
- [x] `uv run --with pyyaml python /home/master/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/lnd-payments`
- [x] Missing-config smoke test fails closed with a clear error
- [x] Private-token scan over the public skill and README found no exact private node/provider/payment identifiers
- [x] Local private profile read-only `lnpay node` smoke test succeeds
- [ ] CI green
- [ ] Codex bot review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `lnd-payments` skill for managing Lightning payments through a Kubernetes-hosted LND node.
  * Supports invoice creation (including QR output), invoice decoding, pay flows with dry-run confirmation, payment tracking, and invoice watching.
  * Added an evaluation plan with safety guidance to avoid unintended live sends.

* **Documentation**
  * Expanded setup/config guidance (including configuration precedence via profiles and environment variables).
  * Added example invocations for Claude Code and Codex.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->