### PR TITLE
multi-reviewer-loop: delegate the edit to a fresh implementer (§ 3a)

### DIFF
--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -513,6 +513,10 @@ the end of the loop.
 
 Otherwise:
 
+0. **Consider delegating the EDIT to a fresh implementer — see § 3a.** You still
+   decide what is real; you do not have to be the one who types the fix. On a long
+   loop this is usually the higher-leverage split.
+
 1. Work the merged list, not two separate lists. Group related findings before
    editing and prefer fixing the root cause once over patching each comment
    independently — including when the two reviewers describe the same root cause
@@ -674,6 +678,39 @@ Otherwise:
    - <claim> — codex right / fable right, per <file:line>
    Validation: <command/result or "no targeted verifier found">
    ```
+
+### 3a. Delegating the edit
+
+**The agent that wrote the text is the worst available editor of it.** After a few
+passes you stop reading what is on the page and start reading what you meant. Measured
+on one long documentation loop: the orchestrator fixing its own artifact introduced
+roughly one to two *new* defects per fixing pass across eleven passes — the same claim
+corrected in one file and left standing in its twin (ten times), replacements spliced
+into the middle of a sentence without re-reading (breaking a list and duplicating a
+clause), and absolutes that outran the code. Handed the same kind of findings, a fresh
+implementer applied five of them with zero self-inflicted defects and proactively swept
+eight sibling occurrences the orchestrator had not been asked about.
+
+Treat that as one trial, not a law — by then the artifact was already much cleaner and
+the findings were unusually well specified. The mechanism is probably **freshness plus a
+written finding list**, not the particular model: delegating forces you to state each
+finding precisely enough for someone else to act on, which by itself kills the vague ones.
+
+**The split that works:**
+
+- **You adjudicate.** Verify each finding against source first. Never hand over a finding
+  you have not checked — you would be outsourcing the judgment, not the typing.
+- **The implementer edits**, in a fresh context, with a prompt that carries: verify before
+  fixing (findings are hypotheses, and one may be wrong); after each fix sweep the whole
+  artifact for the same claim **by concept, not by phrase**; read back every passage you
+  splice into; add no new mechanism; plus your environment and scope guards.
+- **You keep anything the implementer cannot safely touch** — a tool-managed database, a
+  ticket tracker, anything where hand-editing the file corrupts it. Say so explicitly in
+  the prompt and expect those findings back.
+- **Snapshot first.** The implementer has write access; `git` is the undo.
+
+This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
+hands over *only the edit* for findings you have already verified.
 
 ### 4. Stop conditions
 
@@ -929,7 +966,9 @@ deferred, or disproven with evidence?"
 
 ## Guardrails
 
-- Fix issues yourself; do not turn this into a report-only workflow.
+- Never turn this into a report-only workflow: every finding ends as fixed, deferred, or
+  disproven. You may delegate the EDITING (§ 3a) — that is not report-only — but the
+  adjudication stays yours.
 - Run the reviewers independently and in parallel. Never show one reviewer the
   other's findings — correlated reviewers are one reviewer.
 - Keep chat concise; the logs hold the full reviewer output.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -733,19 +733,29 @@ finding precisely enough for someone else to act on, which by itself kills the v
   § 1.6 explicitly permits running on a dirty tree, so plain `git` is *not* your undo:
   `git checkout .`, `git stash`, and `git reset --hard` would each discard the user's
   pre-existing unstaged work along with the delegated edit, which § 1.6 forbids. Capture
-  the tree as a patch first, and confirm the capture is non-empty **before** granting
-  write access — a snapshot you never verified is not a rollback plan:
+  the tree first, **in two layers**, and check that the capture *commands* succeeded
+  before granting write access:
 
   ```bash
-  SNAP="$REVIEW_DIR/pre-delegation.patch"
-  git diff HEAD >"$SNAP"                                  # tracked: staged + unstaged
-  git status --porcelain >"$REVIEW_DIR/pre-delegation.status"
+  git diff --cached >"$REVIEW_DIR/pre-delegation.staged.patch"   || { echo "snapshot failed"; exit 1; }
+  git diff         >"$REVIEW_DIR/pre-delegation.unstaged.patch" || { echo "snapshot failed"; exit 1; }
+  git status --porcelain >"$REVIEW_DIR/pre-delegation.status"    || { echo "snapshot failed"; exit 1; }
   ```
 
-  To roll back, revert only the paths you delegated and re-apply that patch's hunks for
-  them; leave every other path alone. `git diff HEAD` does not capture **untracked**
-  files, so copy any that matter into `$REVIEW_DIR` first or accept that they are outside
-  the snapshot — and say which you did.
+  **Two patches, not one.** A single `git diff HEAD` flattens staged and unstaged into one
+  HEAD-to-worktree delta, so restoring a path that was `MM` brings it back as ` M` — the
+  user's staging selection is gone, and a later `git commit` then carries hunks they had
+  deliberately left out.
+
+  **Empty is a legitimate snapshot.** On a clean tree — the ordinary PR-review case — both
+  patches are empty because the branch's commits are already recoverable from git. Require
+  the commands to *succeed*, never the patches to be non-empty; a non-empty check would
+  refuse to delegate on exactly the tidiest repositories.
+
+  To roll back, revert only the paths you delegated and re-apply each layer's hunks for
+  those paths — staged first, then unstaged — and leave every other path alone. Neither
+  diff captures **untracked** files, so copy any that matter into `$REVIEW_DIR` first, or
+  accept that they sit outside the snapshot and say which you did.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
 hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -745,12 +745,14 @@ finding precisely enough for someone else to act on, which by itself kills the v
     || { echo "snapshot failed"; exit 1; }
   # Every pre-existing UNTRACKED path in the delegated scope, copied — neither patch can
   # restore one, so without this the "non-destructive" guarantee is simply false for them.
-  # mkdir FIRST: `cp --parents` requires an existing destination and otherwise fails with
-  # "with --parents, the destination must be a directory" — which, guarded like this, would
-  # block every delegation that has an untracked path in scope.
-  mkdir -p "$REVIEW_DIR/untracked" || { echo "snapshot failed"; exit 1; }
-  cp -a --parents <each pre-existing untracked path in scope> "$REVIEW_DIR/untracked/" \
-    || { echo "snapshot failed"; exit 1; }
+  # Portable, and one path at a time. `cp --parents` is GNU-only — BSD/macOS `cp` rejects
+  # it outright, and this skill supports macOS explicitly (the `gtimeout` fallback exists
+  # for it) — so the GNU form would make every delegation with an untracked path exit
+  # `snapshot failed` there. `cp -pR` is portable; the parent dirs are built by hand.
+  for f in <each pre-existing untracked path in scope>; do
+    mkdir -p "$REVIEW_DIR/untracked/$(dirname "$f")" || { echo "snapshot failed"; exit 1; }
+    cp -pR "$f" "$REVIEW_DIR/untracked/$f"           || { echo "snapshot failed"; exit 1; }
+  done
   ```
 
   **Refuse the paths this snapshot cannot represent.** Two tree states survive neither
@@ -800,7 +802,19 @@ finding precisely enough for someone else to act on, which by itself kills the v
   refuse to delegate on exactly the tidiest repositories.
 
   To roll back, revert only the paths you delegated and re-apply each layer's hunks for
-  those paths — staged first, then unstaged — and leave every other path alone.
+  those paths — staged first, then unstaged — and leave every other path alone. **Then
+  restore the untracked backups**, which no patch and no `git restore` touches:
+
+  ```bash
+  for f in <each untracked path you delegated>; do
+    mkdir -p "$(dirname "$f")" && cp -pR "$REVIEW_DIR/untracked/$f" "$f" \
+      || { echo "could not restore $f — its bytes are in $REVIEW_DIR/untracked"; exit 1; }
+  done
+  ```
+
+  Taking the backup and never copying it back is the failure worth naming: the bytes
+  survive in the review directory, the rollback reports success, and the user's file is
+  still damaged.
 
   **Then restore intent-to-add from the status file.** § 1.5 runs `git add -N` on untracked
   source files so codex can see them; such a file has an empty staged patch and its whole

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -730,147 +730,48 @@ finding precisely enough for someone else to act on, which by itself kills the v
   the same work with one rule — *use the CLI, never edit the file* — landed clean and the
   database still parsed. Name the tool, forbid the file, and require a read-back.
 - **Snapshot first — and non-destructively.** The implementer has write access, and
-  § 1.6 explicitly permits running on a dirty tree, so plain `git` is *not* your undo:
-  `git checkout .`, `git stash`, and `git reset --hard` would each discard the user's
-  pre-existing unstaged work along with the delegated edit, which § 1.6 forbids. Capture
-  the tree first, **in two layers**, and check that the capture *commands* succeeded
-  before granting write access:
+  § 1.6 explicitly permits a dirty tree, so plain `git` is *not* your undo: `git checkout
+  .`, `git stash` and `git reset --hard` each discard the user's pre-existing work along
+  with the delegated edit, which § 1.6 forbids.
 
-  ```bash
-  git diff --cached --binary --no-textconv >"$REVIEW_DIR/pre-delegation.staged.patch" \
-    || { echo "snapshot failed"; exit 1; }
-  git diff          --binary --no-textconv >"$REVIEW_DIR/pre-delegation.unstaged.patch" \
-    || { echo "snapshot failed"; exit 1; }
-  git status --porcelain -z >"$REVIEW_DIR/pre-delegation.status" \
-    || { echo "snapshot failed"; exit 1; }
-  # Every pre-existing UNTRACKED path in the delegated scope, copied — neither patch can
-  # restore one, so without this the "non-destructive" guarantee is simply false for them.
-  # Portable, and one path at a time. `cp --parents` is GNU-only — BSD/macOS `cp` rejects
-  # it outright, and this skill supports macOS explicitly (the `gtimeout` fallback exists
-  # for it) — so the GNU form would make every delegation with an untracked path exit
-  # `snapshot failed` there. `cp -pR` is portable; the parent dirs are built by hand.
-  for f in <each pre-existing untracked path in scope>; do
-    # Clear the destination first, for the same reason the restore does: on a second
-    # delegation of the same path, `cp -pR` treats the existing backup as a target
-    # DIRECTORY and nests inside it, so the rollback later restores the stale outer copy.
-    rm -rf -- "$REVIEW_DIR/untracked/$f"
-    mkdir -p "$REVIEW_DIR/untracked/$(dirname "$f")" || { echo "snapshot failed"; exit 1; }
-    cp -pR "$f" "$REVIEW_DIR/untracked/$f"           || { echo "snapshot failed"; exit 1; }
-  done
-  ```
+  Capture **three** things before granting access, and require the capture *commands* to
+  succeed — never their output to be non-empty, since on a clean tree an empty patch is
+  the correct answer:
 
-  **Refuse the paths this snapshot cannot represent.** The capture is exactly three things:
-  a staged diff, an unstaged diff, and a byte copy of untracked files. Any tree state that
-  does not round-trip through those is **out of scope for delegation** — take the path out
-  and say you did. That is the rule; the list below is the cases known to hit it, not a
-  boundary that ends there. Growing the capture to cover each new one is a road that ends
-  at `git stash`, and `git stash` does not work here (below).
+  - `git diff --cached --binary --no-textconv` and `git diff --binary --no-textconv`,
+    as **two** patches. One combined `git diff HEAD` flattens the layers, so an `MM` path
+    comes back ` M` and a later commit carries hunks the user left out. Both flags matter:
+    without `--binary` a modified binary records only "Binary files differ" and will not
+    apply; `--no-textconv` because the conversion is not what is on disk.
+  - `git status --porcelain -z`, NUL-delimited. Porcelain quotes paths that need it, so a
+    `cut`-based parse hands back a literal `"caf\303\251.py"` that does not exist. This
+    is also what restores **intent-to-add** entries (` A `) afterwards: § 1.5's `git add
+    -N` runs only before the first pass, so a file demoted to `??` during a rollback drops
+    out of every later `codex review --base`.
+  - a **byte copy of every pre-existing untracked path in scope** — no patch contains
+    them. Clear each destination before copying and again before restoring: `cp -pR` into
+    an existing directory nests rather than replaces, and exits 0 either way.
 
-  - **Unmerged paths** (`UU`, `AA`, …). `git diff --cached` exits 0 emitting only
-    `* Unmerged path …`, and the unstaged diff carries at most the combined working-tree
-    content — the stage-1/2/3 index entries are gone, so replaying cannot rebuild the
-    conflict. Do not delegate a path mid-merge.
-  - **Contents inside a dirty submodule.** The top-level diffs record the gitlink's
-    `-dirty` marker, not the modified bytes, so restoring the gitlink does not restore the
-    user's edit inside it.
-  - **Paths with ANY byte-transforming `.gitattributes` entry** — `filter`, `text`, `eol`,
-    `working-tree-encoding`. `--no-textconv` bypasses none of them: `git diff` snapshots
-    the *converted* representation, so what replays is not what was there. Measured — a
-    clean filter dropping `LOCAL:` lines produced a zero-byte unstaged patch on a file
-    `git status` called modified, and a mixed CRLF/LF file came back entirely CRLF from a
-    patch that applied without error. Use `git check-attr --all -- <path>` and read the
-    whole list; checking `filter` alone was the first version of this rule and it missed
-    the other three.
-  - **Files marked `assume-unchanged`.** Worst of the set, because all three captures
-    *succeed* while recording nothing: git has been told the file is not changing, so the
-    diffs are empty and porcelain is silent — and the revert then replaces the user's
-    bytes with `HEAD`. A silent total loss with no failing command anywhere. `git ls-files
-    -v` flags them with a lowercase status letter.
-  - **Either endpoint of a staged rename.** Porcelain `-z` emits both paths; reverting only
-    the destination leaves the source staged as deleted and the replay then fails, because
-    the source no longer exists in the index. The two endpoints are one unit — delegate
-    both or neither.
+  **Refuse the paths this cannot represent.** The capture is a staged diff, an unstaged
+  diff and a byte copy; any state that does not round-trip through those three is out of
+  scope for delegation — take the path out and say so. Known cases: unmerged paths,
+  contents inside a dirty submodule, anything with a byte-transforming `.gitattributes`
+  entry (`git check-attr --all` — `filter`, `text`, `eol`, `working-tree-encoding`), and
+  files marked `assume-unchanged`, where all three captures *succeed while recording
+  nothing* and the revert then replaces the bytes with `HEAD`. That list is the cases
+  known to hit the rule, not the boundary.
 
-  `git status --porcelain` names both. Take them out of the delegated scope and say you
-  did — a snapshot that silently cannot restore a path is worse than one that refuses it.
-
-  **And no, `git stash create` cannot replace this.** It is the obvious simplification —
-  one command, and git's own code handles binaries, textconv, index stages and submodules
-  correctly — but it *fails outright* on the tree this skill's own preflight builds:
+  **`git stash create` cannot replace any of this**, though it handles every case above
+  correctly. It fails on the tree § 1.5 builds:
 
   ```console
   $ git stash create
   error: Entry 'café.py' not uptodate. Cannot merge.
-  Cannot save the current worktree state
   ```
 
-  § 1.5 runs `git add -N` on untracked source files so codex can see them, and `stash`
-  refuses an intent-to-add entry. So the two-patch capture is not a hand-rolled version of
-  something git already does; it is what is left once the mandatory preflight rules the
-  built-in out. Anyone proposing the swap should reproduce the error above first.
-
-  **Two patches, not one.** A single `git diff HEAD` flattens staged and unstaged into one
-  HEAD-to-worktree delta, so restoring a path that was `MM` brings it back as ` M` — the
-  user's staging selection is gone, and a later `git commit` then carries hunks they had
-  deliberately left out.
-
-  **`--binary --no-textconv` on both.** Without `--binary` a modified binary records only
-  `Binary files a/x and b/x differ` — a patch with no payload, which `git apply` then
-  refuses (measured: *"cannot apply binary patch to 'blob.bin' without full index line"*).
-  And `--binary` does not switch off a configured `textconv` diff driver, which emits
-  *transformed* text that will not apply against the raw file either. Both flags, or the
-  revert is one-way for exactly the files you cannot retype.
-
-  **Empty is a legitimate snapshot.** On a clean tree — the ordinary PR-review case — both
-  patches are empty because the branch's commits are already recoverable from git. Require
-  the commands to *succeed*, never the patches to be non-empty; a non-empty check would
-  refuse to delegate on exactly the tidiest repositories.
-
-  To roll back, revert only the paths you delegated and re-apply each layer's hunks for
-  those paths — staged first, then unstaged — and leave every other path alone. **Then
-  restore the untracked backups**, which no patch and no `git restore` touches:
-
-  ```bash
-  for f in <each untracked path you delegated>; do
-    # REMOVE the destination first. `cp -pR src dest` with dest an existing DIRECTORY
-    # copies into it — you get `d/d/f.txt` while the overwritten `d/f.txt` stays put, and
-    # cp exits 0, so the rollback reports success having restored nothing. Verified.
-    rm -rf -- "$f"
-    mkdir -p "$(dirname "$f")" && cp -pR "$REVIEW_DIR/untracked/$f" "$f" \
-      || { echo "could not restore $f — its bytes are in $REVIEW_DIR/untracked"; exit 1; }
-  done
-  ```
-
-  `rm -rf` is safe *only* because `$f` is one of the paths you enumerated as delegated and
-  backed up seconds earlier. Do not generalise the loop to a glob.
-
-  Taking the backup and never copying it back is the failure worth naming: the bytes
-  survive in the review directory, the rollback reports success, and the user's file is
-  still damaged.
-
-  **Then restore intent-to-add from the status file.** § 1.5 runs `git add -N` on untracked
-  source files so codex can see them; such a file has an empty staged patch and its whole
-  content in the unstaged one, so replaying patches alone brings it back as an ordinary
-  `??`. That is not cosmetic: `git add -N` is prescribed only *before the first pass*, so a
-  file demoted here silently drops out of every later `codex review --base` and half the
-  panel stops seeing it. Intent-to-add shows in porcelain as `" A "` — a **leading space**,
-  then `A` — not `"A "`, which is an ordinary staged addition you must not touch:
-
-  ```bash
-  # -z, and NUL-delimited reads. Porcelain v1 QUOTES any path needing it — `café.py`
-  # arrives as the literal `"caf\303\251.py"` under the default core.quotePath — so a
-  # `cut`-based parse hands `git add -N` a path that does not exist and the file stays
-  # `??`, which is the exact failure this step exists to prevent.
-  while IFS= read -r -d '' entry; do
-    [ "${entry:0:3}" = " A " ] && git add -N -- "${entry:3}"
-  done < "$REVIEW_DIR/pre-delegation.status"
-  ```
-
-  Neither diff captures **untracked** files at all — which is why the capture copies every
-  pre-existing untracked path in the delegated scope. That is not optional: an implementer
-  with write access can overwrite or delete one, and no patch can bring it back. If a path
-  cannot be copied, take it out of the delegated scope rather than documenting a data-loss
-  hole underneath a promise of non-destructive rollback.
+  `git add -N` makes stash refuse outright. Anyone proposing the swap should reproduce
+  that first — and it is also why growing the capture toward stash-parity is a road that
+  ends where stash already is.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
 hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -765,11 +765,17 @@ finding precisely enough for someone else to act on, which by itself kills the v
   **To roll back**, undo only the delegated paths and rebuild them from the capture, in
   this order — anything else reaches for the destructive commands forbidden above:
 
-  1. revert **only** the paths you delegated; leave every other path untouched
-  2. re-apply the **staged** patch for those paths, then the **unstaged** one — that order
-     is what restores the layers rather than flattening them
-  3. restore each untracked backup, clearing its destination first
-  4. re-run `git add -N` for every path the status snapshot recorded as `" A "` — a leading
+  1. **delete the delegated paths the implementer created** — anything absent from the
+     status snapshot. Reverting tracked paths and replaying patches removes nothing, so a
+     rejected new file otherwise survives the rollback and turns up in the next pass
+  2. revert **only** the remaining delegated paths; leave every other path untouched
+  3. re-apply the **staged** patch with `git apply --index`, then the **unstaged** one.
+     Not `--cached`: it updates the index "without touching the working tree", so the
+     worktree stays at `HEAD` and the unstaged patch then fails against it — measured,
+     `error: patch failed`, after the original was already reverted. `--index` restores
+     `MM` correctly
+  4. restore each untracked backup, clearing its destination first
+  5. re-run `git add -N` for every path the status snapshot recorded as `" A "` — a leading
      space, then `A`; `"A "` is an ordinary staged addition and must not be re-added
 
   **`git stash create` cannot replace any of this.** It fails outright on the tree § 1.5

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -754,24 +754,38 @@ finding precisely enough for someone else to act on, which by itself kills the v
 
   **Refuse the paths this cannot represent.** The capture is a staged diff, an unstaged
   diff and a byte copy; any state that does not round-trip through those three is out of
-  scope for delegation — take the path out and say so. Known cases: unmerged paths,
-  contents inside a dirty submodule, anything with a byte-transforming `.gitattributes`
-  entry (`git check-attr --all` — `filter`, `text`, `eol`, `working-tree-encoding`), and
-  files marked `assume-unchanged`, where all three captures *succeed while recording
-  nothing* and the revert then replaces the bytes with `HEAD`. That list is the cases
-  known to hit the rule, not the boundary.
+  scope for delegation — take the path out and say so. Known cases: unmerged paths; either
+  endpoint of a **staged rename**, which are one unit (reverting the destination leaves the
+  source staged as deleted and the replay then fails); contents inside a dirty submodule;
+  anything with a byte-transforming `.gitattributes` entry (`git check-attr --all` —
+  `filter`, `text`, `eol`, `working-tree-encoding`); and files marked `assume-unchanged`,
+  where all three captures *succeed while recording nothing* and the revert then replaces
+  the bytes with `HEAD`. That list is the cases known to hit the rule, not the boundary.
 
-  **`git stash create` cannot replace any of this**, though it handles every case above
-  correctly. It fails on the tree § 1.5 builds:
+  **To roll back**, undo only the delegated paths and rebuild them from the capture, in
+  this order — anything else reaches for the destructive commands forbidden above:
+
+  1. revert **only** the paths you delegated; leave every other path untouched
+  2. re-apply the **staged** patch for those paths, then the **unstaged** one — that order
+     is what restores the layers rather than flattening them
+  3. restore each untracked backup, clearing its destination first
+  4. re-run `git add -N` for every path the status snapshot recorded as `" A "` — a leading
+     space, then `A`; `"A "` is an ordinary staged addition and must not be re-added
+
+  **`git stash create` cannot replace any of this.** It fails outright on the tree § 1.5
+  builds:
 
   ```console
   $ git stash create
   error: Entry 'café.py' not uptodate. Cannot merge.
   ```
 
-  `git add -N` makes stash refuse outright. Anyone proposing the swap should reproduce
-  that first — and it is also why growing the capture toward stash-parity is a road that
-  ends where stash already is.
+  `git add -N` makes stash refuse outright. And it would not be a drop-in even without
+  that: `stash create` takes no `-u`, so an untracked-only tree yields **no stash object at
+  all** (measured), and a conflicted index is rejected rather than saved. It handles the
+  *tracked-content* cases well — binaries, textconv, index layers — which is the useful
+  half of the comparison, not the whole of it. Anyone proposing the swap should reproduce
+  the error above first.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
 hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -700,10 +700,28 @@ finding precisely enough for someone else to act on, which by itself kills the v
 
 - **You adjudicate.** Verify each finding against source first. Never hand over a finding
   you have not checked — you would be outsourcing the judgment, not the typing.
-- **The implementer edits**, in a fresh context, with a prompt that carries: verify before
-  fixing (findings are hypotheses, and one may be wrong); after each fix sweep the whole
-  artifact for the same claim **by concept, not by phrase**; read back every passage you
-  splice into; add no new mechanism; plus your environment and scope guards.
+- **The implementer edits**, in a fresh context. A fresh context is also an *ignorant*
+  one: everything it must not do has to be in the prompt, because none of it is in the
+  air. Carry all of:
+  - **The scope, named.** The exact paths it may touch and the tools it may use. An
+    implementer told only "fix these findings" will range further than you meant, and
+    you cannot review what you did not bound.
+  - **Verify before fixing.** Findings are hypotheses; one may be wrong. Say so, or a
+    fresh agent will treat your list as a work order.
+  - **Sweep by concept, not by phrase.** After each fix, search the whole artifact for
+    the same claim stated differently.
+  - **Read back every passage you splice into** — the whole sentence and its
+    neighbours, not the replaced span.
+  - **Use the harness edit tool, not `sed -i` or `str.replace`**, which report success
+    on zero matches. If an edit must be scripted, assert the target exists before
+    replacing, then grep the file for both the new text and the *absence* of the old.
+    This is the repo's standing edit contract (`agents-md`), and it does not travel to
+    a fresh context on its own.
+  - **Add no *unrequested* mechanism** — not "nothing new". A verified finding may
+    genuinely require a lock, a validation, or a transaction; what is forbidden is
+    anything beyond the finding. Scope conflicts come back to you to adjudicate, not
+    resolved by the implementer.
+  - Plus your environment guards.
 - **Tool-managed state is delegable too — through the tool, never the file.** A ticket
   tracker or database whose on-disk form is a single JSONL line per record is corrupted by
   hand-editing, so the instinct is to keep those findings yourself. Measured: that instinct
@@ -711,7 +729,23 @@ finding precisely enough for someone else to act on, which by itself kills the v
   in a double-quoted update and silently blanked three field names in a record. Delegating
   the same work with one rule — *use the CLI, never edit the file* — landed clean and the
   database still parsed. Name the tool, forbid the file, and require a read-back.
-- **Snapshot first.** The implementer has write access; `git` is the undo.
+- **Snapshot first — and non-destructively.** The implementer has write access, and
+  § 1.6 explicitly permits running on a dirty tree, so plain `git` is *not* your undo:
+  `git checkout .`, `git stash`, and `git reset --hard` would each discard the user's
+  pre-existing unstaged work along with the delegated edit, which § 1.6 forbids. Capture
+  the tree as a patch first, and confirm the capture is non-empty **before** granting
+  write access — a snapshot you never verified is not a rollback plan:
+
+  ```bash
+  SNAP="$REVIEW_DIR/pre-delegation.patch"
+  git diff HEAD >"$SNAP"                                  # tracked: staged + unstaged
+  git status --porcelain >"$REVIEW_DIR/pre-delegation.status"
+  ```
+
+  To roll back, revert only the paths you delegated and re-apply that patch's hunks for
+  them; leave every other path alone. `git diff HEAD` does not capture **untracked**
+  files, so copy any that matter into `$REVIEW_DIR` first or accept that they are outside
+  the snapshot — and say which you did.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
 hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -738,8 +738,15 @@ finding precisely enough for someone else to act on, which by itself kills the v
   succeed — never their output to be non-empty, since on a clean tree an empty patch is
   the correct answer:
 
-  - `git diff --cached --binary --no-textconv` and `git diff --binary --no-textconv`,
-    as **two** patches. One combined `git diff HEAD` flattens the layers, so an `MM` path
+  - `git diff --cached --binary --no-textconv --no-ext-diff -- <the delegated paths>` and
+    `git diff --binary --no-textconv --no-ext-diff -- <the delegated paths>`, as **two**
+    patches. `--no-ext-diff` because a configured `diff.external` helper is not disabled by
+    `--no-textconv`: measured on git 2.43, a helper emitting `bogus` gave an exit-0 capture
+    of non-patch output that could restore nothing. And `-- <paths>` at *capture* time, so
+    the replay needs no filtering: `git apply --include` takes a **pattern**, and both a
+    bare directory and a literal `a[1].txt` silently match no hunks while exiting 0 — after
+    step 2 has already reverted those paths, which turns a rollback into a loss that reports
+    success. One combined `git diff HEAD` flattens the layers, so an `MM` path
     comes back ` M` and a later commit carries hunks the user left out. Both flags matter:
     without `--binary` a modified binary records only "Binary files differ" and will not
     apply; `--no-textconv` because the conversion is not what is on disk.
@@ -775,14 +782,16 @@ finding precisely enough for someone else to act on, which by itself kills the v
      *existence list*, never those merely absent from porcelain status. A clean tracked
      file has no status entry, so the status test would delete a file that was fine
   2. revert **only** the remaining delegated paths; leave every other path untouched
-  3. re-apply the **staged** patch with `git apply --index --include=<each delegated
-     path>`, then the **unstaged** one the same way. Not `--cached`: it updates the index
+  3. re-apply the **staged** patch with `git apply --index`, then the **unstaged** one.
+     No `--include` is needed or wanted — the patches were already restricted by pathspec
+     at capture time, which is the only way to scope them without pattern semantics. Not
+     `--cached`: it updates the index
      "without touching the working tree", so the worktree stays at `HEAD` and the unstaged
      patch fails against it — measured, `error: patch failed`, after the original was
-     already reverted. And `--include` because the capture covers the whole tree while
-     step 2 deliberately left unrelated hunks applied; replaying those re-applies what is
-     already there and the patch aborts with `patch does not apply` before any delegated
-     path is restored. **Skip an empty patch file** (or pass `--allow-empty`): an
+     already reverted. Path-restricted capture is also what keeps the replay from touching
+     unrelated hunks that step 2 deliberately left applied — replaying those would abort
+     the whole patch with `patch does not apply` before any delegated path is restored.
+     **Skip an empty patch file** (or pass `--allow-empty`): an
      unstaged-only edit leaves the staged layer empty and `git apply` exits 128 on it —
      after the revert, so the layer holding the user's work is never applied
   4. restore each untracked backup, clearing its destination first

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -767,6 +767,21 @@ finding precisely enough for someone else to act on, which by itself kills the v
   `git status --porcelain` names both. Take them out of the delegated scope and say you
   did — a snapshot that silently cannot restore a path is worse than one that refuses it.
 
+  **And no, `git stash create` cannot replace this.** It is the obvious simplification —
+  one command, and git's own code handles binaries, textconv, index stages and submodules
+  correctly — but it *fails outright* on the tree this skill's own preflight builds:
+
+  ```console
+  $ git stash create
+  error: Entry 'café.py' not uptodate. Cannot merge.
+  Cannot save the current worktree state
+  ```
+
+  § 1.5 runs `git add -N` on untracked source files so codex can see them, and `stash`
+  refuses an intent-to-add entry. So the two-patch capture is not a hand-rolled version of
+  something git already does; it is what is left once the mandatory preflight rules the
+  built-in out. Anyone proposing the swap should reproduce the error above first.
+
   **Two patches, not one.** A single `git diff HEAD` flattens staged and unstaged into one
   HEAD-to-worktree delta, so restoring a path that was `MM` brings it back as ` M` — the
   user's staging selection is gone, and a later `git commit` then carries hunks they had

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -742,8 +742,11 @@ finding precisely enough for someone else to act on, which by itself kills the v
     `git diff --binary --no-textconv --no-ext-diff -- <the delegated paths>`, as **two**
     patches. `--no-ext-diff` because a configured `diff.external` helper is not disabled by
     `--no-textconv`: measured on git 2.43, a helper emitting `bogus` gave an exit-0 capture
-    of non-patch output that could restore nothing. And `-- <paths>` at *capture* time, so
-    the replay needs no filtering: `git apply --include` takes a **pattern**, and both a
+    of non-patch output that could restore nothing. And `-- :(literal)<path>` for each delegated path at
+    *capture* time — the `:(literal)` magic matters, because a bare pathspec still globs
+    and delegated `a[1].txt` alongside an unrelated dirty `a1.txt` captures both, which
+    then aborts the replay on the hunk step 2 left applied. With literal magic the replay
+    needs no filtering: `git apply --include` takes a **pattern**, and both a
     bare directory and a literal `a[1].txt` silently match no hunks while exiting 0 — after
     step 2 has already reverted those paths, which turns a rollback into a loss that reports
     success. One combined `git diff HEAD` flattens the layers, so an `MM` path
@@ -768,9 +771,11 @@ finding precisely enough for someone else to act on, which by itself kills the v
   endpoint of a **staged rename**, which are one unit (reverting the destination leaves the
   source staged as deleted and the replay then fails); contents inside a dirty submodule;
   anything with a byte-transforming `.gitattributes` entry (`git check-attr --all` —
-  `filter`, `text`, `eol`, `working-tree-encoding`); text files under `core.autocrlf=true`,
-  which normalizes worktree bytes with **no** attribute for `check-attr` to report
-  (measured: a mixed CRLF/LF file replayed as all-CRLF from a patch that applied cleanly);
+  `filter`, `text`, `eol`, `working-tree-encoding`); text files under `core.autocrlf`, in **either**
+  `true` or `input` — both convert, with no attribute for `check-attr` to report.
+  Measured: under `true` a mixed CRLF/LF file replayed as all-CRLF from a patch that
+  applied cleanly; under `input` a CRLF worktree against an LF index gave an empty patch
+  for a file `git status` called modified, and the rollback then rewrote it to LF;
   and files marked `assume-unchanged`,
   where all three captures *succeed while recording nothing* and the revert then replaces
   the bytes with `HEAD`. That list is the cases known to hit the rule, not the boundary.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -704,9 +704,13 @@ finding precisely enough for someone else to act on, which by itself kills the v
   fixing (findings are hypotheses, and one may be wrong); after each fix sweep the whole
   artifact for the same claim **by concept, not by phrase**; read back every passage you
   splice into; add no new mechanism; plus your environment and scope guards.
-- **You keep anything the implementer cannot safely touch** — a tool-managed database, a
-  ticket tracker, anything where hand-editing the file corrupts it. Say so explicitly in
-  the prompt and expect those findings back.
+- **Tool-managed state is delegable too — through the tool, never the file.** A ticket
+  tracker or database whose on-disk form is a single JSONL line per record is corrupted by
+  hand-editing, so the instinct is to keep those findings yourself. Measured: that instinct
+  cost more than it saved. The orchestrator's own shell command-substituted the backticks
+  in a double-quoted update and silently blanked three field names in a record. Delegating
+  the same work with one rule — *use the CLI, never edit the file* — landed clean and the
+  database still parsed. Name the tool, forbid the file, and require a read-back.
 - **Snapshot first.** The implementer has write access; `git` is the undo.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -737,9 +737,9 @@ finding precisely enough for someone else to act on, which by itself kills the v
   before granting write access:
 
   ```bash
-  git diff --cached >"$REVIEW_DIR/pre-delegation.staged.patch"   || { echo "snapshot failed"; exit 1; }
-  git diff         >"$REVIEW_DIR/pre-delegation.unstaged.patch" || { echo "snapshot failed"; exit 1; }
-  git status --porcelain >"$REVIEW_DIR/pre-delegation.status"    || { echo "snapshot failed"; exit 1; }
+  git diff --cached --binary >"$REVIEW_DIR/pre-delegation.staged.patch"   || { echo "snapshot failed"; exit 1; }
+  git diff          --binary >"$REVIEW_DIR/pre-delegation.unstaged.patch" || { echo "snapshot failed"; exit 1; }
+  git status --porcelain     >"$REVIEW_DIR/pre-delegation.status"         || { echo "snapshot failed"; exit 1; }
   ```
 
   **Two patches, not one.** A single `git diff HEAD` flattens staged and unstaged into one
@@ -747,15 +747,34 @@ finding precisely enough for someone else to act on, which by itself kills the v
   user's staging selection is gone, and a later `git commit` then carries hunks they had
   deliberately left out.
 
+  **`--binary` on both.** Without it a modified binary records only `Binary files a/x and
+  b/x differ` — a patch with no payload, which `git apply` then refuses. Revert that path
+  and the user's original bytes are unrecoverable, from a snapshot that looked like it
+  worked.
+
   **Empty is a legitimate snapshot.** On a clean tree — the ordinary PR-review case — both
   patches are empty because the branch's commits are already recoverable from git. Require
   the commands to *succeed*, never the patches to be non-empty; a non-empty check would
   refuse to delegate on exactly the tidiest repositories.
 
   To roll back, revert only the paths you delegated and re-apply each layer's hunks for
-  those paths — staged first, then unstaged — and leave every other path alone. Neither
-  diff captures **untracked** files, so copy any that matter into `$REVIEW_DIR` first, or
-  accept that they sit outside the snapshot and say which you did.
+  those paths — staged first, then unstaged — and leave every other path alone.
+
+  **Then restore intent-to-add from the status file.** § 1.5 runs `git add -N` on untracked
+  source files so codex can see them; such a file has an empty staged patch and its whole
+  content in the unstaged one, so replaying patches alone brings it back as an ordinary
+  `??`. That is not cosmetic: `git add -N` is prescribed only *before the first pass*, so a
+  file demoted here silently drops out of every later `codex review --base` and half the
+  panel stops seeing it. Intent-to-add shows in porcelain as `" A "` — a **leading space**,
+  then `A` — not `"A "`, which is an ordinary staged addition you must not touch:
+
+  ```bash
+  grep '^ A ' "$REVIEW_DIR/pre-delegation.status" | cut -c4- \
+    | while IFS= read -r f; do git add -N -- "$f"; done
+  ```
+
+  Neither diff captures **untracked** files at all, so copy any that matter into
+  `$REVIEW_DIR` first, or accept that they sit outside the snapshot and say which you did.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
 hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -745,10 +745,27 @@ finding precisely enough for someone else to act on, which by itself kills the v
     || { echo "snapshot failed"; exit 1; }
   # Every pre-existing UNTRACKED path in the delegated scope, copied — neither patch can
   # restore one, so without this the "non-destructive" guarantee is simply false for them.
-  # If you cannot copy them, do not delegate those paths.
+  # mkdir FIRST: `cp --parents` requires an existing destination and otherwise fails with
+  # "with --parents, the destination must be a directory" — which, guarded like this, would
+  # block every delegation that has an untracked path in scope.
+  mkdir -p "$REVIEW_DIR/untracked" || { echo "snapshot failed"; exit 1; }
   cp -a --parents <each pre-existing untracked path in scope> "$REVIEW_DIR/untracked/" \
     || { echo "snapshot failed"; exit 1; }
   ```
+
+  **Refuse the paths this snapshot cannot represent.** Two tree states survive neither
+  patch, and both are cheaper to exclude than to reconstruct:
+
+  - **Unmerged paths** (`UU`, `AA`, …). `git diff --cached` exits 0 emitting only
+    `* Unmerged path …`, and the unstaged diff carries at most the combined working-tree
+    content — the stage-1/2/3 index entries are gone, so replaying cannot rebuild the
+    conflict. Do not delegate a path mid-merge.
+  - **Contents inside a dirty submodule.** The top-level diffs record the gitlink's
+    `-dirty` marker, not the modified bytes, so restoring the gitlink does not restore the
+    user's edit inside it.
+
+  `git status --porcelain` names both. Take them out of the delegated scope and say you
+  did — a snapshot that silently cannot restore a path is worse than one that refuses it.
 
   **Two patches, not one.** A single `git diff HEAD` flattens staged and unstaged into one
   HEAD-to-worktree delta, so restoring a path that was `MM` brings it back as ` M` — the

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -807,10 +807,17 @@ finding precisely enough for someone else to act on, which by itself kills the v
 
   ```bash
   for f in <each untracked path you delegated>; do
+    # REMOVE the destination first. `cp -pR src dest` with dest an existing DIRECTORY
+    # copies into it — you get `d/d/f.txt` while the overwritten `d/f.txt` stays put, and
+    # cp exits 0, so the rollback reports success having restored nothing. Verified.
+    rm -rf -- "$f"
     mkdir -p "$(dirname "$f")" && cp -pR "$REVIEW_DIR/untracked/$f" "$f" \
       || { echo "could not restore $f — its bytes are in $REVIEW_DIR/untracked"; exit 1; }
   done
   ```
+
+  `rm -rf` is safe *only* because `$f` is one of the paths you enumerated as delegated and
+  backed up seconds earlier. Do not generalise the loop to a glob.
 
   Taking the backup and never copying it back is the failure worth naming: the bytes
   survive in the review directory, the rollback reports success, and the user's file is

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -737,9 +737,17 @@ finding precisely enough for someone else to act on, which by itself kills the v
   before granting write access:
 
   ```bash
-  git diff --cached --binary >"$REVIEW_DIR/pre-delegation.staged.patch"   || { echo "snapshot failed"; exit 1; }
-  git diff          --binary >"$REVIEW_DIR/pre-delegation.unstaged.patch" || { echo "snapshot failed"; exit 1; }
-  git status --porcelain     >"$REVIEW_DIR/pre-delegation.status"         || { echo "snapshot failed"; exit 1; }
+  git diff --cached --binary --no-textconv >"$REVIEW_DIR/pre-delegation.staged.patch" \
+    || { echo "snapshot failed"; exit 1; }
+  git diff          --binary --no-textconv >"$REVIEW_DIR/pre-delegation.unstaged.patch" \
+    || { echo "snapshot failed"; exit 1; }
+  git status --porcelain -z >"$REVIEW_DIR/pre-delegation.status" \
+    || { echo "snapshot failed"; exit 1; }
+  # Every pre-existing UNTRACKED path in the delegated scope, copied — neither patch can
+  # restore one, so without this the "non-destructive" guarantee is simply false for them.
+  # If you cannot copy them, do not delegate those paths.
+  cp -a --parents <each pre-existing untracked path in scope> "$REVIEW_DIR/untracked/" \
+    || { echo "snapshot failed"; exit 1; }
   ```
 
   **Two patches, not one.** A single `git diff HEAD` flattens staged and unstaged into one
@@ -747,10 +755,12 @@ finding precisely enough for someone else to act on, which by itself kills the v
   user's staging selection is gone, and a later `git commit` then carries hunks they had
   deliberately left out.
 
-  **`--binary` on both.** Without it a modified binary records only `Binary files a/x and
-  b/x differ` — a patch with no payload, which `git apply` then refuses. Revert that path
-  and the user's original bytes are unrecoverable, from a snapshot that looked like it
-  worked.
+  **`--binary --no-textconv` on both.** Without `--binary` a modified binary records only
+  `Binary files a/x and b/x differ` — a patch with no payload, which `git apply` then
+  refuses (measured: *"cannot apply binary patch to 'blob.bin' without full index line"*).
+  And `--binary` does not switch off a configured `textconv` diff driver, which emits
+  *transformed* text that will not apply against the raw file either. Both flags, or the
+  revert is one-way for exactly the files you cannot retype.
 
   **Empty is a legitimate snapshot.** On a clean tree — the ordinary PR-review case — both
   patches are empty because the branch's commits are already recoverable from git. Require
@@ -769,12 +779,20 @@ finding precisely enough for someone else to act on, which by itself kills the v
   then `A` — not `"A "`, which is an ordinary staged addition you must not touch:
 
   ```bash
-  grep '^ A ' "$REVIEW_DIR/pre-delegation.status" | cut -c4- \
-    | while IFS= read -r f; do git add -N -- "$f"; done
+  # -z, and NUL-delimited reads. Porcelain v1 QUOTES any path needing it — `café.py`
+  # arrives as the literal `"caf\303\251.py"` under the default core.quotePath — so a
+  # `cut`-based parse hands `git add -N` a path that does not exist and the file stays
+  # `??`, which is the exact failure this step exists to prevent.
+  while IFS= read -r -d '' entry; do
+    [ "${entry:0:3}" = " A " ] && git add -N -- "${entry:3}"
+  done < "$REVIEW_DIR/pre-delegation.status"
   ```
 
-  Neither diff captures **untracked** files at all, so copy any that matter into
-  `$REVIEW_DIR` first, or accept that they sit outside the snapshot and say which you did.
+  Neither diff captures **untracked** files at all — which is why the capture copies every
+  pre-existing untracked path in the delegated scope. That is not optional: an implementer
+  with write access can overwrite or delete one, and no patch can bring it back. If a path
+  cannot be copied, take it out of the delegated scope rather than documenting a data-loss
+  hole underneath a promise of non-destructive rollback.
 
 This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
 hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -751,6 +751,9 @@ finding precisely enough for someone else to act on, which by itself kills the v
   - a **byte copy of every pre-existing untracked path in scope** — no patch contains
     them. Clear each destination before copying and again before restoring: `cp -pR` into
     an existing directory nests rather than replaces, and exits 0 either way.
+  - an **explicit existence list**: which delegated paths exist right now. Porcelain says
+    nothing about a clean tracked file, so status-absence is *not* an existence test —
+    treating it as one deletes exactly the files that were fine.
 
   **Refuse the paths this cannot represent.** The capture is a staged diff, an unstaged
   diff and a byte copy; any state that does not round-trip through those three is out of
@@ -758,22 +761,30 @@ finding precisely enough for someone else to act on, which by itself kills the v
   endpoint of a **staged rename**, which are one unit (reverting the destination leaves the
   source staged as deleted and the replay then fails); contents inside a dirty submodule;
   anything with a byte-transforming `.gitattributes` entry (`git check-attr --all` —
-  `filter`, `text`, `eol`, `working-tree-encoding`); and files marked `assume-unchanged`,
+  `filter`, `text`, `eol`, `working-tree-encoding`); text files under `core.autocrlf=true`,
+  which normalizes worktree bytes with **no** attribute for `check-attr` to report
+  (measured: a mixed CRLF/LF file replayed as all-CRLF from a patch that applied cleanly);
+  and files marked `assume-unchanged`,
   where all three captures *succeed while recording nothing* and the revert then replaces
   the bytes with `HEAD`. That list is the cases known to hit the rule, not the boundary.
 
   **To roll back**, undo only the delegated paths and rebuild them from the capture, in
   this order — anything else reaches for the destructive commands forbidden above:
 
-  1. **delete the delegated paths the implementer created** — anything absent from the
-     status snapshot. Reverting tracked paths and replaying patches removes nothing, so a
-     rejected new file otherwise survives the rollback and turns up in the next pass
+  1. **delete the delegated paths the implementer created** — those absent from the
+     *existence list*, never those merely absent from porcelain status. A clean tracked
+     file has no status entry, so the status test would delete a file that was fine
   2. revert **only** the remaining delegated paths; leave every other path untouched
-  3. re-apply the **staged** patch with `git apply --index`, then the **unstaged** one.
-     Not `--cached`: it updates the index "without touching the working tree", so the
-     worktree stays at `HEAD` and the unstaged patch then fails against it — measured,
-     `error: patch failed`, after the original was already reverted. `--index` restores
-     `MM` correctly
+  3. re-apply the **staged** patch with `git apply --index --include=<each delegated
+     path>`, then the **unstaged** one the same way. Not `--cached`: it updates the index
+     "without touching the working tree", so the worktree stays at `HEAD` and the unstaged
+     patch fails against it — measured, `error: patch failed`, after the original was
+     already reverted. And `--include` because the capture covers the whole tree while
+     step 2 deliberately left unrelated hunks applied; replaying those re-applies what is
+     already there and the patch aborts with `patch does not apply` before any delegated
+     path is restored. **Skip an empty patch file** (or pass `--allow-empty`): an
+     unstaged-only edit leaves the staged layer empty and `git apply` exits 128 on it —
+     after the revert, so the layer holding the user's work is never applied
   4. restore each untracked backup, clearing its destination first
   5. re-run `git add -N` for every path the status snapshot recorded as `" A "` — a leading
      space, then `A`; `"A "` is an ordinary staged addition and must not be re-added

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -750,13 +750,21 @@ finding precisely enough for someone else to act on, which by itself kills the v
   # for it) — so the GNU form would make every delegation with an untracked path exit
   # `snapshot failed` there. `cp -pR` is portable; the parent dirs are built by hand.
   for f in <each pre-existing untracked path in scope>; do
+    # Clear the destination first, for the same reason the restore does: on a second
+    # delegation of the same path, `cp -pR` treats the existing backup as a target
+    # DIRECTORY and nests inside it, so the rollback later restores the stale outer copy.
+    rm -rf -- "$REVIEW_DIR/untracked/$f"
     mkdir -p "$REVIEW_DIR/untracked/$(dirname "$f")" || { echo "snapshot failed"; exit 1; }
     cp -pR "$f" "$REVIEW_DIR/untracked/$f"           || { echo "snapshot failed"; exit 1; }
   done
   ```
 
-  **Refuse the paths this snapshot cannot represent.** Two tree states survive neither
-  patch, and both are cheaper to exclude than to reconstruct:
+  **Refuse the paths this snapshot cannot represent.** The capture is exactly three things:
+  a staged diff, an unstaged diff, and a byte copy of untracked files. Any tree state that
+  does not round-trip through those is **out of scope for delegation** — take the path out
+  and say you did. That is the rule; the list below is the cases known to hit it, not a
+  boundary that ends there. Growing the capture to cover each new one is a road that ends
+  at `git stash`, and `git stash` does not work here (below).
 
   - **Unmerged paths** (`UU`, `AA`, …). `git diff --cached` exits 0 emitting only
     `* Unmerged path …`, and the unstaged diff carries at most the combined working-tree
@@ -765,6 +773,16 @@ finding precisely enough for someone else to act on, which by itself kills the v
   - **Contents inside a dirty submodule.** The top-level diffs record the gitlink's
     `-dirty` marker, not the modified bytes, so restoring the gitlink does not restore the
     user's edit inside it.
+  - **Paths with an active `.gitattributes` clean filter.** `--no-textconv` does not
+    bypass it: `git diff` snapshots the *cleaned* representation, so worktree-only bytes
+    the filter strips are absent from the patch. Measured — a filter dropping `LOCAL:`
+    lines produced a zero-byte unstaged patch on a file `git status` called modified, and
+    the rollback discarded that line permanently. `git check-attr filter -- <path>` names
+    them.
+  - **Either endpoint of a staged rename.** Porcelain `-z` emits both paths; reverting only
+    the destination leaves the source staged as deleted and the replay then fails, because
+    the source no longer exists in the index. The two endpoints are one unit — delegate
+    both or neither.
 
   `git status --porcelain` names both. Take them out of the delegated scope and say you
   did — a snapshot that silently cannot restore a path is worse than one that refuses it.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -773,12 +773,19 @@ finding precisely enough for someone else to act on, which by itself kills the v
   - **Contents inside a dirty submodule.** The top-level diffs record the gitlink's
     `-dirty` marker, not the modified bytes, so restoring the gitlink does not restore the
     user's edit inside it.
-  - **Paths with an active `.gitattributes` clean filter.** `--no-textconv` does not
-    bypass it: `git diff` snapshots the *cleaned* representation, so worktree-only bytes
-    the filter strips are absent from the patch. Measured — a filter dropping `LOCAL:`
-    lines produced a zero-byte unstaged patch on a file `git status` called modified, and
-    the rollback discarded that line permanently. `git check-attr filter -- <path>` names
-    them.
+  - **Paths with ANY byte-transforming `.gitattributes` entry** — `filter`, `text`, `eol`,
+    `working-tree-encoding`. `--no-textconv` bypasses none of them: `git diff` snapshots
+    the *converted* representation, so what replays is not what was there. Measured — a
+    clean filter dropping `LOCAL:` lines produced a zero-byte unstaged patch on a file
+    `git status` called modified, and a mixed CRLF/LF file came back entirely CRLF from a
+    patch that applied without error. Use `git check-attr --all -- <path>` and read the
+    whole list; checking `filter` alone was the first version of this rule and it missed
+    the other three.
+  - **Files marked `assume-unchanged`.** Worst of the set, because all three captures
+    *succeed* while recording nothing: git has been told the file is not changing, so the
+    diffs are empty and porcelain is silent — and the revert then replaces the user's
+    bytes with `HEAD`. A silent total loss with no failing command anywhere. `git ls-files
+    -v` flags them with a lowercase status letter.
   - **Either endpoint of a staged rename.** Porcelain `-z` emits both paths; reverting only
     the destination leaves the source staged as deleted and the replay then fails, because
     the source no longer exists in the index. The two endpoints are one unit — delegate


### PR DESCRIPTION
**Draft — recovered work, not newly authored.** Opening it for review rather than leaving
it where it was found.

## Provenance

These two commits existed **only** in the install clone at
`~/.local/share/douglaz-skills` and had never been pushed. `install.sh` refused to
fast-forward because of them, which is how they surfaced; a `git reset --hard` to unblock
the installer would have destroyed ~44 lines silently. They are unmodified apart from
being replayed onto current `master` (`git am`, applied clean).

Someone had edited the *installed copy* rather than the working repo. Worth noting as a
hazard in its own right: the install directory is a symlink target, so edits there are
live immediately and invisible to `git status` in the repo you think you are working in.

## What it adds

A `§ 3a` on delegating **the edit** — not the judgment — to a fresh implementer:

> "The agent that wrote the text is the worst available editor of it. After a few passes
> you stop reading what is on the page and start reading what you meant."

The split it proposes: **you adjudicate** (verify every finding against source first — never
hand over one you have not checked, or you are outsourcing the judgment rather than the
typing); **the implementer edits** in a fresh context with a prompt carrying verify-before-
fixing, sweep-by-concept-not-by-phrase, read-back-what-you-splice, and add-no-mechanism.
Snapshot first, because the implementer has write access and `git` is the undo.

It also covers tool-managed state: for a tracker whose on-disk form is one JSONL line per
record, delegate **through the CLI, never the file** — with a measured case where the
orchestrator's own shell command-substituted backticks in a double-quoted update and
blanked three field names.

It is careful about its own evidence: *"Treat that as one trial, not a law"*, and it
attributes the effect to **freshness plus a written finding list** rather than to any
particular model.

## Why I think it is worth landing

Today's session is unplanned corroboration. Acting as the orchestrator fixing my own
artifact, I shipped: a test assertion that could never match (quotes in a pattern against
shell-stripped data, so it passed unconditionally); a fix for a security claim that made an
unresolvable base fatal and would have silently killed a reviewer in every repo whose base
ref does not resolve; and three separate cases of correcting code while leaving the prose
describing it untouched. Each was caught by an outside reader, not by me re-reading my own
work. That is the failure mode this section describes.

## Review notes

- Docs only — one file, `skills/multi-reviewer-loop/SKILL.md`, +44 −1.
- No suite covers this file; `bot-gate.test` (104) and `drive-status.test` (70) are green on
  the branch but neither exercises it.
- Draft because the content deserves a read by someone who did not just live through the
  session that agrees with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the multi-reviewer workflow to support delegated edits for verified findings while preserving adjudication oversight.
  * Added guidance for scoped handoffs, repository-wide concept checks, read-back verification, snapshots, rollback, and tool-managed state.
  * Clarified handling of working-tree states, untracked files, intent-to-add files, and staged or unstaged changes.
  * Reinforced guardrails requiring every finding to be fixed, deferred, or disproven.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Round 2 — bot findings, all fixed

- **[P1] Preserve dirty-tree edits separately.** A single `git diff HEAD` flattens staged and unstaged into one delta, so restoring an `MM` path brings it back as ` M` — the staging selection gone, a later commit carrying hunks the user left out. The rollback was committing the class of loss it exists to prevent. Now two patches, replayed staged-first.
- **[Major] Empty snapshots must pass.** "Confirm the capture is non-empty" was backwards for the ordinary case: on a clean tree both patches are legitimately empty, because those commits are already recoverable from git. The rule refused to delegate on the tidiest repositories. The capture *commands* must succeed; their content is never required.
