### PR TITLE
Make bead audit a default reviewer panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Use the plan-to-beads-transfer skill on docs/PLAN.md.
 
 Runs repeated bead-graph refinement rounds for coverage, deduplication,
 dependency repair, sizing, priority, and verification completeness until the
-graph converges.
+graph converges. For every non-trivial graph, normal completion runs the
+`second-model-bead-audit` reviewer panel before implementation; a failed or
+conditional audit feeds accepted findings back into another focused polish round.
 
 Claude Code:
 
@@ -121,16 +123,20 @@ Use the bead-polish-loop skill on the current bead graph.
 
 ### second-model-bead-audit
 
-Provides an independent audit of an existing bead graph against the plan, with
-blocking findings first and exact bead-level fixes when obvious. The second model
-is whichever CLI you are not currently running in — `codex exec` from a Claude
-session, `claude --model fable --effort high` from a Codex one — and the report
-names which model audited and whether it was independent or a self-audit.
+Provides the default final audit of a polished bead graph against the plan, with
+blocking findings first and exact bead-level fixes when obvious. It runs a
+read-only reviewer panel in parallel — Codex `gpt-5.6-sol` at `xhigh` plus Claude
+Fable at high effort — then merges findings as `BOTH`, `CODEX`, `FABLE`, or
+`CONFLICT` and reconciles them against the plan and graph. One unavailable
+reviewer produces a clearly labeled degraded audit; with neither external
+reviewer available, the audit is blocked rather than silently replaced by a
+self-review.
 
 Claude Code:
 
 ```text
 /second-model-bead-audit docs/PLAN.md
+/second-model-bead-audit docs/PLAN.md --reviewers fable  # explicitly pin one reviewer
 ```
 
 Codex:
@@ -313,19 +319,27 @@ directories created by `--migrate-existing`.
 - [Claude Code](https://claude.com/claude-code) for Claude installation targets
 - [OpenAI Codex CLI](https://github.com/openai/codex) for Codex installation targets
 - `codex` on `PATH` for the `multi-reviewer-loop` panel, the
+  `second-model-bead-audit` panel,
   `orchestrating-with-rb-lite` harden-until-clean panel, and the default
   `orchestrating-with-rb-lite` reviewer panel
 - `claude` on `PATH` for the Claude Fable reviewer in `multi-reviewer-loop`,
+  `second-model-bead-audit`,
   `orchestrating-with-rb-lite` harden-until-clean mode, and
   `pr-with-codex-bot-review`, and for the default `orchestrating-with-rb-lite`
   implementer cycle and reviewer panel.
-  Either review CLI alone runs the loops degraded — with both missing they stop
-- `jq` on `PATH` to unwrap the Claude reviewer's JSON in `multi-reviewer-loop`,
+  When both reviewers are requested, either CLI alone runs the loops degraded;
+  with both missing they stop. An explicitly pinned reviewer produces
+  `PINNED PANEL` when healthy and `BLOCKED` when it fails.
+- `jq` on `PATH` to build `second-model-bead-audit` graph snapshots and unwrap
+  Claude reviewer JSON in `multi-reviewer-loop`, `second-model-bead-audit`,
   `orchestrating-with-rb-lite`, and `pr-with-codex-bot-review`; Nix-wrapped
   rb-lite supplies its own for the default panel
-- `timeout` with `--kill-after` support for normal `orchestrating-with-rb-lite`
-  runs when using a source/path rb-lite install; Nix-wrapped rb-lite supplies
-  GNU coreutils
+- SHA-256 tooling (`sha256sum` or `shasum`) for
+  `second-model-bead-audit` snapshot integrity
+- GNU `timeout` with `--kill-after` support (named `timeout`, or `gtimeout` from
+  Homebrew coreutils) for `second-model-bead-audit` and normal
+  `orchestrating-with-rb-lite` runs when using a source/path rb-lite install;
+  Nix-wrapped rb-lite supplies GNU coreutils
 - `npx` plus Gemini credentials to enable the optional third default
   `orchestrating-with-rb-lite` reviewer
 - `rb-lite` on `PATH`, or `nix run --refresh github:douglaz/rb-lite -- ...`

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -2,17 +2,19 @@
 name: bead-polish-loop
 description: >-
   Refine an existing bead graph through repeated review-and-revise rounds until
-  it converges into launch-ready executable memory with strong coverage,
+  it converges into audit-ready executable memory with strong coverage,
   deduplication, dependency shape, sizing, priority, and verification detail.
   Use when beads already exist but feel vague, duplicated, over-broad,
   dependency-wrong, or under-tested; when a large transfer from a markdown plan
   just landed; when a plan revision likely introduced graph drift; or when the
   user asks to clean up, tighten, review, or launch-ready the beads. Do not use
   for first-draft planning, direct implementation, or repos that do not yet have
-  meaningful beads to inspect.
+  meaningful beads to inspect. Normal completion hands the converged graph to the
+  second-model-bead-audit reviewer panel before implementation.
 ---
 
-Polish the bead graph until it is launch-ready, not merely plausible.
+Polish the bead graph until it is ready for the independent launch gate, not
+merely plausible.
 
 ## Core invariants
 
@@ -20,10 +22,14 @@ Polish the bead graph until it is launch-ready, not merely plausible.
 - Preserve functionality and intent; do not oversimplify away features, constraints, or verification.
 - Optimize for fungible agents: clear beads, correct dependencies, and a healthy ready frontier for parallel work.
 - Stop on convergence, not on an arbitrary round count.
+- Treat convergence as readiness for the independent audit, not permission to skip it.
 
 ## Preflight
 
 - Confirm `br` and `bv` are on `PATH`. If either is missing, stop and say so.
+- Record whether `codex`, `claude`, and `jq` are available for the final reviewer
+  panel. Missing panel tools do not block polishing, but they determine whether
+  the eventual audit can be full, degraded, or blocked.
 - Re-read `AGENTS.md`, `README.md`, and the relevant plan/spec before editing the graph.
 - If there are no meaningful beads yet, redirect to `plan-to-beads-transfer`.
 - If polishing keeps surfacing architecture questions, step back into plan space instead of repeatedly fixing downstream symptoms.
@@ -50,6 +56,9 @@ Do not declare convergence before all of these are true:
 - every `P0` and `P1` bead was inspected at least once
 - every bead on the critical dependency path was inspected at least once
 - every important unresolved finding is either fixed or explicitly waived with a reason
+
+Convergence ends the polishing phase. It does not complete the bead lifecycle:
+run `second-model-bead-audit` by default after the graph meets these gates.
 
 ## Per-round workflow
 
@@ -154,7 +163,38 @@ Use these escalations:
 
 - step back into plan space when the graph keeps expanding because the plan is still undecided
 - restart in a fresh session when current assumptions feel sticky or compaction degraded context
-- hand the graph to `second-model-bead-audit` when you want an independent launch-readiness verdict
+- stop and ask for a decision when the graph exposes a real product or architecture ambiguity
+
+## Default reviewer-panel gate
+
+After convergence:
+
+1. Flush the final graph with `br sync --flush-only`.
+2. Invoke `second-model-bead-audit` with the source plan/spec path. Its default
+   Codex + Fable panel is read-only and must not receive this skill's findings
+   ledger or conclusions.
+3. Handle the verdict:
+   - unqualified `PASS`: polishing is complete; proceed to implementation.
+   - `PASS (DEGRADED)` or `PASS (PINNED PANEL)`: do not proceed automatically.
+     Rerun a healthy full panel, or obtain and record the user's explicit
+     acceptance of the reduced review coverage.
+   - `CONDITIONAL PASS`: add accepted conditions to the ledger, run a focused
+     polish round, and re-audit before any implementation starts.
+   - `FAIL`: reopen polishing, resolve blocking findings, and rerun the panel.
+4. Preserve the audit quality label. A qualified pass is not equivalent to a
+   healthy full-panel pass, and a blocked audit has no launch verdict.
+
+The panel gate is the default for every non-trivial graph, not merely
+launch-critical work. The user may explicitly opt out for tiny or low-risk work;
+record that the gate was skipped. Do not count panel audits toward the minimum
+polish-round budget, and do not let the read-only reviewers mutate beads.
+
+Bound an automatic polish/audit cycle to three panel runs. Stop sooner if the same
+material finding survives two genuine fix attempts, the graph changes while a
+panel is reading it, reviewer health is blocked, or a product/architecture choice
+is required. Report the remaining issue instead of recursively bouncing between
+skills forever. Any graph mutation after an audit invalidates that verdict and
+requires a new panel snapshot.
 
 ## Hard failure modes
 
@@ -167,6 +207,9 @@ Do not:
 - assume a large graph is complete because it is verbose
 - oversimplify and silently delete functionality or test obligations
 - stop after the first pass that merely feels decent
+- proceed directly to implementation after non-trivial polishing without running
+  or explicitly waiving the reviewer-panel gate
+- bias the audit by handing the panel this session's findings ledger
 
 ## Command palette
 
@@ -195,4 +238,6 @@ This is the second step in the bead lifecycle:
 2. `bead-polish-loop`
 3. `second-model-bead-audit`
 
-Before using this skill, beads should already exist. After convergence, recommend `second-model-bead-audit` for high-stakes launches, or proceed to implementation when the graph is genuinely clean.
+Before using this skill, beads should already exist. After convergence, run
+`second-model-bead-audit` as the normal final gate. Failed and conditional audits
+loop back here with their accepted findings, then return to the panel.

--- a/skills/bead-polish-loop/references/convergence-scorecard.md
+++ b/skills/bead-polish-loop/references/convergence-scorecard.md
@@ -88,11 +88,14 @@ score = 0.30 * coverage + 0.25 * findings + 0.25 * velocity + 0.20 * stability
 - `< 0.50`: not close; keep iterating
 - `0.50 - 0.74`: improving, but not launch-ready by convergence alone
 - `0.75 - 0.84`: close in some dimensions, but still below the stop threshold
-- `0.85 - 0.94`: usually good enough if the ledger is clear and the stop gates pass
-- `>= 0.95`: likely at diminishing returns
+- `0.85 - 0.94`: usually ready for the independent reviewer-panel handoff if the
+  ledger is clear and the stop gates pass
+- `>= 0.95`: likely at diminishing returns; hand off to the panel
 
 ## Interpretation notes
 
 - A high score does not excuse missing coverage, weak verification, or unresolved graph bottlenecks.
+- A high score is a polishing stop signal, not implementation approval. The
+  default `second-model-bead-audit` panel still owns the launch verdict.
 - If any critical findings ledger item remains open, cap the effective score at `0.74`.
 - Two consecutive rounds with scores above `0.85`, only corrective edits, and a clear findings ledger are a strong stop signal.

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -131,4 +131,6 @@ This is the first step in the bead lifecycle:
 2. `bead-polish-loop`
 3. `second-model-bead-audit`
 
-Recommend `bead-polish-loop` after almost every non-trivial transfer. For high-stakes or large graphs, recommend `second-model-bead-audit` before implementation.
+Run `bead-polish-loop` after almost every non-trivial transfer. Normal polish
+completion now includes the `second-model-bead-audit` reviewer-panel gate before
+implementation; do not reserve that audit only for high-stakes graphs.

--- a/skills/plan-to-beads-transfer/references/coverage-matrix-template.md
+++ b/skills/plan-to-beads-transfer/references/coverage-matrix-template.md
@@ -1,6 +1,7 @@
 # Plan-to-Beads Coverage Matrix Template
 
-Load this file during transfer audits and later polishing passes.
+Load this file during transfer audits, later polishing passes, and the final
+`second-model-bead-audit` reviewer-panel gate.
 
 Use a simple table or checklist like this while translating the plan:
 

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -1,180 +1,286 @@
 ---
 name: second-model-bead-audit
 description: >-
-  Audits a bead graph against the plan with an independent second opinion,
-  checking coverage gaps, duplicate ownership, weak descriptions, dependency
-  mistakes, and missing verification obligations before implementation starts.
-  Use when another agent already created or polished the beads and you want a
-  launch verdict with exact fixes, or when the user says "sanity check the
-  beads", "audit the graph", "give me a second opinion on these beads", "are
-  the beads ready to build?", or "review the bead graph before we start". Also
-  works as a self-audit when no second model is available. Prefer read-only
+  Runs the default final launch-readiness audit for a polished bead graph against
+  its plan. A read-only two-reviewer panel (Codex gpt-5.6-sol at xhigh plus Claude
+  Fable at high effort) independently checks coverage, ownership, bead quality,
+  dependencies, priority, verification, and operational obligations; the
+  orchestrator merges and reconciles their findings into one verdict. Use after
+  bead-polish-loop by default, or when the user asks to sanity-check, audit, get a
+  second opinion on, or approve beads before implementation. Prefer read-only
   review unless the user explicitly asks for bead edits.
-compatibility: Requires br and bv on PATH and a repo that uses .beads/. The
-  second model is whichever of `codex` / `claude` you are not currently running
-  in; either CLI on PATH enables a genuine cross-model audit, and the skill also
-  works as a self-audit without them.
+argument-hint: "[plan/spec path] [--reviewers codex|fable|codex,fable]"
+compatibility: >-
+  Requires br, bv, jq, SHA-256 tooling (sha256sum or shasum), and GNU timeout
+  (timeout or gtimeout) on PATH, plus a repo that uses .beads/. The full default
+  panel also requires authenticated codex and claude CLIs. One available reviewer
+  produces a DEGRADED audit; if no requested reviewer can run, the audit is
+  BLOCKED.
 ---
 
-Provide a second-model audit of the bead graph without inheriting the first
-model's blind spots.
+# second-model-bead-audit
 
-## Tool dependencies
+Give the polished bead graph a fresh, adversarial launch-readiness check before
+implementation starts.
 
-This skill requires `br` (beads_rust) and `bv` (bead viewer) on `PATH`.
-If either command is missing, stop and tell the user. If commands fail with
-unexpected errors, check whether the CLI version matches the expected subcommand
-signatures in the command palette below — flag version mismatches to the user
-rather than guessing at alternative syntax.
-
-## Who the second model is
-
-"Second model" means *a different model from the one that built the graph*, not
-merely a second pass. A model re-reading its own work inherits the assumptions
-that produced the gaps.
-
-Pick the auditor from **who built the graph**, not from which CLI you happen to
-be sitting in. Auditing a Claude-built graph with Claude is a self-audit even
-when a different session runs it.
-
-| Graph was built by | Auditor to invoke |
-|---|---|
-| Claude | `codex exec` (default `gpt-5.6-sol` at `model_reasoning_effort="xhigh"`) |
-| Codex | `claude -p "<audit prompt>" --model fable --effort high --output-format json` |
-| Unknown | Ask, or check the bead history (`br show <id> --json` actor fields). If it stays unknown, run the audit anyway and mark independence `UNKNOWN` |
-| The other CLI is unavailable | Self-audit — say so explicitly in the verdict |
-
-Concretely, from a Codex session:
-
-```bash
-set -o pipefail   # else jq's failure is masked and an empty audit reads as a thin one
-claude -p "$(cat /tmp/bead-audit-prompt.txt)" \
-  --model fable --effort high --output-format json \
-  --tools "Bash,Read,Glob,Grep" --allowedTools "Bash,Read,Glob,Grep" \
-  --disallowedTools "Edit,Write,NotebookEdit" \
-  | jq -er 'if .is_error then error(.result // "auditor returned is_error")
-            else (.result // empty) end'
-```
-
-A non-zero exit means the auditor never ran (auth, rate limit, overload) — fall
-back to a `SELF-AUDIT` and label it, rather than reporting a thin audit as an
-independent one. Keep `--disallowedTools`: this skill is read-only by default,
-and an auditor that edits beads has stopped being a second opinion.
-
-The audit prompt should carry the plan path, the `br`/`bv` commands from the
-command palette below, the audit categories, and the report template — the second
-model has none of this session's context, and that ignorance is exactly what you
-are buying.
-
-Two rules that keep this honest:
-
-- **Do not hand the second model your own conclusions.** Give it the plan and the
-  graph, not your assessment of them. An auditor shown the answer grades the
-  answer.
-- **Reconcile, don't rubber-stamp in reverse.** Its findings are hypotheses too.
-  Where it disagrees with you about the graph, go read the beads and the plan and
-  decide with citations — and record which of you was right in the report.
-
-A self-audit is still worth running when no second CLI is available. Label it
-`SELF-AUDIT` in the verdict so the user knows the independence claim is weaker.
+This is still called a second-model audit because at least one panel member should
+be independent of the model lineage that built and polished the graph. The default
+is now a panel, not one hand-picked alternate model: two independent reads expose
+both shared findings and useful disagreements, and avoid making graph authorship a
+prerequisite for choosing the reviewer.
 
 ## Default posture
 
-Stay in read-only audit mode unless the user explicitly asks you to apply fixes.
+- Run this audit after every non-trivial `bead-polish-loop`, not only for
+  high-stakes launches.
+- Keep the panel read-only. It reports exact fixes; `bead-polish-loop` owns normal
+  graph mutation.
+- Run both reviewers independently and in parallel. Never seed one with the
+  other's findings or with your own conclusions.
+- Treat panel findings as hypotheses to verify, not commands to obey.
+- Do not proceed to implementation on `FAIL` or `CONDITIONAL PASS`. Resolve and
+  re-audit every accepted condition first; any graph edit invalidates the old
+  verdict.
 
-## Use this skill when
+The user may explicitly opt out for a tiny or low-risk graph. Record the skipped
+gate rather than silently treating the polisher's own convergence judgment as an
+independent audit.
 
-- Claude or another agent already created/refined beads and the user wants Codex,
-  Claude Fable, or another model to review them
-- the project is important enough that a second-model check is worth the time
-- the graph feels plausible but you want an independent launch verdict
+## Inputs
 
-## Do not use this skill when
+Parse `--reviewers <list>` first. Valid values are `codex`, `fable`, and
+`codex,fable`; the default is both. A user-pinned one-reviewer audit is a
+`PINNED PANEL`, not an availability failure, but it still lacks full-panel
+agreement.
 
-- there is no real bead graph yet
-- the user wants implementation instead of review
-- the request is actually a planning task, not a bead audit
+The remaining argument is the plan/spec path. If it is absent, discover the
+relevant plan from the beads' spec refs and repo docs. Ask only when multiple
+plausible source plans would materially change the coverage audit.
+
+## Tool dependencies and panel health
+
+The graph audit itself requires `br`, `bv`, `jq`, SHA-256 tooling (`sha256sum` or
+`shasum`), and GNU `timeout` (`timeout` or `gtimeout`). If any is missing, stop
+and tell the user. If their commands fail unexpectedly, flag a likely CLI-version
+mismatch rather than inventing alternate syntax.
+
+The default panel is:
+
+| Reviewer | Invocation | Role |
+|---|---|---|
+| `codex` | `codex exec`, `gpt-5.6-sol`, `model_reasoning_effort="xhigh"`, read-only sandbox | Independent plan/graph audit with a custom rubric |
+| `fable` | `claude -p`, `--model fable --effort high`, read-only tool set | Independent plan/graph audit with the same rubric |
+
+`jq` is used to build the common graph snapshot and unwrap the Claude JSON result.
+
+- Both healthy: `FULL PANEL`.
+- One missing, unauthenticated, timed out, or unusable: continue with the survivor
+  and label the audit `DEGRADED`.
+- No requested external reviewer runs successfully: `BLOCKED`. Do not silently
+  replace the panel with the coordinating agent's self-review.
+- A user-pinned reviewer that runs successfully: `PINNED PANEL`.
+- Never turn an empty, truncated, ambiguous, or failed reviewer response into a
+  clean vote.
+
+Exact prompts, invocations, log layout, clean detection, and recovery rules live
+in [references/reviewer-panel.md](references/reviewer-panel.md). Read that file
+before launching the panel.
+
+## Independence from the graph
+
+Panel health and graph independence are different claims. Report both.
+
+Determine who built or substantially polished the graph from session context or
+`br show <id> --json` actor/history fields when practical. Do not delay the audit
+just to establish authorship.
+
+For each reviewer, label independence:
+
+- `INDEPENDENT`: a different model family from the graph's builder/polisher.
+- `BUILDER-LINEAGE`: the same model family; useful corroboration, but not the
+  second opinion.
+- `UNKNOWN`: graph authorship could not be established.
+
+With a Codex-built graph, Fable supplies the independent vote; with a Claude-built
+graph, Codex does. When authorship is mixed or unknown, the two-reviewer panel is
+still stronger than guessing which single auditor to invoke.
 
 ## Required outputs
 
-1. A launch verdict: fail, conditional pass, or pass.
-2. Which model performed the audit, and whether it was independent or a
-   `SELF-AUDIT`.
-3. A structured report with blocking findings first.
-4. Exact bead-level fixes or proposed `br` actions where possible.
-5. Clear distinction between hard blockers, important improvements, and optional nits.
-6. Any place the auditor and you disagreed, and the citation that settled it.
+1. Launch verdict: `FAIL`, `CONDITIONAL PASS`, or `PASS`; `NONE` when panel
+   health is `BLOCKED`.
+2. Audit quality: `FULL PANEL`, `DEGRADED`, `PINNED PANEL`, or `BLOCKED`.
+3. Panel roster, model settings, exit health, and independence labels.
+4. One merged report with blockers first and every finding tagged `BOTH`,
+   `CODEX`, `FABLE`, or `CONFLICT`.
+5. Exact bead-level fixes or proposed `br` actions where they are safe to state.
+6. Disagreements and contradictions, plus the plan section or bead evidence that
+   settled them.
+7. Paths to the raw reviewer outputs and merged report.
+
+A semantic `PASS` from a degraded or pinned audit must retain that quality label,
+for example `PASS (DEGRADED)`. Only a healthy full panel can produce an
+unqualified `PASS`. If no reviewer is `INDEPENDENT` from the known graph lineage,
+also append `NO INDEPENDENT VOTE` to any pass label. A blocked audit produces no
+launch verdict.
+
+Only an unqualified `PASS` clears the gate automatically. A qualified pass
+requires either a later healthy full-panel pass or the user's explicit,
+recorded acceptance of the reduced review coverage.
 
 ## Workflow
 
-1. Reread `AGENTS.md`, then read the relevant plan/spec and current bead graph.
-2. Ground in reality:
-   - `br list --limit 0 --json -a`
-   - `bv --robot-triage`
-   - `bv --robot-plan`
-   - `bv --robot-suggest`
-   - optionally `bv --robot-insights`, `bv --robot-priority`, and `br show <id> --json`
-3. Re-derive the judgment independently. Do not assume the existing graph is correct because another strong model made it.
-4. Audit the graph across these categories:
-   - plan coverage
-   - duplicate or overlapping ownership
-   - vague or under-specified beads
-   - dependency correctness and frontier health
-   - priority and sequencing fit
-   - verification obligations, including unit/integration/e2e and useful diagnostics where relevant
-   - user-visible and operator-visible risks that are still unowned
-5. Use the template in [references/review-report-template.md](references/review-report-template.md).
-6. If you are asked to apply fixes, mutate only the clearly justified ones with `br`, then flush with `br sync --flush-only`.
+### 1. Preflight and shared scope
 
-## Review standards
+1. Read `AGENTS.md`, `README.md`, the relevant plan/spec, and any graph-specific
+   guidance.
+2. Confirm the graph is meaningful and has already had a real polish pass. If it
+   is raw, redirect to `bead-polish-loop`; the final gate should not substitute for
+   routine cleanup.
+3. Confirm `br`, `bv`, the requested reviewer CLIs, and `jq` as applicable.
+4. Define the audit scope explicitly:
+   - authoritative plan/spec files, approved deltas, and recorded waivers
+   - plan-backed root beads/epics and their child/dependency closure
+   - the wider graph only for cross-scope dependencies and frontier health
 
-A good audit is not a rubber stamp. It should be willing to say:
+   Do not label unrelated backlog beads as unplanned merely because
+   `br list -a` includes them.
+5. Flush once, capture one shared baseline, and fingerprint it before launching
+   either reviewer:
 
-- the graph is missing work even though it looks large
-- two beads should merge even though their titles differ
-- one bead is overloaded and should split
-- the graph is not launch-ready because testing or failure-handling is still implicit
+   ```bash
+   br sync --flush-only
+   br list --limit 0 --json -a
+   bv --robot-triage
+   bv --robot-plan
+   bv --robot-suggest
+   ```
+
+   Add `bv --robot-insights`, `bv --robot-priority`, and targeted
+   `br show <id> --json` when useful.
+6. Create a unique audit directory and one neutral prompt containing the
+   snapshotted requirement and graph paths, audit scope, categories, severity
+   rules, and output contract. Do not include your conclusions or prior polish
+   findings.
+
+### 2. Run the panel
+
+Start Codex and Fable in parallel with the same prompt. Close stdin on both batch
+commands, persist stdout/stderr separately, and bound hangs when `timeout` is
+available.
+
+The panel audits:
+
+- plan-to-bead and bead-to-plan coverage
+- duplicate or overlapping ownership
+- vague, overloaded, undersized, or under-specified beads
+- dependency direction, cycles, bottlenecks, and ready-frontier health
+- priority and sequencing fit
+- unit, integration/e2e, acceptance, and regression obligations
+- logging, diagnostics, rollout, recovery, and operator-visible obligations
+- scope growth or beads with no plan backing
+
+Each reviewer must cite plan sections and bead IDs, propose bead-level remedies,
+and state `No findings.` explicitly when clean.
+
+Before parsing or merging findings, recompute the graph and requirement-source
+fingerprints. Any drift during the panel invalidates every vote: report
+`BLOCKED`, preserve the evidence, do not reset user state, and rerun only from a
+stable new snapshot. Also reject contradictory or truncated reviewer output as
+ambiguous rather than treating the presence of any finding tag as a usable audit.
+
+### 3. Merge and reconcile
+
+Merge on the underlying claim, not wording:
+
+- `BOTH`: both reviewers found the same issue.
+- `CODEX` / `FABLE`: only that reviewer found it.
+- `CONFLICT`: one asserts a problem and the other explicitly says the same graph
+  shape is correct.
+
+Agreement increases confidence and review order; it does not replace verification.
+Silence from the other reviewer is not counter-evidence. For every contradiction,
+read the cited plan and beads yourself, decide with citations, and record which
+reviewer was right.
+
+Reject a finding only with concrete plan, bead, or graph evidence. If a proposed
+fix adds work not required by the plan or a real delivery/verification risk,
+record it as out of scope rather than expanding the graph reflexively.
+
+Use [references/review-report-template.md](references/review-report-template.md)
+for the synthesis.
+
+### 4. Decide the verdict
+
+- `FAIL`: any blocking coverage, ownership, dependency, execution, or verification
+  defect remains.
+- `CONDITIONAL PASS`: no blocker, but one or more named important conditions must
+  be fixed before the intended launch shape is safe.
+- `PASS`: no blocking or important findings remain; optional nits may remain.
+
+Reviewer verdict votes are evidence, not a majority election. The orchestrator
+owns the final verdict and must explain any departure from either vote.
+
+### 5. Handoff and re-audit
+
+Normal mode is report-only:
+
+- `PASS`: proceed to implementation.
+- `CONDITIONAL PASS` or `FAIL`: send accepted findings into
+  `bead-polish-loop`'s ledger, fix them there, then rerun the full panel.
+
+If the user explicitly asks this skill to apply fixes, mutate only reconciled,
+clearly justified items with `br`, flush with `br sync --flush-only`, and rerun the
+panel before upgrading the verdict. Never let a reviewer edit the graph directly.
+
+Bound an automatic polish/audit cycle to three panel runs. Stop earlier when the
+same material finding survives two genuine fix attempts, the graph drifts during
+review, reviewer health is blocked, or an architecture/product decision is
+required. Surface the remaining issue instead of recursively invoking the two
+skills forever.
+
+Stop and ask for a product/architecture decision when a finding exposes ambiguity
+in the plan rather than a bead-quality defect.
 
 ## Command palette
 
 ```bash
 br list --limit 0 --json -a
 br show <id> --json
+br update <id> --description "..."
+br close <id> --reason "..."
+br dep add <issue> <depends-on>
+br dep remove <issue> <depends-on>
+br lint
 bv --robot-triage
 bv --robot-plan
 bv --robot-suggest
 bv --robot-insights
 bv --robot-priority
+br sync --flush-only
 ```
 
-## Common failure patterns to avoid
+## Failure patterns to avoid
 
-- praising the graph without independently checking plan coverage
-- nitpicking style while missing missing-work risks
-- collapsing all findings into one severity bucket
-- suggesting implementation changes when the graph itself is the problem
-- editing beads by default when the user asked for a review
+- choosing only the presumed alternate model when both reviewers are available
+- running reviewers sequentially or showing one the other's conclusions
+- giving reviewers the polish findings and creating an echo chamber
+- calling a one-reviewer, failed, empty, or ambiguous panel an unqualified pass
+- counting reviewer votes instead of reconciling claims against the plan and graph
+- dismissing a single-source finding because the other reviewer stayed silent
+- letting either reviewer mutate beads
+- nitpicking wording while missing absent work, dependency errors, or test gaps
+- expanding the graph for speculative hardening with no plan or delivery need
 
 ## Pipeline context
 
-This skill is the **final check** in the bead lifecycle:
+This is the default final gate in the bead lifecycle:
 
-1. **plan-to-beads-transfer** — create beads from a stable plan
-2. **bead-polish-loop** — refine the graph through iterative review rounds
-3. **second-model-bead-audit** (you are here) — independent launch-readiness verdict
+1. `plan-to-beads-transfer` — create executable memory from a stable plan.
+2. `bead-polish-loop` — iteratively refine the graph.
+3. `second-model-bead-audit` — run the read-only reviewer panel and issue the
+   launch verdict.
 
-Before using this skill, the graph should already have been through at least one
-round of polishing (via `bead-polish-loop` or manual review). Auditing a raw,
-unpolished transfer will produce a long list of issues that polishing would have
-caught — use `bead-polish-loop` first in that case.
-
-After the audit:
-- **Pass**: proceed to implementation.
-- **Conditional pass**: fix the noted conditions (often via a quick
-  `bead-polish-loop` round), then proceed.
-- **Fail**: return to `bead-polish-loop` to address blocking findings before
-  re-auditing.
-
-## Additional resources
-
-- For the report structure, see [references/review-report-template.md](references/review-report-template.md).
+The gate is part of normal completion, not an optional high-stakes add-on. A
+failed or conditional audit loops back to polishing and then through this gate
+again.

--- a/skills/second-model-bead-audit/references/review-report-template.md
+++ b/skills/second-model-bead-audit/references/review-report-template.md
@@ -1,60 +1,87 @@
-# Second-Model Bead Audit Report Template
+# Bead Audit Panel Report Template
 
-Load this file when writing the final review.
+Load this file when merging the panel's findings and writing the final verdict.
 
-```markdown
+````markdown
 # Bead Graph Audit
 
-## Auditor
-- Model: <e.g. claude fable (high effort) | codex gpt-5.6-sol (xhigh)>
-- Independence: INDEPENDENT (different model than built the graph) | SELF-AUDIT | UNKNOWN (graph authorship not determined)
+## Panel
+- Quality: FULL PANEL | DEGRADED | PINNED PANEL | BLOCKED
+- Codex: <model/effort> — <healthy | failed | unavailable | not requested> — <INDEPENDENT | BUILDER-LINEAGE | UNKNOWN>
+- Fable: <model/effort> — <healthy | failed | unavailable | not requested> — <INDEPENDENT | BUILDER-LINEAGE | UNKNOWN>
+- Graph authorship: <known model lineage or UNKNOWN>
+- Independent vote present: yes | no | unknown
+- Graph snapshot: <fingerprint>
+- Scope: <plan-backed bead roots/epics and dependency closure>
+- Degraded/blocked reason: <reason or none>
 
 ## Launch verdict
-- Fail / Conditional pass / Pass
-- One-sentence reason
+- FAIL | CONDITIONAL PASS | PASS | PASS (DEGRADED) | PASS (PINNED PANEL) |
+  PASS (<quality>, NO INDEPENDENT VOTE) | NONE (panel BLOCKED)
+- <one-sentence reason>
+- Reviewer votes: Codex=<vote or n/a>, Fable=<vote or n/a>
 
 ## Blocking findings
-- [B1] Finding
-  - Why it matters
-  - Affected bead IDs
-  - Recommended fix
+- [B1][BOTH | CODEX | FABLE | CONFLICT] <finding>
+  - Evidence: <plan section and bead IDs>
+  - Why it blocks:
+  - Recommended bead-level fix:
 
-## Important improvements
-- [I1] Finding
-  - Why it matters
-  - Affected bead IDs
-  - Recommended fix
+## Important conditions
+- [I1][BOTH | CODEX | FABLE | CONFLICT] <finding>
+  - Evidence: <plan section and bead IDs>
+  - Why it matters:
+  - Recommended bead-level fix:
 
 ## Optional nits
-- [N1] Finding
-  - Suggested cleanup
+- [N1][BOTH | CODEX | FABLE] <finding>
+  - Evidence:
+  - Suggested cleanup:
 
-## Coverage notes
-- Plan elements still weakly represented or missing
-- Any beads with no clear plan backing
+## Coverage and scope notes
+- Missing or weakly represented plan elements
+- Beads with no clear plan backing
 
-## Dependency notes
-- Incorrect, missing, or over-constraining dependencies
-- Bottlenecks, cycles, or frontier-shape issues
+## Dependency and frontier notes
+- Incorrect, missing, reversed, or over-constraining dependencies
+- Bottlenecks, cycles, or unhealthy ready-frontier shape
 
-## Verification notes
-- Missing or weak unit/integration/e2e obligations
-- Missing diagnostics or logging where they are needed
+## Verification and operations notes
+- Missing or weak unit/integration/e2e/acceptance obligations
+- Missing diagnostics, logging, rollout, or recovery obligations
 
-## Disagreements with the auditor
-- <auditor's claim> — upheld / overruled, per <bead id or plan section>
+## Reconciliation
+- <single-source or disputed claim> — upheld / rejected / reframed, per <plan section and bead IDs>
+- <direct contradiction> — Codex right / Fable right, per <plan section and bead IDs>
 
 ## Suggested br actions
 ```bash
-# exact commands when you can state them confidently
-```
+# exact commands only when they can be stated safely
 ```
 
-Drop the disagreements section on a self-audit; there is no second opinion to
-disagree with, and an empty heading implies independence you did not have.
+## Logs
+- Codex: <path>
+- Fable: <path>
+- Merged: <path>
+````
 
 ## Severity rules
 
-- Blocking = do not start implementation yet.
-- Important = should be fixed before a large swarm launch, but might not block a tiny scoped effort.
-- Nit = nice cleanup with low leverage.
+- **Blocking**: implementation or the intended launch shape should not start yet.
+- **Important condition**: fix and re-audit before implementation starts.
+- **Nit**: low-leverage cleanup that does not affect execution safety.
+
+## Merge rules
+
+- Merge duplicate claims and tag the result `BOTH`; do not count two phrasings as
+  two defects.
+- Keep a single-source finding unless concrete evidence disproves it. The other
+  reviewer's silence is not evidence.
+- Mark direct reviewer contradictions `CONFLICT` until the orchestrator settles
+  them from the plan and graph.
+- List rejected findings and the concrete counter-evidence; do not silently omit
+  them from the merged report.
+- Treat suggested `br` commands as untrusted prose until the orchestrator checks
+  the installed CLI syntax and shell quoting.
+- Drop empty sections, but never drop the panel quality, reviewer health,
+  independence, verdict, or logs.

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -1,0 +1,605 @@
+# Bead Audit Reviewer Panel
+
+Exact setup, prompt, invocations, and failure handling for the default read-only
+Codex + Claude Fable bead-audit panel. Load this before starting an audit.
+
+## Why a panel
+
+The graph may have been built by Codex, Claude, both, or an unknown agent. Running
+both reviewers removes authorship detection from reviewer selection and guarantees
+a cross-model read whenever the full panel is healthy. Shared findings raise
+confidence; disagreements identify assumptions the orchestrator must verify.
+
+Both reviewers receive the same custom prompt and inspect the same plan and graph
+snapshot. Unlike `multi-reviewer-loop`, this panel uses `codex exec`, not
+`codex review`, because the audit target is a plan and bead graph rather than a Git
+diff.
+
+## Audit directory
+
+Before running any block, set `PLAN_PATH` to the absolute authoritative plan/spec
+path and `AUDIT_SCOPE` to the plan-backed root beads/epics plus their
+child/dependency closure.
+
+```bash
+set -euo pipefail
+
+: "${PLAN_PATH:?Set PLAN_PATH to an absolute plan/spec path}"
+: "${AUDIT_SCOPE:?Set AUDIT_SCOPE before capture}"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+_PROJECT=$(basename "$REPO_ROOT")
+AUDIT_DIR=$(mktemp -d "/tmp/bead-audit-${_PROJECT}.XXXXXXXX")
+
+AUDIT_PROMPT_FILE="$AUDIT_DIR/audit-prompt.txt"
+CODEX_OUT="$AUDIT_DIR/codex.txt"
+CODEX_TRACE="$AUDIT_DIR/codex.trace.txt"
+CODEX_ERR="$AUDIT_DIR/codex.stderr.txt"
+FABLE_RAW="$AUDIT_DIR/fable.raw.json"
+FABLE_OUT="$AUDIT_DIR/fable.txt"
+FABLE_ERR="$AUDIT_DIR/fable.stderr.txt"
+MERGED_OUT="$AUDIT_DIR/merged.md"
+GRAPH_JSON="$AUDIT_DIR/graph.json"
+GRAPH_JSONL="$AUDIT_DIR/issues.jsonl"
+GRAPH_AFTER_JSONL="$AUDIT_DIR/issues.after.jsonl"
+TRIAGE_OUT="$AUDIT_DIR/triage.txt"
+PLAN_OUT="$AUDIT_DIR/plan.txt"
+SUGGEST_OUT="$AUDIT_DIR/suggest.txt"
+GRAPH_DEPS_JSON="$AUDIT_DIR/graph-dependencies.json"
+ISSUE_DIR="$AUDIT_DIR/issues"
+SOURCE_DIR="$AUDIT_DIR/sources"
+SOURCE_MANIFEST="$AUDIT_DIR/source-manifest.txt"
+SOURCE_STATE_BEFORE="$AUDIT_DIR/source-state.before.txt"
+SOURCE_STATE_AFTER="$AUDIT_DIR/source-state.after.txt"
+mkdir -p "$ISSUE_DIR" "$SOURCE_DIR"
+```
+
+Use a unique directory so retries never overwrite the evidence from a failed or
+ambiguous run.
+
+Run every shell block in this reference in the same Bash process. The initial
+`set -euo pipefail` is part of the safety contract: snapshot capture must stop on
+any failed `br`, `bv`, `jq`, copy, or fingerprint command.
+
+## Shared graph snapshot
+
+Flush before capture, prohibit graph mutations while the panel runs, and give both
+reviewers the same baseline files. First define `SOURCE_FILES` as a Bash array
+containing the authoritative plan/spec, `README.md`, `AGENTS.md` when present,
+approved deltas/waivers, and every linked document needed to interpret the plan.
+The panel must not discover requirement sources live.
+
+```bash
+fingerprint_file() {
+  local raw
+  if command -v sha256sum >/dev/null 2>&1; then
+    raw=$(sha256sum "$1") || return
+    printf '%s\n' "${raw%% *}"
+  elif command -v shasum >/dev/null 2>&1; then
+    raw=$(shasum -a 256 "$1") || return
+    printf '%s\n' "${raw%% *}"
+  else
+    echo "SHA-256 unavailable: install sha256sum or shasum" >&2
+    return 1
+  fi
+}
+
+# Add every authoritative/linked requirement file before capture, without
+# duplicates. Use add_source for approved deltas, waivers, and linked docs.
+SOURCE_FILES=()
+add_source() {
+  local candidate=$1 existing
+  for existing in "${SOURCE_FILES[@]}"; do
+    [ "$existing" != "$candidate" ] || return 0
+  done
+  SOURCE_FILES+=("$candidate")
+}
+add_source "$PLAN_PATH"
+[ ! -f "$REPO_ROOT/README.md" ] || add_source "$REPO_ROOT/README.md"
+# Extend before AGENTS discovery, for example:
+# add_source "$REPO_ROOT/docs/APPROVED-DELTA.md"
+# add_source "$REPO_ROOT/docs/ROLLOUT.md"
+
+# Include every AGENTS.md that governs a source: the file's directory, each
+# ancestor directory, and the repository root.
+governed_sources=("${SOURCE_FILES[@]}")
+for governed in "${governed_sources[@]}"; do
+  dir=$(dirname "$governed")
+  while [ "$dir" = "$REPO_ROOT" ] || [[ "$dir" == "$REPO_ROOT/"* ]]; do
+    [ ! -f "$dir/AGENTS.md" ] || add_source "$dir/AGENTS.md"
+    [ "$dir" != "$REPO_ROOT" ] || break
+    dir=$(dirname "$dir")
+  done
+done
+
+: >"$SOURCE_MANIFEST"
+: >"$SOURCE_STATE_BEFORE"
+source_n=0
+for src in "${SOURCE_FILES[@]}"; do
+  [ -f "$src" ] || {
+    echo "Missing audit source: $src" >&2
+    exit 1
+  }
+  source_n=$((source_n + 1))
+  copy="$SOURCE_DIR/$(printf '%03d' "$source_n")-$(basename "$src")"
+  cp "$src" "$copy"
+  copy_fp=$(fingerprint_file "$copy") || {
+    echo "Could not fingerprint source snapshot: $copy" >&2
+    exit 1
+  }
+  live_fp=$(fingerprint_file "$src") || {
+    echo "Could not fingerprint source: $src" >&2
+    exit 1
+  }
+  [ -n "$copy_fp" ] && [ "$copy_fp" = "$live_fp" ] || {
+    echo "Audit source changed while being snapshotted: $src" >&2
+    exit 1
+  }
+  printf '%s\t%s\n' "$src" "$copy" >>"$SOURCE_MANIFEST"
+  printf '%s\t%s\n' "$live_fp" "$src" >>"$SOURCE_STATE_BEFORE"
+done
+
+br sync --flush-only
+BEADS_JSONL=$(br where --json | jq -er '.jsonl_path')
+cp "$BEADS_JSONL" "$GRAPH_JSONL"
+GRAPH_FINGERPRINT=$(fingerprint_file "$GRAPH_JSONL") || {
+  echo "Could not fingerprint initial graph snapshot" >&2
+  exit 1
+}
+[ -n "$GRAPH_FINGERPRINT" ] || {
+  echo "Initial graph fingerprint is empty" >&2
+  exit 1
+}
+
+br list --limit 0 --json -a >"$GRAPH_JSON"
+bv --robot-triage >"$TRIAGE_OUT"
+bv --robot-plan >"$PLAN_OUT"
+bv --robot-suggest >"$SUGGEST_OUT"
+br graph --all --json >"$GRAPH_DEPS_JSON"
+
+if ISSUE_IDS=$(jq -er '(.issues // .)[] | .id' <"$GRAPH_JSON"); then
+  :
+else
+  echo "Could not extract issue IDs from graph snapshot" >&2
+  exit 1
+fi
+
+while IFS= read -r id; do
+  safe_id=$(printf '%s' "$id" | tr -c 'A-Za-z0-9._-' '_')
+  br show "$id" --json >"$ISSUE_DIR/$safe_id.json"
+done <<<"$ISSUE_IDS"
+
+br sync --flush-only
+CAPTURE_AFTER_JSONL="$AUDIT_DIR/issues.capture-after.jsonl"
+cp "$BEADS_JSONL" "$CAPTURE_AFTER_JSONL"
+CAPTURE_AFTER_FINGERPRINT=$(fingerprint_file "$CAPTURE_AFTER_JSONL") || {
+  echo "Could not fingerprint graph after capture" >&2
+  exit 1
+}
+[ -n "$CAPTURE_AFTER_FINGERPRINT" ] || {
+  echo "Post-capture graph fingerprint is empty" >&2
+  exit 1
+}
+[ "$GRAPH_FINGERPRINT" = "$CAPTURE_AFTER_FINGERPRINT" ] || {
+  echo "Graph changed while audit artifacts were being captured" >&2
+  exit 1
+}
+```
+
+Set `AUDIT_SCOPE` to the plan-backed root bead IDs/epics and their child/dependency
+closure. The full graph remains available for cross-scope dependency and frontier
+checks, but unrelated backlog is not a coverage defect.
+
+## Shared prompt
+
+Build the prompt in a file so both reviewers get byte-for-byte identical
+instructions and shell quoting cannot truncate the rubric.
+
+```bash
+{
+  printf 'Audit the bead graph in repository: %s\n' "$REPO_ROOT"
+  printf 'Source snapshot manifest: %s\n' "$SOURCE_MANIFEST"
+  printf 'Source snapshot directory: %s\n\n' "$SOURCE_DIR"
+  printf 'Audit scope: %s\n' "$AUDIT_SCOPE"
+  printf 'Graph fingerprint: %s\n' "$GRAPH_FINGERPRINT"
+  printf 'Shared graph JSON: %s\n' "$GRAPH_JSON"
+  printf 'Authoritative issues JSONL: %s\n' "$GRAPH_JSONL"
+  printf 'Shared triage output: %s\n' "$TRIAGE_OUT"
+  printf 'Shared plan output: %s\n' "$PLAN_OUT"
+  printf 'Shared suggest output: %s\n' "$SUGGEST_OUT"
+  printf 'Shared dependency graph: %s\n' "$GRAPH_DEPS_JSON"
+  printf 'Per-issue JSON directory: %s\n\n' "$ISSUE_DIR"
+  cat <<'EOF'
+This is the final read-only launch-readiness gate after bead polishing. Independently
+derive your judgment from the plan and graph. Do not trust or search for another
+reviewer's conclusions.
+
+First read the snapshotted AGENTS.md, README.md, source plan/spec, approved
+deltas/waivers, and linked docs listed in the source manifest. Treat those copies,
+not live repo versions, as authoritative.
+Use only the shared snapshot, dependency graph, and per-issue JSON files as the
+authoritative graph baseline. Do not run br or bv commands. Do not modify, create,
+or delete files.
+
+Audit both directions (plan -> beads and beads -> plan) and check:
+- missing plan workflows, constraints, failure/recovery paths, rollout, docs, or
+  operator obligations
+- duplicate or overlapping ownership and in-scope beads with no plan backing
+- vague, overloaded, undersized, or non-self-contained beads
+- dependency direction, missing edges, cycles, bottlenecks, and ready-frontier health
+- priority and sequencing
+- concrete unit, integration/e2e, acceptance, regression, logging, diagnostics,
+  observability, migration, and recovery obligations where relevant
+
+Do not invent requirements or recommend speculative hardening. Every finding must
+cite affected bead IDs and the supporting plan section (or explain that the bead
+has no plan backing). Verify graph claims from the shared files before asserting
+them.
+
+Output contract:
+1. First line: VERDICT: FAIL | CONDITIONAL PASS | PASS
+2. One-sentence rationale.
+3. Findings, one per item, beginning with exactly one of:
+     [BLOCKER] <claim>
+     [IMPORTANT] <claim>
+     [NIT] <claim>
+   Under each item include:
+     Evidence: <plan section + bead IDs>
+     Why: <concrete execution or launch risk>
+     Fix: <exact bead-level remedy; br command only when safe>
+4. End with all three exact headings:
+     COVERAGE: <short notes>
+     DEPENDENCIES: <short notes>
+     VERIFICATION: <short notes>
+
+FAIL means at least one blocker. CONDITIONAL PASS means no blocker but named
+important conditions remain. PASS means no blocker or important condition remains.
+If there are no findings, after the rationale output exactly: No findings.
+EOF
+} >"$AUDIT_PROMPT_FILE"
+```
+
+Do not append the polishing ledger, the orchestrator's assessment, or one
+reviewer's findings. Independence is lost if the prompt tells auditors what to
+find.
+
+## Run both reviewers in parallel
+
+Set `PANEL_REVIEWERS` from the parsed `--reviewers` value. The default is
+`codex,fable`; a pinned run starts only the requested block.
+
+```bash
+PANEL_REVIEWERS=${PANEL_REVIEWERS:-codex,fable}
+if command -v timeout >/dev/null 2>&1 &&
+   timeout --kill-after=1s 1s true >/dev/null 2>&1; then
+  TIMEOUT_BIN=$(command -v timeout)
+elif command -v gtimeout >/dev/null 2>&1 &&
+     gtimeout --kill-after=1s 1s true >/dev/null 2>&1; then
+  TIMEOUT_BIN=$(command -v gtimeout)
+else
+  echo "GNU timeout is required (timeout or gtimeout)" >&2
+  exit 1
+fi
+
+RUN_CODEX=false
+RUN_FABLE=false
+case "$PANEL_REVIEWERS" in
+  codex)       RUN_CODEX=true ;;
+  fable)       RUN_FABLE=true ;;
+  codex,fable) RUN_CODEX=true; RUN_FABLE=true ;;
+  *) echo "Invalid reviewer panel: $PANEL_REVIEWERS" >&2; exit 2 ;;
+esac
+
+if $RUN_CODEX; then
+  "$TIMEOUT_BIN" --kill-after=30s 900s codex exec \
+    -C "$REPO_ROOT" \
+    --sandbox read-only \
+    --ephemeral \
+    --ignore-user-config \
+    -c 'mcp_servers={}' \
+    -m gpt-5.6-sol \
+    -c 'model_reasoning_effort="xhigh"' \
+    --output-last-message "$CODEX_OUT" \
+    "$(cat "$AUDIT_PROMPT_FILE")" \
+    </dev/null >"$CODEX_TRACE" 2>"$CODEX_ERR" &
+  CODEX_PID=$!
+fi
+
+if $RUN_FABLE; then
+  (
+    cd "$REPO_ROOT"
+    "$TIMEOUT_BIN" --kill-after=30s 900s claude -p "$(cat "$AUDIT_PROMPT_FILE")" \
+      --model fable \
+      --effort high \
+      --output-format json \
+      --no-session-persistence \
+      --safe-mode \
+      --strict-mcp-config \
+      --mcp-config '{"mcpServers":{}}' \
+      --add-dir "$AUDIT_DIR" \
+      --tools "Read,Glob,Grep" \
+      --allowedTools "Read,Glob,Grep" \
+      --disallowedTools "Edit,Write,NotebookEdit" \
+      </dev/null
+  ) >"$FABLE_RAW" 2>"$FABLE_ERR" &
+  FABLE_PID=$!
+fi
+
+if $RUN_CODEX; then
+  if wait "$CODEX_PID"; then CODEX_RC=0; else CODEX_RC=$?; fi
+fi
+if $RUN_FABLE; then
+  if wait "$FABLE_PID"; then FABLE_RC=0; else FABLE_RC=$?; fi
+fi
+```
+
+Close stdin even though each command receives a prompt argument. These are
+non-interactive batch commands; an unexpected stdin read must get EOF rather than
+hang the audit.
+
+GNU `timeout` is mandatory so a hung reviewer cannot block the panel indefinitely.
+The snippet accepts GNU's usual `timeout` name or Homebrew coreutils' `gtimeout`.
+Exit 124 is a failed reviewer, never a clean one.
+
+The `if wait` form is deliberate: under `set -e`, a plain failing `wait` would
+abort before the other reviewer's status is collected.
+
+The Codex sandbox enforces read-only filesystem access; `--ignore-user-config`
+plus the empty `mcp_servers` override prevents configured MCP tools from bypassing
+it. Fable's safe/strict empty-MCP configuration and built-in tool allowlist expose
+only file inspection tools. `--add-dir "$AUDIT_DIR"` makes the snapshots readable
+when Claude restricts file access to declared working directories; the absence of
+write-capable tools keeps that added directory read-only in practice. The
+coordinator pre-captures every `br`/`bv` output the reviewers need. Do not add
+`Bash`, remove the MCP isolation flags, or use `--permission-mode acceptEdits`.
+
+## Unwrap and validate Fable
+
+Run this only when Fable was requested:
+
+```bash
+if jq -er 'if .is_error then error(.result // "fable auditor returned is_error")
+           else (.result // empty) end' <"$FABLE_RAW" >"$FABLE_OUT"; then
+  JQ_RC=0
+else
+  JQ_RC=$?
+fi
+```
+
+If unwrapping succeeded, inspect denied tool names and carry inspection denials
+into reviewer state:
+
+```bash
+FABLE_DENIALS=
+FABLE_INSPECTION_BLOCKED=false
+if [ "$JQ_RC" -eq 0 ]; then
+  if FABLE_DENIALS=$(jq -r '.permission_denials[]?.tool_name' <"$FABLE_RAW"); then
+    if printf '%s\n' "$FABLE_DENIALS" |
+       grep -qE '^(Read|Glob|Grep)$'; then
+      FABLE_INSPECTION_BLOCKED=true
+    fi
+  else
+    JQ_RC=$?
+  fi
+fi
+printf '%s\n' "$FABLE_DENIALS"
+```
+
+- Denied `Edit`, `Write`, or `NotebookEdit`: the read-only guard worked; note it,
+  but do not degrade the audit.
+- Denied `Read`, `Glob`, or `Grep`: the reviewer could not inspect what it
+  needed. Treat that reviewer as failed; the surviving one can only produce a
+  degraded panel result.
+
+Optionally confirm the actual model:
+
+```bash
+if [ "$JQ_RC" -eq 0 ]; then
+  jq -r '.modelUsage | keys[]' <"$FABLE_RAW" || true
+fi
+```
+
+## Healthy, findings, ambiguous, failed
+
+A reviewer is:
+
+- **Clean**: exit 0, non-empty output, a valid `VERDICT: PASS`, no finding tags,
+  and an explicit `No findings.` line.
+- **Findings present**: exit 0, non-empty output, one or more `[BLOCKER]`,
+  `[IMPORTANT]`, or `[NIT]` lines, all required closing headings, and a verdict
+  consistent with the highest finding severity.
+- **Ambiguous**: exit 0 but missing a valid verdict, or zero findings without the
+  explicit clean signal, or any verdict/severity/section contradiction. Rerun
+  once; do not count it as clean.
+- **Failed**: non-zero exit, timeout, Claude `is_error: true`, failed `jq`, empty
+  output, or denied inspection tools.
+
+Validate the complete contract, not only whether tags exist:
+
+```bash
+validate_audit_output() {
+  local file=$1 verdict rationale blockers important nits total closing
+  [ -s "$file" ] || return 1
+  verdict=$(sed -n '1s/^VERDICT: //p' "$file")
+  rationale=$(sed -n '2p' "$file")
+  [ -n "$rationale" ] || return 1
+  if printf '%s\n' "$rationale" |
+     grep -qE '^(\[(BLOCKER|IMPORTANT|NIT)\]|No findings\.|COVERAGE:|DEPENDENCIES:|VERIFICATION:)'; then
+    return 1
+  fi
+  blockers=$(grep -cE '^[[:space:]]*\[BLOCKER\]' "$file" || true)
+  important=$(grep -cE '^[[:space:]]*\[IMPORTANT\]' "$file" || true)
+  nits=$(grep -cE '^[[:space:]]*\[NIT\]' "$file" || true)
+  total=$((blockers + important + nits))
+
+  closing=$(tail -n 3 "$file")
+  printf '%s\n' "$closing" | sed -n '1p' | grep -q '^COVERAGE:' || return 1
+  printf '%s\n' "$closing" | sed -n '2p' | grep -q '^DEPENDENCIES:' || return 1
+  printf '%s\n' "$closing" | sed -n '3p' | grep -q '^VERIFICATION:' || return 1
+
+  # Every finding must carry all three support fields before the next finding.
+  awk '
+    function finish() {
+      if (in_item && !(have_evidence && have_why && have_fix)) exit 1
+    }
+    /^[[:space:]]*\[(BLOCKER|IMPORTANT|NIT)\]/ {
+      finish()
+      in_item=1
+      have_evidence=have_why=have_fix=0
+      next
+    }
+    in_item && /^[[:space:]]+Evidence:[[:space:]]*[^[:space:]]/ { have_evidence=1 }
+    in_item && /^[[:space:]]+Why:[[:space:]]*[^[:space:]]/ { have_why=1 }
+    in_item && /^[[:space:]]+Fix:[[:space:]]*[^[:space:]]/ { have_fix=1 }
+    END { finish() }
+  ' "$file" || return 1
+
+  if [ "$blockers" -gt 0 ]; then
+    [ "$verdict" = FAIL ] || return 1
+  elif [ "$important" -gt 0 ]; then
+    [ "$verdict" = "CONDITIONAL PASS" ] || return 1
+  else
+    [ "$verdict" = PASS ] || return 1
+  fi
+
+  if [ "$total" -eq 0 ]; then
+    grep -qx 'No findings\.' "$file" || return 1
+  else
+    ! grep -qx 'No findings\.' "$file" || return 1
+  fi
+}
+
+if $RUN_CODEX && [ "$CODEX_RC" -eq 0 ]; then
+  if validate_audit_output "$CODEX_OUT"; then
+    CODEX_STATE=usable
+  else
+    CODEX_STATE=ambiguous
+  fi
+elif $RUN_CODEX; then
+  CODEX_STATE=failed
+fi
+if $RUN_FABLE && [ "$FABLE_RC" -eq 0 ] && [ "$JQ_RC" -eq 0 ] &&
+   ! $FABLE_INSPECTION_BLOCKED; then
+  if validate_audit_output "$FABLE_OUT"; then
+    FABLE_STATE=usable
+  else
+    FABLE_STATE=ambiguous
+  fi
+elif $RUN_FABLE && $FABLE_INSPECTION_BLOCKED; then
+  FABLE_STATE=failed
+elif $RUN_FABLE; then
+  FABLE_STATE=failed
+fi
+```
+
+## Detect graph drift
+
+After both reviewers finish:
+
+```bash
+PANEL_INVALID=false
+
+br sync --flush-only
+cp "$BEADS_JSONL" "$GRAPH_AFTER_JSONL"
+GRAPH_AFTER_FINGERPRINT=$(fingerprint_file "$GRAPH_AFTER_JSONL") || {
+  echo "Could not fingerprint graph after audit" >&2
+  exit 1
+}
+[ -n "$GRAPH_AFTER_FINGERPRINT" ] || {
+  echo "Post-audit graph fingerprint is empty" >&2
+  exit 1
+}
+if [ "$GRAPH_FINGERPRINT" != "$GRAPH_AFTER_FINGERPRINT" ]; then
+  printf 'Graph changed during audit: before=%s after=%s\n' \
+    "$GRAPH_FINGERPRINT" "$GRAPH_AFTER_FINGERPRINT" >&2
+  PANEL_INVALID=true
+fi
+
+: >"$SOURCE_STATE_AFTER"
+for src in "${SOURCE_FILES[@]}"; do
+  [ -f "$src" ] || {
+    echo "Audit source disappeared during panel: $src" >&2
+    PANEL_INVALID=true
+    continue
+  }
+  if source_fp=$(fingerprint_file "$src") && [ -n "$source_fp" ]; then
+    printf '%s\t%s\n' "$source_fp" "$src" >>"$SOURCE_STATE_AFTER"
+  else
+    echo "Could not fingerprint audit source after panel: $src" >&2
+    PANEL_INVALID=true
+  fi
+done
+if ! cmp -s "$SOURCE_STATE_BEFORE" "$SOURCE_STATE_AFTER"; then
+  echo "One or more requirement sources changed during audit" >&2
+  PANEL_INVALID=true
+fi
+
+if $PANEL_INVALID; then
+  echo "Audit BLOCKED: snapshot drift invalidated every reviewer vote" >&2
+  # Preserve all evidence. Do not reset or overwrite user changes.
+  exit 1
+fi
+```
+
+Any graph or requirement-source mismatch invalidates the panel because the votes
+no longer describe current source truth. Its audit quality is `BLOCKED` and it has
+no launch verdict. Preserve logs, establish who or what changed when possible,
+and rerun only after capturing a stable new baseline.
+
+## Recovery
+
+| Symptom | Action |
+|---|---|
+| Codex model unavailable | Retry once without `-m gpt-5.6-sol`; record the environment-default fallback. |
+| Codex auth/non-zero error | Surface stderr; continue `DEGRADED` with Fable. |
+| Claude `is_error`, rate limit, overload, or auth error | Retry once; then continue `DEGRADED` with Codex. |
+| Output ambiguous | Reread the prompt file and rerun that reviewer once. A second ambiguity is a reviewer failure. |
+| Reviewer timeout | Ignore partial output and mark that reviewer failed. |
+| Graph or source snapshot drifts | Invalidate every vote and report `BLOCKED`; never synthesize a verdict from stale evidence. |
+| All requested reviewers fail or are absent | Report `BLOCKED` with no launch verdict; preserve every failure reason. |
+
+A user-pinned one-reviewer run is `PINNED PANEL` if healthy. It becomes
+`BLOCKED` if the requested reviewer fails; do not silently substitute a reviewer
+the user excluded.
+
+## Merge
+
+Merge duplicate claims into one finding and tag source:
+
+```markdown
+| # | Severity | Source | Claim | Evidence | Disposition |
+|---|---|---|---|---|---|
+| 1 | BLOCKER | BOTH | Recovery workflow is unowned | Plan §4; bd-12, bd-18 | UPHELD |
+| 2 | IMPORTANT | FABLE | bd-31 has no executable acceptance signal | Plan §7; bd-31 | UPHELD |
+| 3 | NIT | CODEX | Two tiny docs beads could merge | Plan §9; bd-42, bd-43 | REJECTED |
+| 4 | IMPORTANT | CONFLICT | Whether rollout blocks the API epic | Plan §8; bd-7, bd-20 | RESOLVED: CODEX |
+```
+
+`BOTH` is a confidence and ordering signal, not automatic truth. A single-source
+finding keeps its severity until evidence changes it. Silence is not
+counter-evidence. Resolve `CONFLICT` from the plan and graph, with citations.
+
+Write the complete reconciled report from
+[review-report-template.md](review-report-template.md) to `"$MERGED_OUT"` before
+publishing stable names. Artifact preservation is part of audit completeness and
+must fail closed:
+
+```bash
+[ -s "$MERGED_OUT" ] || {
+  echo "Audit BLOCKED: merged report was not created" >&2
+  exit 1
+}
+grep -q '^# Bead Graph Audit$' "$MERGED_OUT"
+grep -q '^## Panel$' "$MERGED_OUT"
+grep -q '^## Launch verdict$' "$MERGED_OUT"
+grep -q '^## Logs$' "$MERGED_OUT"
+
+if $RUN_CODEX && [ "${CODEX_STATE:-failed}" = usable ]; then
+  [ -s "$CODEX_OUT" ]
+  cp "$CODEX_OUT" "$AUDIT_DIR/audit.codex.txt"
+fi
+if $RUN_FABLE && [ "${FABLE_STATE:-failed}" = usable ]; then
+  [ -s "$FABLE_OUT" ]
+  cp "$FABLE_OUT" "$AUDIT_DIR/audit.fable.txt"
+fi
+cp "$MERGED_OUT" "$AUDIT_DIR/audit.merged.md"
+```


### PR DESCRIPTION
## Summary

Make the bead audit the default final gate after non-trivial bead polishing and replace the single alternate-model audit with a parallel Codex + Claude Fable reviewer panel.

The panel now snapshots the bead graph and authoritative requirement sources, runs both reviewers independently under read-only/MCP-isolated configurations, validates their output contract, merges findings by source, and blocks stale or incomplete verdicts.

## Details

- route normal `bead-polish-loop` completion through `second-model-bead-audit`
- loop failed or conditional audits back through focused polishing and re-audit
- add full/degraded/pinned/blocked panel semantics and per-reviewer lineage labels
- add exact panel setup, invocation, recovery, merge, and drift-detection guidance
- update report templates, convergence guidance, lifecycle docs, README, and prerequisites

## Trade-offs accepted

- keep the `second-model-bead-audit` name for compatibility even though its default is now a two-reviewer panel
- require `jq` for deterministic graph snapshot preparation
- block rather than silently substitute a self-audit when no requested reviewer can run
- bound automatic polish/audit cycling to three panel runs

## Test plan

- [x] `git diff --check`
- [x] parse all skill frontmatter and verify skill-name/directory agreement
- [x] verify local Markdown links from every `SKILL.md`
- [x] smoke-test graph/source snapshot capture and drift fingerprints against a copied `.beads` workspace
- [x] smoke-test reviewer output validation for clean, blocking, truncated, and contradictory reports
- [x] exercise the documented Codex read-only/MCP-isolated invocation
- [x] exercise the documented Fable safe-mode/strict-MCP invocation
- [x] local Fable review findings addressed
- [x] final independent P1-only review clean

## Review note

A separate `codex review --uncommitted` validation run timed out because a configured compound-review plugin remained in its internal peer-job wait. Its partial findings were preserved and addressed. The new panel's documented Codex invocation uses `--ignore-user-config` and an empty MCP configuration; that exact invocation completed successfully in a smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated bead polishing guidance to require an independent launch-readiness audit before implementation.
  - Added a two-reviewer audit process with parallel review, finding reconciliation, health checks, and clear verdicts.
  - Documented degraded, pinned, blocked, and re-audit workflows.
  - Expanded guidance for tracking review evidence, detecting changes after review, and preserving quality labels.
  - Updated transfer and convergence documentation to incorporate the audit gate into standard workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->