### PR TITLE
feat(lnd-payments): add newaddress onchain address command

### DIFF
--- a/skills/lnd-payments/SKILL.md
+++ b/skills/lnd-payments/SKILL.md
@@ -4,10 +4,11 @@ description: >-
   Send and receive Bitcoin Lightning payments with an lnd node reached through
   kubectl exec and lncli. Use when the user wants to pay a Lightning/BOLT11
   invoice, decode an invoice or Lightning QR image, create a receive invoice
-  optionally as a QR code, watch a receive invoice until settlement, inspect
-  outgoing payment status/fees/routes/preimages, or check an lnd node's sync and
-  channel balance. Use for Kubernetes-hosted lnd nodes configured through
-  environment variables or XDG config files.
+  optionally as a QR code, generate an onchain (on-chain) bitcoin receive
+  address, watch a receive invoice until settlement, inspect outgoing payment
+  status/fees/routes/preimages, or check an lnd node's sync and channel balance.
+  Use for Kubernetes-hosted lnd nodes configured through environment variables
+  or XDG config files.
 ---
 
 # lnd-payments
@@ -69,6 +70,7 @@ use `scripts/lnpay` from the skill directory.
 ```bash
 scripts/lnpay config                    show loaded config, without secrets
 scripts/lnpay node                      sync status + spendable/inbound balance
+scripts/lnpay newaddress [TYPE] [--json] generate an onchain receive address
 scripts/lnpay receive <sats> [--memo M] create an invoice to receive sats
       [--qr PATH] [--ansi] [--expiry S] [--json]
 scripts/lnpay decode <bolt11|lightning:...>
@@ -87,12 +89,26 @@ scripts/lnpay watch <payment_hash|bolt11>
 ```
 
 The CLI is non-interactive: commands exit non-zero on failure, `--json` returns
-`lncli` JSON for `decode` and `track`, `receive --json` adds a hex
+`lncli` JSON for `decode`, `track`, and `newaddress`, `receive --json` adds a hex
 `payment_hash`, and other commands print key/value lines.
 
 Start by running `scripts/lnpay config` and `scripts/lnpay node` to verify the
 configured node is reachable, synced, and has enough spendable local balance for
 sends.
+
+## On-chain addresses
+
+Use `scripts/lnpay newaddress` to generate a fresh on-chain bitcoin receive
+address from the lnd wallet. The address type is an optional positional argument:
+
+- `p2wkh` (default) — native SegWit `bc1q…`, widely compatible.
+- `np2wkh` — nested SegWit `3…`, for legacy senders.
+- `p2tr` — Taproot `bc1p…`.
+
+Each call returns a new unused address. Add `--json` to pass through the raw
+`lncli newaddress` JSON (`{"address": "..."}`) for scripting. This funds the lnd
+on-chain wallet (e.g. for opening channels); it does not create a Lightning
+invoice — use `receive` for that.
 
 ## Receiving
 

--- a/skills/lnd-payments/evals/evals.json
+++ b/skills/lnd-payments/evals/evals.json
@@ -31,6 +31,12 @@
       "prompt": "what route did that lightning payment use?",
       "expected_output": "Runs `scripts/lnpay track <payment_hash|bolt11>`; reports local node alias if configured, every successful HTLC part, route aliases, pubkeys/channel IDs, actual fee, preimage, and payment index when available.",
       "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "generate an onchain address on our lnd",
+      "expected_output": "Runs `scripts/lnpay newaddress` (default p2wkh native SegWit) and returns the fresh bc1q address; offers np2wkh or p2tr as alternatives when relevant, without hand-writing a raw kubectl exec.",
+      "files": []
     }
   ]
 }

--- a/skills/lnd-payments/scripts/lnpay
+++ b/skills/lnd-payments/scripts/lnpay
@@ -333,6 +333,33 @@ need_value() {
   [ "$#" -ge 2 ] || die "$1 requires a value"
 }
 
+cmd_newaddress() {
+  local addr_type="" json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json=1; shift;;
+      -*) die "unknown flag: $1";;
+      *) [ -z "$addr_type" ] && { addr_type="$1"; shift; } || die "unexpected arg: $1";;
+    esac
+  done
+  addr_type="${addr_type:-p2wkh}"
+  case "$addr_type" in
+    p2wkh|np2wkh|p2tr) ;;
+    *) die "unknown address type '$addr_type' - use p2wkh, np2wkh, or p2tr";;
+  esac
+
+  local out; out="$(lncli newaddress "$addr_type")" || die "newaddress failed"
+  local address; address="$(printf '%s' "$out" | jget address)"
+  [ -n "$address" ] || die "no address returned"
+
+  if [ "$json" = 1 ]; then
+    printf '%s\n' "$out"
+  else
+    echo "address_type: $addr_type"
+    echo "address:      $address"
+  fi
+}
+
 cmd_receive() {
   local sats="" memo="lnpay invoice" qr="" ansi=0 expiry="" json=0
   while [ $# -gt 0 ]; do
@@ -584,6 +611,8 @@ lnpay - send and receive Lightning payments via kubectl exec + lncli
 Commands:
   lnpay config                            show loaded config, without secrets
   lnpay node                              node sync status + spendable balance
+  lnpay newaddress [p2wkh|np2wkh|p2tr]    generate an onchain receive address
+        [--json]
   lnpay receive <sats> [--memo M]         create an invoice to receive sats
         [--qr PATH] [--ansi] [--expiry S] [--json]
   lnpay decode <bolt11|lightning:...>     show what an invoice will pay
@@ -618,6 +647,7 @@ cmd="${1:-}"; shift || true
 case "$cmd" in
   config) cmd_config "$@";;
   node) cmd_node "$@";;
+  newaddress) cmd_newaddress "$@";;
   receive) cmd_receive "$@";;
   decode) cmd_decode "$@";;
   decode-qr) cmd_decode_qr "$@";;


### PR DESCRIPTION
## Summary
Adds a `newaddress` subcommand to the `lnd-payments` skill's `lnpay` script so it can generate an on-chain bitcoin receive address from the lnd wallet. Previously the skill only covered Lightning (invoices, pay, track, watch) plus node status, so generating an on-chain address required hand-writing a raw `kubectl exec ... lncli newaddress`.

## Changes
- `scripts/lnpay`: new `cmd_newaddress` + dispatch + usage. Address type is an optional positional arg — `p2wkh` (default, native SegWit `bc1q…`), `np2wkh` (nested `3…`), `p2tr` (Taproot `bc1p…`). The type is validated and fails closed on anything else. `--json` passes through the raw `lncli newaddress` JSON.
- `SKILL.md`: frontmatter trigger now mentions onchain address generation; added a row to the CLI table and a new "On-chain addresses" section clarifying this funds the lnd on-chain wallet (not a Lightning invoice).
- `evals/evals.json`: added eval #6 for "generate an onchain address on our lnd".

## Test Plan
- [x] `bash -n scripts/lnpay` passes; `evals.json` parses.
- [x] Verified live against the configured lnd node: `p2wkh` → `bc1q…`, `p2tr` → `bc1p…`, `np2wkh` → `3…`, `--json` → raw JSON, invalid type exits non-zero with a clear message.