### PR TITLE
Do not edit while codex review runs — the loss looks like a successful commit

### DIFF
--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -54,22 +54,27 @@ git diff --cached                            # sweeps in unrelated work. And REA
                                              # hunks in that same file.
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 # The commit's own file list first — every path you touched, and nothing you did not.
-_chk=$(mktemp)
+_chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file you changed that gained or changed content>; do
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
   grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
-# Removal-only edits have no new phrase to find, and any surviving phrase passes even if
-# the removal was reverted. Assert the removed text is GONE:
+# Removal-only edits have no new phrase to find, and any surviving phrase passes even
+# if the removal was reverted. Assert the EXPECTED REMAINING COUNT — not absence,
+# which rejects a correct partial removal:
 for f in <every file you removed lines from>; do
-  # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
-  # is skipped — an accidental whole-file deletion reads identically to a clean removal.
+  # Existence FIRST: `git show HEAD:<gone>` fails, and without this assert an
+  # accidental whole-file deletion would reach the count check with an empty file
+  # and read as a clean removal. Whole-file deletions belong in the absence loop
+  # below, never here.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
-  # COUNT, not absence: removing one of several identical lines legitimately leaves
-  # the phrase behind, and demanding zero rejects that correct commit.
+  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
+  # hits on one line count as one), and not absence: removing one of several
+  # identical lines legitimately leaves the phrase behind, and demanding zero
+  # rejects that correct commit.
   [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
     || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
 done

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -56,9 +56,11 @@ git show --stat --format= HEAD               # all the paths you meant, and only
 ```
 
 Then confirm the *content* landed, per file, by the check that fits it — a file that
-gained content must contain a distinctive new phrase; a file you only removed lines from
-must still exist **and** hold the expected remaining count of the deleted phrase; a
-deleted path must be absent. One does not substitute for another, and each has a way to
+gained content must contain a distinctive new phrase; a file you removed lines from must
+still exist **and** hold the expected remaining count of the deleted phrase; a deleted path
+must be absent. A file that BOTH gained and lost content needs both of the first two — the
+added phrase passing says nothing about whether the removal survived. One does not
+substitute for another, and each has a way to
 lie: `grep` defaults to regex (use `-Fq --`), `git show ... | grep` returns 141 under
 `pipefail` when grep exits early (capture to a file first), `grep -c` counts lines rather
 than occurrences, and demanding *zero* occurrences rejects a correct partial removal.

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -47,45 +47,25 @@ commit), and for anything you care about also look inside the commit, since a
 partial loss commits cleanly at exit 0:
 
 ```
-git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it
-git diff --cached                            # sweeps in unrelated work. And READ this:
-                                             # on a path that was ALREADY dirty, staging
-                                             # it by name still takes the other agent's
-                                             # hunks in that same file.
+git add -- <every path this change touched>   # not `git add -A`: on a dirty tree it
+git diff --cached                            # sweeps in unrelated work — and READ this,
+                                             # since staging a path that was already
+                                             # dirty takes the other agent's hunks too
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-# The commit's own file list first — every path you touched, and nothing you did not.
+git show --stat --format= HEAD               # all the paths you meant, and only those
+```
+
+Then confirm the *content* landed, per file, by the check that fits it — a file that
+gained content must contain a distinctive new phrase; a file you only removed lines from
+must still exist **and** hold the expected remaining count of the deleted phrase; a
+deleted path must be absent. One does not substitute for another, and each has a way to
+lie: `grep` defaults to regex (use `-Fq --`), `git show ... | grep` returns 141 under
+`pipefail` when grep exits early (capture to a file first), `grep -c` counts lines rather
+than occurrences, and demanding *zero* occurrences rejects a correct partial removal.
+
+```bash
 _chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
-git show --stat --format= HEAD
-# Each file that should CONTAIN the change:
-for f in <every file you changed that gained or changed content>; do
-  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-  grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
-done
-# Removal-only edits have no new phrase to find, and any surviving phrase passes even
-# if the removal was reverted. Assert the EXPECTED REMAINING COUNT — not absence,
-# which rejects a correct partial removal:
-for f in <every file you removed lines from>; do
-  # Existence FIRST: `git show HEAD:<gone>` fails, and without this assert an
-  # accidental whole-file deletion would reach the count check with an empty file
-  # and read as a clean removal. Whole-file deletions belong in the absence loop
-  # below, never here.
-  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
-  # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
-  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
-  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
-  # hits on one line count as one), and not absence: removing one of several
-  # identical lines legitimately leaves the phrase behind, and demanding zero
-  # rejects that correct commit.
-  [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
-    || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
-done
-# Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
-# design on a deleted path, so folding deletions into the loop above marks every correct
-# deletion as a loss:
-for f in <every path the change deletes>; do
-  git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
-done
+# ...the three loops, using `grep -Fq --` / `grep -Fo | wc -l || true` on a captured file.
 ```
 
 A clean `git status` is neither check.

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -47,8 +47,12 @@ commit), and for anything you care about also look inside the commit, since a
 partial loss commits cleanly at exit 0:
 
 ```
-git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it sweeps
-git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }   # in unrelated work
+git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it
+git diff --cached                            # sweeps in unrelated work. And READ this:
+                                             # on a path that was ALREADY dirty, staging
+                                             # it by name still takes the other agent's
+                                             # hunks in that same file.
+git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 # The commit's own file list first — every path you touched, and nothing you did not.
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
@@ -58,6 +62,9 @@ done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
 for f in <every file you removed lines from>; do
+  # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
+  # is skipped — an accidental whole-file deletion reads identically to a clean removal.
+  git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
   git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
     && { echo "$f still contains text this change removed"; exit 1; }
 done

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -39,6 +39,13 @@ afterwards for both the new text and the absence of the old. Prose and markdown
 are where this bites hardest: nothing compiles a README, so a silently skipped
 edit survives and gets reported as done.
 
+The check does not stop at the file. A commit can report success with the content
+absent from `HEAD`: `nothing to commit, working tree clean` reads exactly the same
+whether the work was already committed or was reverted underneath you by another
+process holding the tree. After committing something you care about, look in the
+commit — `git show HEAD:<file> | grep -c "<distinctive phrase>"` — rather than
+trusting a clean `git status`.
+
 The same tools also corrupt without failing. In a `sed` replacement string `&`
 means "the whole match", so substituting a value containing `&&` — any shell
 command that chains, which is most of them — silently doubles it and reports

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -48,8 +48,17 @@ partial loss commits cleanly at exit 0:
 
 ```
 git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-for f in <every file you changed>; do
+# The commit's own file list first — every path you touched, and nothing you did not.
+git show --stat --format= HEAD
+# Each file that should CONTAIN the change:
+for f in <every file you changed that gained or changed content>; do
   git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
+# Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
+# design on a deleted path, so folding deletions into the loop above marks every correct
+# deletion as a loss:
+for f in <every path the change deletes>; do
+  git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
 done
 ```
 

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -47,12 +47,19 @@ commit), and for anything you care about also look inside the commit, since a
 partial loss commits cleanly at exit 0:
 
 ```
-git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it sweeps
+git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }   # in unrelated work
 # The commit's own file list first — every path you touched, and nothing you did not.
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file you changed that gained or changed content>; do
   git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
+# Removal-only edits have no new phrase to find, and any surviving phrase passes even if
+# the removal was reverted. Assert the removed text is GONE:
+for f in <every file you removed lines from>; do
+  git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
+    && { echo "$f still contains text this change removed"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -48,7 +48,9 @@ partial loss commits cleanly at exit 0:
 
 ```
 git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-git show HEAD:<file> | grep -c "<distinctive phrase>"
+for f in <every file you changed>; do
+  git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
 ```
 
 A clean `git status` is neither check.

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -54,19 +54,20 @@ git diff --cached                            # sweeps in unrelated work. And REA
                                              # hunks in that same file.
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 # The commit's own file list first — every path you touched, and nothing you did not.
+_chk=$(mktemp)
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file you changed that gained or changed content>; do
-  git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
+  grep -q "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
 for f in <every file you removed lines from>; do
   # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
   # is skipped — an accidental whole-file deletion reads identically to a clean removal.
-  git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
-  git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
-    && { echo "$f still contains text this change removed"; exit 1; }
+  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
+  grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -59,7 +59,7 @@ git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file you changed that gained or changed content>; do
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-  grep -q "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
+  grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
@@ -67,7 +67,11 @@ for f in <every file you removed lines from>; do
   # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
   # is skipped — an accidental whole-file deletion reads identically to a clean removal.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
+  _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
+  # COUNT, not absence: removing one of several identical lines legitimately leaves
+  # the phrase behind, and demanding zero rejects that correct commit.
+  [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
+    || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -70,7 +70,9 @@ for f in <every file you removed lines from>; do
   # and read as a clean removal. Whole-file deletions belong in the absence loop
   # below, never here.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
+  # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
+  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
   # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
   # hits on one line count as one), and not absence: removing one of several
   # identical lines legitimately leaves the phrase behind, and demanding zero

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -39,12 +39,19 @@ afterwards for both the new text and the absence of the old. Prose and markdown
 are where this bites hardest: nothing compiles a README, so a silently skipped
 edit survives and gets reported as done.
 
-The check does not stop at the file. A commit can report success with the content
-absent from `HEAD`: `nothing to commit, working tree clean` reads exactly the same
-whether the work was already committed or was reverted underneath you by another
-process holding the tree. After committing something you care about, look in the
-commit — `git show HEAD:<file> | grep -c "<distinctive phrase>"` — rather than
-trusting a clean `git status`.
+The check does not stop at the file. `nothing to commit, working tree clean` reads
+exactly the same whether the work was already committed or was reverted underneath
+you by another process holding the tree — so never take that message as proof a
+commit happened. Take the exit code instead (`git commit` exits **1** on an empty
+commit), and for anything you care about also look inside the commit, since a
+partial loss commits cleanly at exit 0:
+
+```
+git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+git show HEAD:<file> | grep -c "<distinctive phrase>"
+```
+
+A clean `git status` is neither check.
 
 The same tools also corrupt without failing. In a `sed` replacement string `&`
 means "the whole match", so substituting a value containing `&&` — any shell

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -259,8 +259,10 @@ A phase closes on evidence or it does not close.
   # accidental whole-file deletion reads exactly like a clean removal.
   for f in <every file you removed lines from>; do
     git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-    _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
-    # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
+    _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
+    # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
+  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
+  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
     # hits on one line count as one), and not absence: removing one of several
     # identical lines legitimately leaves the phrase behind, and demanding zero
     # rejects that correct commit.

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -237,13 +237,16 @@ A phase closes on evidence or it does not close.
   # Stage the paths this change touched — NOT `git add -A`. On the dirty tree § 1.6
   # permits, `-A` sweeps in another agent's edits and any untracked file lying around,
   # including a secret, and `git show --stat` only reveals that after the commit exists.
-  git add -- <every path this change touched>   # not `git add -A`: on a dirty tree it
-  git diff --cached                            # sweeps in unrelated work — and READ it
+  git add -- <every path this change touched>   # NOT `git add -A`: on a dirty tree that
+                                               # stages unrelated work. Even by name, a path
+                                               # already dirty brings the other agent's hunks.
+  git diff --cached                            # read-only review of what you just staged
   git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
   git show --stat --format= HEAD               # all the paths you meant, and only those
   # Then per file, by the check that fits: gained content must contain a distinctive new
-  # phrase; a removal-only file must still EXIST and hold the expected remaining count;
-  # a deleted path must be absent. `grep -Fq --` (regex is the default), capture to a
+  # phrase; a file with removals must still EXIST and hold the expected remaining count;
+  # a deleted path must be absent. A file with BOTH needs both checks — the added phrase
+  # passing says nothing about whether the removal survived. `grep -Fq --` (regex is the default), capture to a
   # file first (`git show ... | grep` returns 141 under pipefail), and count occurrences
   # rather than lines — demanding zero rejects a correct partial removal.
   ```

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -239,14 +239,18 @@ A phase closes on evidence or it does not close.
   # including a secret, and `git show --stat` only reveals that after the commit exists.
   git add -- <every path this change touched>
   git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+  git diff --cached --stat                # BEFORE committing: only your hunks, only your paths?
   git show --stat --format= HEAD          # does this list all of them, and only them?
-  for f in <every file you edited>; do
+  for f in <every file that gained new content>; do
     git show "HEAD:$f" | grep -q "<a distinctive phrase from that file's change>" \
       || { echo "$f did not land"; exit 1; }
   done
   # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
-  # the removal was reverted. Assert the removed text is GONE:
+  # the removal was reverted — so they belong here, NOT in the loop above. Existence first:
+  # `git show HEAD:<gone>` fails, grep returns nonzero, and the `&&` is skipped, so an
+  # accidental whole-file deletion reads exactly like a clean removal.
   for f in <every file you removed lines from>; do
+    git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
     git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
       && { echo "$f still contains text this change removed"; exit 1; }
   done

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -238,11 +238,19 @@ A phase closes on evidence or it does not close.
   # permits, `-A` sweeps in another agent's edits and any untracked file lying around,
   # including a secret, and `git show --stat` only reveals that after the commit exists.
   git add -- <every path this change touched>
+  git diff --cached          # READ IT NOW, while the index still has something in it.
+                             # Staging by name still takes another agent's hunks from a
+                             # file that was already dirty. After the commit this is
+                             # empty, and `git show --stat` shows path names, not hunks.
   git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-  git diff --cached --stat                # BEFORE committing: only your hunks, only your paths?
-  git show --stat --format= HEAD          # does this list all of them, and only them?
+  _chk=$(mktemp)
+  git show --stat --format= HEAD        # does this list all of them, and only them?
   for f in <every file that gained new content>; do
-    git show "HEAD:$f" | grep -q "<a distinctive phrase from that file's change>" \
+    # Capture, do not pipe: `git show ... | grep -q` returns 141 under `pipefail` when
+    # grep exits on an early match and git show takes SIGPIPE — verified — which reads
+    # as "no match" and inverts both checks below.
+    git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
+    grep -q "<a distinctive phrase from that file's change>" "$_chk" \
       || { echo "$f did not land"; exit 1; }
   done
   # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
@@ -250,9 +258,8 @@ A phase closes on evidence or it does not close.
   # `git show HEAD:<gone>` fails, grep returns nonzero, and the `&&` is skipped, so an
   # accidental whole-file deletion reads exactly like a clean removal.
   for f in <every file you removed lines from>; do
-    git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
-    git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
-      && { echo "$f still contains text this change removed"; exit 1; }
+    git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
+    grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
   done
   # Deletions are verified by ABSENCE — `git show HEAD:<path>` fails by design on a
   # deleted path, so folding them into the loops above fails every correct deletion:

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -231,14 +231,17 @@ A phase closes on evidence or it does not close.
   clean` is what you see both when the work is already committed and when it was
   destroyed underneath you — and an edit made while `codex review` is running *is*
   destroyed, silently, leaving nothing in the file or in `HEAD`. So never edit the repo
-  while a review process is in flight, and check the tree rather than the exit code:
+  while a review process is in flight, and take both checks the message hides:
 
   ```bash
+  git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
   git show HEAD:<file> | grep -c "<distinctive phrase from the change>"   # must be >0
   ```
 
-  Gates that passed *before* the loss are not evidence either; the work was real when
-  they ran. See
+  The `||` catches a total loss — `git commit` with nothing staged exits **1**, however
+  reassuring its message reads. The `grep` catches a partial one, which commits cleanly
+  at exit 0 with half the change in it. Gates that passed *before* the loss are not
+  evidence either; the work was real when they ran. See
   [multi-reviewer-loop/references/reviewer-panel.md](../multi-reviewer-loop/references/reviewer-panel.md).
 - **`br` is not exempt — but know which failure you are guarding.** An *explicit*
   `br sync --flush-only` propagates a real exit code, so just require it to succeed. The

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -243,7 +243,7 @@ A phase closes on evidence or it does not close.
                              # file that was already dirty. After the commit this is
                              # empty, and `git show --stat` shows path names, not hunks.
   git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-  _chk=$(mktemp)
+  _chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
   git show --stat --format= HEAD        # does this list all of them, and only them?
   for f in <every file that gained new content>; do
     # Capture, do not pipe: `git show ... | grep -q` returns 141 under `pipefail` when
@@ -259,9 +259,11 @@ A phase closes on evidence or it does not close.
   # accidental whole-file deletion reads exactly like a clean removal.
   for f in <every file you removed lines from>; do
     git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-    _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
-    # COUNT, not absence: removing one of several identical lines legitimately leaves
-    # the phrase behind, and demanding zero rejects that correct commit.
+    _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+    # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
+    # hits on one line count as one), and not absence: removing one of several
+    # identical lines legitimately leaves the phrase behind, and demanding zero
+    # rejects that correct commit.
     [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
       || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
   done

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -236,10 +236,15 @@ A phase closes on evidence or it does not close.
   ```bash
   git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
   # EVERY file the change touched, not a representative one.
-  git show --stat --format= HEAD          # does this list all of them?
+  git show --stat --format= HEAD          # does this list all of them, and only them?
   for f in <every file you edited>; do
     git show "HEAD:$f" | grep -q "<a distinctive phrase from that file's change>" \
       || { echo "$f did not land"; exit 1; }
+  done
+  # Deletions are verified by ABSENCE — `git show HEAD:<path>` fails by design on a
+  # deleted path, so folding them into the loop above fails every correct deletion:
+  for f in <every path you deleted>; do
+    git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
   done
   ```
 

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -234,15 +234,24 @@ A phase closes on evidence or it does not close.
   while a review process is in flight, and take both checks the message hides:
 
   ```bash
-  git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-  # EVERY file the change touched, not a representative one.
+  # Stage the paths this change touched — NOT `git add -A`. On the dirty tree § 1.6
+  # permits, `-A` sweeps in another agent's edits and any untracked file lying around,
+  # including a secret, and `git show --stat` only reveals that after the commit exists.
+  git add -- <every path this change touched>
+  git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
   git show --stat --format= HEAD          # does this list all of them, and only them?
   for f in <every file you edited>; do
     git show "HEAD:$f" | grep -q "<a distinctive phrase from that file's change>" \
       || { echo "$f did not land"; exit 1; }
   done
+  # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
+  # the removal was reverted. Assert the removed text is GONE:
+  for f in <every file you removed lines from>; do
+    git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
+      && { echo "$f still contains text this change removed"; exit 1; }
+  done
   # Deletions are verified by ABSENCE — `git show HEAD:<path>` fails by design on a
-  # deleted path, so folding them into the loop above fails every correct deletion:
+  # deleted path, so folding them into the loops above fails every correct deletion:
   for f in <every path you deleted>; do
     git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
   done

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -235,13 +235,21 @@ A phase closes on evidence or it does not close.
 
   ```bash
   git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-  git show HEAD:<file> | grep -c "<distinctive phrase from the change>"   # must be >0
+  # EVERY file the change touched, not a representative one.
+  git show --stat --format= HEAD          # does this list all of them?
+  for f in <every file you edited>; do
+    git show "HEAD:$f" | grep -q "<a distinctive phrase from that file's change>" \
+      || { echo "$f did not land"; exit 1; }
+  done
   ```
 
   The `||` catches a total loss — `git commit` with nothing staged exits **1**, however
-  reassuring its message reads. The `grep` catches a partial one, which commits cleanly
-  at exit 0 with half the change in it. Gates that passed *before* the loss are not
-  evidence either; the work was real when they ran. See
+  reassuring its message reads. The loop catches a partial one, which commits cleanly at
+  exit 0. **Check every file, not one.** Grepping a single path proves only that path
+  survived: if another file was reverted while your sample was left intact, the commit
+  exits 0 and the grep passes, and the guard reports success for exactly the loss it was
+  written to catch. Gates that passed *before* the loss are not evidence either; the work
+  was real when they ran. See
   [multi-reviewer-loop/references/reviewer-panel.md](../multi-reviewer-loop/references/reviewer-panel.md).
 - **`br` is not exempt — but know which failure you are guarding.** An *explicit*
   `br sync --flush-only` propagates a real exit code, so just require it to succeed. The

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -227,6 +227,19 @@ A phase closes on evidence or it does not close.
   green test that never could have gone red proves nothing.
 - Words that need a number or an exit code behind them: "passing", "working", "clean",
   "verified", "done". Without one, say what you actually observed instead.
+- **A commit is not evidence its content landed.** `nothing to commit, working tree
+  clean` is what you see both when the work is already committed and when it was
+  destroyed underneath you — and an edit made while `codex review` is running *is*
+  destroyed, silently, leaving nothing in the file or in `HEAD`. So never edit the repo
+  while a review process is in flight, and check the tree rather than the exit code:
+
+  ```bash
+  git show HEAD:<file> | grep -c "<distinctive phrase from the change>"   # must be >0
+  ```
+
+  Gates that passed *before* the loss are not evidence either; the work was real when
+  they ran. See
+  [multi-reviewer-loop/references/reviewer-panel.md](../multi-reviewer-loop/references/reviewer-panel.md).
 - **`br` is not exempt — but know which failure you are guarding.** An *explicit*
   `br sync --flush-only` propagates a real exit code, so just require it to succeed. The
   *automatic* flush that follows a mutating command like `br close` does not: its error is

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -237,43 +237,15 @@ A phase closes on evidence or it does not close.
   # Stage the paths this change touched — NOT `git add -A`. On the dirty tree § 1.6
   # permits, `-A` sweeps in another agent's edits and any untracked file lying around,
   # including a secret, and `git show --stat` only reveals that after the commit exists.
-  git add -- <every path this change touched>
-  git diff --cached          # READ IT NOW, while the index still has something in it.
-                             # Staging by name still takes another agent's hunks from a
-                             # file that was already dirty. After the commit this is
-                             # empty, and `git show --stat` shows path names, not hunks.
+  git add -- <every path this change touched>   # not `git add -A`: on a dirty tree it
+  git diff --cached                            # sweeps in unrelated work — and READ it
   git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-  _chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
-  git show --stat --format= HEAD        # does this list all of them, and only them?
-  for f in <every file that gained new content>; do
-    # Capture, do not pipe: `git show ... | grep -q` returns 141 under `pipefail` when
-    # grep exits on an early match and git show takes SIGPIPE — verified — which reads
-    # as "no match" and inverts both checks below.
-    git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-    grep -Fq -- "<a distinctive phrase from that file's change>" "$_chk" \
-      || { echo "$f did not land"; exit 1; }
-  done
-  # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
-  # the removal was reverted — so they belong here, NOT in the loop above. Existence first:
-  # `git show HEAD:<gone>` fails, grep returns nonzero, and the `&&` is skipped, so an
-  # accidental whole-file deletion reads exactly like a clean removal.
-  for f in <every file you removed lines from>; do
-    git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-    _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
-    # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
-  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
-  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
-    # hits on one line count as one), and not absence: removing one of several
-    # identical lines legitimately leaves the phrase behind, and demanding zero
-    # rejects that correct commit.
-    [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
-      || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
-  done
-  # Deletions are verified by ABSENCE — `git show HEAD:<path>` fails by design on a
-  # deleted path, so folding them into the loops above fails every correct deletion:
-  for f in <every path you deleted>; do
-    git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
-  done
+  git show --stat --format= HEAD               # all the paths you meant, and only those
+  # Then per file, by the check that fits: gained content must contain a distinctive new
+  # phrase; a removal-only file must still EXIST and hold the expected remaining count;
+  # a deleted path must be absent. `grep -Fq --` (regex is the default), capture to a
+  # file first (`git show ... | grep` returns 141 under pipefail), and count occurrences
+  # rather than lines — demanding zero rejects a correct partial removal.
   ```
 
   The `||` catches a total loss — `git commit` with nothing staged exits **1**, however

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -250,7 +250,7 @@ A phase closes on evidence or it does not close.
     # grep exits on an early match and git show takes SIGPIPE — verified — which reads
     # as "no match" and inverts both checks below.
     git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-    grep -q "<a distinctive phrase from that file's change>" "$_chk" \
+    grep -Fq -- "<a distinctive phrase from that file's change>" "$_chk" \
       || { echo "$f did not land"; exit 1; }
   done
   # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
@@ -259,7 +259,11 @@ A phase closes on evidence or it does not close.
   # accidental whole-file deletion reads exactly like a clean removal.
   for f in <every file you removed lines from>; do
     git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-    grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
+    _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
+    # COUNT, not absence: removing one of several identical lines legitimately leaves
+    # the phrase behind, and demanding zero rejects that correct commit.
+    [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
+      || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
   done
   # Deletions are verified by ABSENCE — `git show HEAD:<path>` fails by design on a
   # deleted path, so folding them into the loops above fails every correct deletion:

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -44,8 +44,11 @@ Treat that as the default for anything non-trivial.
      `grep -Fq -- '<new phrase>' "$_chk"`. `-F` because `grep` defaults to basic regex, so
      a phrase containing `[`, `.` or `*` will not match itself; `--` because one starting
      with `-` parses as an option.
-   - **removal-only, file retained** — same capture, then compare the EXPECTED REMAINING
-     COUNT: `grep -Fo -- '<deleted phrase>' "$_chk" | wc -l`. Not absence, which rejects a
+   - **removals, file retained** (whether or not it also gained content — a file with both
+     needs this check AND the one above) — same capture, then compare the EXPECTED REMAINING
+     COUNT: `grep -Fo -- '<deleted phrase>' "$_chk" | wc -l || true`. The `|| true` because
+     grep exits 1 on no match and `pipefail` would abort at the complete-removal case this
+     check exists to confirm. Not absence, which rejects a
      correct commit that removed one of several identical lines; and not `grep -c`, which
      counts matching *lines* rather than occurrences.
    - **whole file deleted** — `git show "HEAD:$f"` must FAIL; running it through the

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -33,11 +33,13 @@ Treat that as the default for anything non-trivial.
    ```
 4. Apply findings, re-commit, re-review. Loop until a pass returns no P0/P1.
    **Apply nothing until the review process has exited.** An edit to a tracked file
-   while `codex review` is running is silently destroyed and the loss reads as a
-   *successful* commit — `nothing to commit, working tree clean`, with the content
-   gone from the file and from `HEAD`. On re-commit, assert the content landed
-   (`git show HEAD:<file> | grep -c '<phrase>'`), not the exit code; a clean `git
-   status` cannot tell the two apart. See
+   while `codex review` is running is silently destroyed, and the commit that should
+   have carried it prints `nothing to commit, working tree clean` with the content
+   gone from the file and from `HEAD`. On re-commit take both checks that message
+   hides: require `git commit` to exit 0 (it exits **1** on an empty commit, however
+   reassuring the wording), then assert the content with
+   `git show HEAD:<file> | grep -c '<phrase>'` — a partial loss commits cleanly. A
+   clean `git status` is neither check. See
    [multi-reviewer-loop/references/reviewer-panel.md](../../multi-reviewer-loop/references/reviewer-panel.md).
 5. For plan-shaped work, `plan-eng-review` / `plan-ceo-review` add a product lens.
 

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -37,10 +37,19 @@ Treat that as the default for anything non-trivial.
    have carried it prints `nothing to commit, working tree clean` with the content
    gone from the file and from `HEAD`. On re-commit take both checks that message
    hides: require `git commit` to exit 0 (it exits **1** on an empty commit, however
-   reassuring the wording), then assert the content of **every** file you changed with
-   `git show "HEAD:$f" | grep -q '<a phrase from that file>'` — a partial loss commits
-   cleanly, and checking one path only proves that path survived. A clean `git status`
-   is neither check. See
+   reassuring the wording), then assert **every** path you changed, by the right check for
+   each — a partial loss commits cleanly, and checking one path only proves that path
+   survived. Three cases, and one does not substitute for another:
+   - **gained content** — `git show "HEAD:$f" >"$_chk"` then `grep -q '<new phrase>' "$_chk"`
+   - **removal-only, file retained** — same capture, then grep must NOT match; a spec edit
+     that only deletes text has no new phrase, and grepping surviving text passes even when
+     the removal was reverted
+   - **whole file deleted** — `git show "HEAD:$f"` must FAIL; running it through the
+     positive check rejects a correct commit
+
+   Capture to a file rather than piping: `git show ... | grep -q` returns 141 under
+   `pipefail` when grep exits early and git show takes SIGPIPE, which reads as "no match".
+   A clean `git status` is none of these checks. See
    [multi-reviewer-loop/references/reviewer-panel.md](../../multi-reviewer-loop/references/reviewer-panel.md).
 5. For plan-shaped work, `plan-eng-review` / `plan-ceo-review` add a product lens.
 

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -32,6 +32,13 @@ Treat that as the default for anything non-trivial.
    # no PROMPT arg when --base is used — they are mutually exclusive
    ```
 4. Apply findings, re-commit, re-review. Loop until a pass returns no P0/P1.
+   **Apply nothing until the review process has exited.** An edit to a tracked file
+   while `codex review` is running is silently destroyed and the loss reads as a
+   *successful* commit — `nothing to commit, working tree clean`, with the content
+   gone from the file and from `HEAD`. On re-commit, assert the content landed
+   (`git show HEAD:<file> | grep -c '<phrase>'`), not the exit code; a clean `git
+   status` cannot tell the two apart. See
+   [multi-reviewer-loop/references/reviewer-panel.md](../../multi-reviewer-loop/references/reviewer-panel.md).
 5. For plan-shaped work, `plan-eng-review` / `plan-ceo-review` add a product lens.
 
 **Exit gate:** spec committed **and** a codex xhigh pass returns no P0/P1. Quote the pass.
@@ -203,7 +210,9 @@ phase whose entire job is to establish that the instrument works.
      -c 'model="gpt-5.6-sol"' -c 'model_reasoning_effort="xhigh"'
    ```
    Budget ~2 fix rounds of narrow P2 edges on delicate paths, then hold the line and
-   surface further P2s to the user rather than auto-chasing them.
+   surface further P2s to the user rather than auto-chasing them. As in SPEC, do not
+   edit while that review is in flight — the edit is destroyed silently and the failed
+   commit looks like a successful one.
 
 Re-verify the build and tests yourself after every fix round. **And re-run the panel after
 any final-gate fix** — once you change code, the earlier clean verdicts no longer cover the

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -37,9 +37,10 @@ Treat that as the default for anything non-trivial.
    have carried it prints `nothing to commit, working tree clean` with the content
    gone from the file and from `HEAD`. On re-commit take both checks that message
    hides: require `git commit` to exit 0 (it exits **1** on an empty commit, however
-   reassuring the wording), then assert the content with
-   `git show HEAD:<file> | grep -c '<phrase>'` — a partial loss commits cleanly. A
-   clean `git status` is neither check. See
+   reassuring the wording), then assert the content of **every** file you changed with
+   `git show "HEAD:$f" | grep -q '<a phrase from that file>'` — a partial loss commits
+   cleanly, and checking one path only proves that path survived. A clean `git status`
+   is neither check. See
    [multi-reviewer-loop/references/reviewer-panel.md](../../multi-reviewer-loop/references/reviewer-panel.md).
 5. For plan-shaped work, `plan-eng-review` / `plan-ceo-review` add a product lens.
 

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -40,10 +40,14 @@ Treat that as the default for anything non-trivial.
    reassuring the wording), then assert **every** path you changed, by the right check for
    each — a partial loss commits cleanly, and checking one path only proves that path
    survived. Three cases, and one does not substitute for another:
-   - **gained content** — `git show "HEAD:$f" >"$_chk"` then `grep -q '<new phrase>' "$_chk"`
-   - **removal-only, file retained** — same capture, then grep must NOT match; a spec edit
-     that only deletes text has no new phrase, and grepping surviving text passes even when
-     the removal was reverted
+   - **gained content** — `git show "HEAD:$f" >"$_chk"` then
+     `grep -Fq -- '<new phrase>' "$_chk"`. `-F` because `grep` defaults to basic regex, so
+     a phrase containing `[`, `.` or `*` will not match itself; `--` because one starting
+     with `-` parses as an option.
+   - **removal-only, file retained** — same capture, then compare the EXPECTED REMAINING
+     COUNT: `grep -Fo -- '<deleted phrase>' "$_chk" | wc -l`. Not absence, which rejects a
+     correct commit that removed one of several identical lines; and not `grep -c`, which
+     counts matching *lines* rather than occurrences.
    - **whole file deleted** — `git show "HEAD:$f"` must FAIL; running it through the
      positive check rejects a correct commit
 

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -407,6 +407,15 @@ For each pass `N` from `1` to `MAX_PASSES`:
    for _p in "$CODEX_PID" "$FABLE_PID"; do
      kill "$_p" 2>/dev/null || true        # never `pkill -f`; already-exited is fine
    done
+   # Bounded escalation. Signalling the `timeout` wrapper from outside forwards TERM but does
+   # NOT start its --kill-after timer, so a reviewer that ignores TERM leaves wrapper and
+   # child alive and the waits below block until the original 1500s deadline — which is
+   # exactly the hung-reviewer case this hatch exists for. Give it a few seconds, then KILL
+   # the process group.
+   sleep 5
+   for _p in "$CODEX_PID" "$FABLE_PID"; do
+     kill -0 "$_p" 2>/dev/null && kill -KILL -- "-$_p" 2>/dev/null || true
+   done
    CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # reaping is what closes the window
    FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?
    ```

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -395,14 +395,20 @@ For each pass `N` from `1` to `MAX_PASSES`:
    clean` with the content absent from the file and from `HEAD`. Backgrounding
    both reviewers is exactly what puts this loop in the hazard window: codex's
    findings are readable while Fable is still running, and acting on them there
-   is how the work disappears. If you must edit sooner, kill that reviewer by the
-   PID you captured at launch and **then reap it** — `kill` only *sends* SIGTERM
+   is how the work disappears. If you must edit sooner, kill **both** reviewers by the
+   PIDs you captured at launch and **then reap them** — `kill` only *sends* SIGTERM
    and returns immediately, so the wrapper and the reviewer are still shutting
    down when it comes back, and an edit right after is still inside the window:
 
    ```bash
-   kill "$CODEX_PID" 2>/dev/null || true          # never `pkill -f`; already-exited is fine
+   # BOTH reviewers, not just codex. The hatch abandons the pass, and this section's own
+   # rule is that every reviewer has exited before you edit — leaving Fable alive holds a
+   # Bash-capable process against the tree you are about to change, and unreaped besides.
+   for _p in "$CODEX_PID" "$FABLE_PID"; do
+     kill "$_p" 2>/dev/null || true        # never `pkill -f`; already-exited is fine
+   done
    CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # reaping is what closes the window
+   FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?
    ```
 
    Both `||`s are load-bearing under `set -e`, and they guard different moments.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -389,6 +389,17 @@ For each pass `N` from `1` to `MAX_PASSES`:
    value is two *independent* reads. Feeding codex's findings into the Claude
    reviewer's prompt collapses it into an echo chamber.
 
+   **Do not edit the repo until both `wait`s have returned.** An edit made to a
+   tracked file while `codex review` is in flight is silently destroyed, and the
+   loss presents as a *successful* commit (`nothing to commit, working tree
+   clean`) with the content absent from the file and from `HEAD`. Backgrounding
+   both reviewers is exactly what puts this loop in the hazard window: codex's
+   findings are readable while Fable is still running, and acting on them there
+   is how the work disappears. If you must edit sooner, `pkill -f "codex review"`
+   first and accept the lost pass. Full detail, the commit-time assertion, and
+   the probe that gives a false all-clear are in
+   [references/reviewer-panel.md](references/reviewer-panel.md).
+
 2. Unwrap the Claude reviewer's JSON into a plain findings file with `jq`, and
    parse findings from both reviewers with the shared pattern in
    [references/reviewer-panel.md](references/reviewer-panel.md) § Parsing findings.
@@ -453,6 +464,13 @@ For each pass `N` from `1` to `MAX_PASSES`:
    reviewer output into the conversation unless the user asks.
 
 ### 3. Fix and validate
+
+**Entry condition: every reviewer has exited.** Not "codex has finished and I can
+see its findings" — both `wait`s returned. Editing a tracked file while `codex
+review` is still running destroys the edit silently (§ 2), so the first fix of
+this phase cannot legally start until the last reviewer of the previous one is
+dead. This is an ordering rule, not a preference; the skill tells you to run the
+reviewers in parallel, which is precisely what makes the early-start tempting.
 
 If every panel reviewer is clean, go to § 4b (the consistency pass) — not
 straight to "Finish". A clean diff is the entry condition for that phase, not

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -361,11 +361,11 @@ For each pass `N` from `1` to `MAX_PASSES`:
    PASS_ID=$(printf '%02d' "$N")
    TO=$(command -v timeout || command -v gtimeout) \
      || { echo "no GNU timeout — see references/reviewer-panel.md"; exit 1; }
-   "$TO" --kill-after=60 1500 codex review --base "$DIFF_BASE" \
+   setsid "$TO" --kill-after=60 1500 codex review --base "$DIFF_BASE" \
      -c 'model="gpt-5.6-sol"' -c 'model_reasoning_effort="xhigh"' \
      </dev/null >"$REVIEW_DIR/pass-${PASS_ID}.codex.txt" 2>"$REVIEW_DIR/pass-${PASS_ID}.codex.stderr.txt" &
    CODEX_PID=$!
-   "$TO" --kill-after=60 1500 \
+   setsid "$TO" --kill-after=60 1500 \
      claude -p "$(cat "$FABLE_PROMPT_FILE")" --model fable --effort high --output-format json \
      --tools "Bash,Read,Glob,Grep" --allowedTools "Bash,Read,Glob,Grep" \
      --disallowedTools "Edit,Write,NotebookEdit" \

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -401,14 +401,17 @@ For each pass `N` from `1` to `MAX_PASSES`:
    down when it comes back, and an edit right after is still inside the window:
 
    ```bash
-   kill "$CODEX_PID"                        # never `pkill -f` — it matches your own shell
+   kill "$CODEX_PID" 2>/dev/null || true          # never `pkill -f`; already-exited is fine
    CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # reaping is what closes the window
    ```
 
-   `|| CODEX_RC=$?`, for the same reason § 2's own `wait`s use it: a TERM-killed
-   process makes `wait` return **143**, and under `set -e` a bare `wait` exits the
-   shell right there — before you reach the edit this hatch exists for, and with
-   Fable still unreaped in the background.
+   Both `||`s are load-bearing under `set -e`, and they guard different moments.
+   `kill` fails if codex exited on its own between your decision and the signal —
+   a race you cannot exclude — so an unguarded `kill` exits the shell before the
+   `wait`. And `wait` on a TERM-killed process returns **143**, so an unguarded
+   `wait` exits it before the edit this hatch exists for. Either way Fable is left
+   running unreaped. § 2's own `wait`s carry the same `|| VAR=$?` for the same
+   reason.
 
    Then accept the lost pass. Full detail, the commit-time assertion, and the
    probe that gives a false all-clear are in

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -401,9 +401,14 @@ For each pass `N` from `1` to `MAX_PASSES`:
    down when it comes back, and an edit right after is still inside the window:
 
    ```bash
-   kill "$CODEX_PID"          # never `pkill -f` — it matches your own shell
-   wait "$CODEX_PID"          # THIS is what makes the window closed
+   kill "$CODEX_PID"                        # never `pkill -f` — it matches your own shell
+   CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # reaping is what closes the window
    ```
+
+   `|| CODEX_RC=$?`, for the same reason § 2's own `wait`s use it: a TERM-killed
+   process makes `wait` return **143**, and under `set -e` a bare `wait` exits the
+   shell right there — before you reach the edit this hatch exists for, and with
+   Fable still unreaped in the background.
 
    Then accept the lost pass. Full detail, the commit-time assertion, and the
    probe that gives a false all-clear are in

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -396,9 +396,17 @@ For each pass `N` from `1` to `MAX_PASSES`:
    both reviewers is exactly what puts this loop in the hazard window: codex's
    findings are readable while Fable is still running, and acting on them there
    is how the work disappears. If you must edit sooner, kill that reviewer by the
-   PID you captured at launch (`kill "$CODEX_PID"` — never `pkill -f`, which
-   matches your own shell) and accept the lost pass. Full detail, the commit-time
-   assertion, and the probe that gives a false all-clear are in
+   PID you captured at launch and **then reap it** — `kill` only *sends* SIGTERM
+   and returns immediately, so the wrapper and the reviewer are still shutting
+   down when it comes back, and an edit right after is still inside the window:
+
+   ```bash
+   kill "$CODEX_PID"          # never `pkill -f` — it matches your own shell
+   wait "$CODEX_PID"          # THIS is what makes the window closed
+   ```
+
+   Then accept the lost pass. Full detail, the commit-time assertion, and the
+   probe that gives a false all-clear are in
    [references/reviewer-panel.md](references/reviewer-panel.md).
 
 2. Unwrap the Claude reviewer's JSON into a plain findings file with `jq`, and

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -358,14 +358,17 @@ For each pass `N` from `1` to `MAX_PASSES`:
    [references/reviewer-panel.md](references/reviewer-panel.md). The shape is:
 
    ```bash
+   set -m          # each reviewer in its own process group; the escape hatch needs it.
+                   # `set -m`, not `setsid` — that is util-linux and absent on macOS,
+                   # which this skill supports. See references/reviewer-panel.md.
    PASS_ID=$(printf '%02d' "$N")
    TO=$(command -v timeout || command -v gtimeout) \
      || { echo "no GNU timeout — see references/reviewer-panel.md"; exit 1; }
-   setsid "$TO" --kill-after=60 1500 codex review --base "$DIFF_BASE" \
+   "$TO" --kill-after=60 1500 codex review --base "$DIFF_BASE" \
      -c 'model="gpt-5.6-sol"' -c 'model_reasoning_effort="xhigh"' \
      </dev/null >"$REVIEW_DIR/pass-${PASS_ID}.codex.txt" 2>"$REVIEW_DIR/pass-${PASS_ID}.codex.stderr.txt" &
    CODEX_PID=$!
-   setsid "$TO" --kill-after=60 1500 \
+   "$TO" --kill-after=60 1500 \
      claude -p "$(cat "$FABLE_PROMPT_FILE")" --model fable --effort high --output-format json \
      --tools "Bash,Read,Glob,Grep" --allowedTools "Bash,Read,Glob,Grep" \
      --disallowedTools "Edit,Write,NotebookEdit" \

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -391,13 +391,14 @@ For each pass `N` from `1` to `MAX_PASSES`:
 
    **Do not edit the repo until both `wait`s have returned.** An edit made to a
    tracked file while `codex review` is in flight is silently destroyed, and the
-   loss presents as a *successful* commit (`nothing to commit, working tree
-   clean`) with the content absent from the file and from `HEAD`. Backgrounding
+   commit that should have carried it prints `nothing to commit, working tree
+   clean` with the content absent from the file and from `HEAD`. Backgrounding
    both reviewers is exactly what puts this loop in the hazard window: codex's
    findings are readable while Fable is still running, and acting on them there
-   is how the work disappears. If you must edit sooner, `pkill -f "codex review"`
-   first and accept the lost pass. Full detail, the commit-time assertion, and
-   the probe that gives a false all-clear are in
+   is how the work disappears. If you must edit sooner, kill that reviewer by the
+   PID you captured at launch (`kill "$CODEX_PID"` — never `pkill -f`, which
+   matches your own shell) and accept the lost pass. Full detail, the commit-time
+   assertion, and the probe that gives a false all-clear are in
    [references/reviewer-panel.md](references/reviewer-panel.md).
 
 2. Unwrap the Claude reviewer's JSON into a plain findings file with `jq`, and

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -157,14 +157,21 @@ the exact PID captured at launch, then reap it**, and accept the lost pass:
 
 ```bash
 kill "$CODEX_PID"
-wait "$CODEX_PID"     # kill only SENDS the signal; this is what waits for it
+CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # kill only SENDS; this waits for it
 ```
 
 The `wait` is not decoration. `kill` returns as soon as SIGTERM is delivered, so
 the `timeout` wrapper and the reviewer beneath it are still tearing down when it
 does — and an edit made in that gap is inside the very window the kill was meant
-to close. Not `pkill -f "codex review"` either: that matches your own shell and
-other sessions' reviewers running the same command, per the rule below.
+to close.
+
+The `|| CODEX_RC=$?` is not decoration either, and it is the same rule as the
+`wait`s under "Running the panel": a TERM-killed process makes `wait` return
+**143**, so under `set -e` a bare `wait` exits the shell *at that line* — before
+the edit this hatch exists for, and with Fable still running unreaped.
+
+Not `pkill -f "codex review"` either: that matches your own shell and other
+sessions' reviewers running the same command, per the rule below.
 
 This loop is the most exposed skill in the repo to it: § 2 backgrounds both
 reviewers *by design*, and § 3 is entirely about editing. An agent that starts on
@@ -196,8 +203,17 @@ Then still assert the content, because a *partial* loss commits cleanly at exit
 0 — some files reverted, others not, one real commit carrying half the fix:
 
 ```bash
-for f in <every file the fix touched>; do
+# The commit's own file list first — every path you touched, and nothing you did not.
+git show --stat --format= HEAD
+# Each file that should CONTAIN the change:
+for f in <every file the fix touched that gained or changed content>; do
   git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
+# Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
+# design on a deleted path, so folding deletions into the loop above marks every correct
+# deletion as a loss:
+for f in <every path the change deletes>; do
+  git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
 done
 ```
 

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -153,9 +153,18 @@ non-zero exit.
 **An edit made to a tracked file while `codex review` is in flight is silently
 destroyed.** Both reviewers must have exited — `wait` returned for each PID —
 before you change a single file. If you must edit sooner, kill the reviewer **by
-the exact PID captured at launch** — `kill "$CODEX_PID"` — and accept the lost
-pass. Not `pkill -f "codex review"`: that matches your own shell and other
-sessions' reviewers running the same command, per the rule below.
+the exact PID captured at launch, then reap it**, and accept the lost pass:
+
+```bash
+kill "$CODEX_PID"
+wait "$CODEX_PID"     # kill only SENDS the signal; this is what waits for it
+```
+
+The `wait` is not decoration. `kill` returns as soon as SIGTERM is delivered, so
+the `timeout` wrapper and the reviewer beneath it are still tearing down when it
+does — and an edit made in that gap is inside the very window the kill was meant
+to close. Not `pkill -f "codex review"` either: that matches your own shell and
+other sessions' reviewers running the same command, per the rule below.
 
 This loop is the most exposed skill in the repo to it: § 2 backgrounds both
 reviewers *by design*, and § 3 is entirely about editing. An agent that starts on
@@ -187,7 +196,9 @@ Then still assert the content, because a *partial* loss commits cleanly at exit
 0 — some files reverted, others not, one real commit carrying half the fix:
 
 ```bash
-git show HEAD:path/to/file | grep -c "<distinctive phrase from the fix>"   # must be >0
+for f in <every file the fix touched>; do
+  git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
 ```
 
 A clean `git status` is neither check. It is equally consistent with the edits

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -217,19 +217,20 @@ Then still assert the content, because a *partial* loss commits cleanly at exit
 
 ```bash
 # The commit's own file list first — every path you touched, and nothing you did not.
+_chk=$(mktemp)
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the fix touched that gained or changed content>; do
-  git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
+  grep -q "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
 for f in <every file you removed lines from>; do
   # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
   # is skipped — an accidental whole-file deletion reads identically to a clean removal.
-  git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
-  git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
-    && { echo "$f still contains text this change removed"; exit 1; }
+  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
+  grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -217,22 +217,27 @@ Then still assert the content, because a *partial* loss commits cleanly at exit
 
 ```bash
 # The commit's own file list first — every path you touched, and nothing you did not.
-_chk=$(mktemp)
+_chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the fix touched that gained or changed content>; do
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
   grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
-# Removal-only edits have no new phrase to find, and any surviving phrase passes even if
-# the removal was reverted. Assert the removed text is GONE:
+# Removal-only edits have no new phrase to find, and any surviving phrase passes even
+# if the removal was reverted. Assert the EXPECTED REMAINING COUNT — not absence,
+# which rejects a correct partial removal:
 for f in <every file you removed lines from>; do
-  # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
-  # is skipped — an accidental whole-file deletion reads identically to a clean removal.
+  # Existence FIRST: `git show HEAD:<gone>` fails, and without this assert an
+  # accidental whole-file deletion would reach the count check with an empty file
+  # and read as a clean removal. Whole-file deletions belong in the absence loop
+  # below, never here.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
-  # COUNT, not absence: removing one of several identical lines legitimately leaves
-  # the phrase behind, and demanding zero rejects that correct commit.
+  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
+  # hits on one line count as one), and not absence: removing one of several
+  # identical lines legitimately leaves the phrase behind, and demanding zero
+  # rejects that correct commit.
   [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
     || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
 done

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -148,6 +148,58 @@ full timeout on the same hung reviewer. Record it, drop
 that reviewer from the pass, and mark the pass `DEGRADED` — the same as any other
 non-zero exit.
 
+### Do not touch the repo while `codex review` is running
+
+**An edit made to a tracked file while `codex review` is in flight is silently
+destroyed.** Both reviewers must have exited — `wait` returned for each PID —
+before you change a single file. If you must edit sooner, `pkill -f "codex
+review"` first and accept the lost pass.
+
+This loop is the most exposed skill in the repo to it: § 2 backgrounds both
+reviewers *by design*, and § 3 is entirely about editing. An agent that starts on
+codex's findings while Fable is still running is inside the hazard window with
+no warning.
+
+The loss does not present as a failure. It presents as a **successful commit**:
+
+```console
+$ git add -A && git commit -m "fix the retry path"
+nothing to commit, working tree clean
+```
+
+— which is indistinguishable from "already committed". `git status` is clean and
+the content is gone from both the working file and `HEAD`. Observed twice on a
+money-path branch, both times after the edits had been applied, verified on disk
+with `grep -c`, and compiled green (clippy clean, 867 tests passing). Gates that
+passed *before* the loss are not evidence.
+
+So when you commit a fix, **assert the content landed, not the exit code**:
+
+```bash
+git show HEAD:path/to/file | grep -c "<distinctive phrase from the fix>"   # must be >0
+```
+
+A clean `git status` is not that assertion — it is equally consistent with the
+edits having been reverted underneath you.
+
+**If you re-test this, do not plant the marker first.** An edit made *before* the
+review starts survives: it disappears mid-run and comes back at the end. Only
+edits made *during* the run are lost. A probe planted early returns a null result
+and would tell the next reader the tool is safe — a worse error than the original.
+Plant it with the review confirmed running (`ps -eo pid,args | grep '[c]odex
+review'`), then re-check on disk before the run ends:
+
+```
+planted mid-run                  count=1
+t=125s, still inside the review  count=0
+```
+
+The mechanism is not established. `git stash list`, `git reflog` and `git
+worktree list` show no trace, and codex's own 1.4 MB transcript contains only
+`git diff` and `git show` — no stash, checkout, reset, or worktree. "Restores a
+snapshot taken at start" fits every observation but was never confirmed at the
+implementation level. The rule above does not depend on which mechanism is right.
+
 ### When a pass looks stuck
 
 Check elapsed time against the 5-15 minute norm before assuming progress:

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -204,51 +204,25 @@ exits **1**, so check it — an unchecked `git add -A && git commit` inside a
 larger block is how the message gets believed and the failure walks:
 
 ```bash
-git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it
-git diff --cached                            # sweeps in unrelated work. And READ this:
-                                             # on a path that was ALREADY dirty, staging
-                                             # it by name still takes the other agent's
-                                             # hunks in that same file.
+git add -- <every path this change touched>   # not `git add -A`: on a dirty tree it
+git diff --cached                            # sweeps in unrelated work — and READ this,
+                                             # since staging a path that was already
+                                             # dirty takes the other agent's hunks too
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+git show --stat --format= HEAD               # all the paths you meant, and only those
 ```
 
-Then still assert the content, because a *partial* loss commits cleanly at exit
-0 — some files reverted, others not, one real commit carrying half the fix:
+Then confirm the *content* landed, per file, by the check that fits it — a file that
+gained content must contain a distinctive new phrase; a file you only removed lines from
+must still exist **and** hold the expected remaining count of the deleted phrase; a
+deleted path must be absent. One does not substitute for another, and each has a way to
+lie: `grep` defaults to regex (use `-Fq --`), `git show ... | grep` returns 141 under
+`pipefail` when grep exits early (capture to a file first), `grep -c` counts lines rather
+than occurrences, and demanding *zero* occurrences rejects a correct partial removal.
 
 ```bash
-# The commit's own file list first — every path you touched, and nothing you did not.
 _chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
-git show --stat --format= HEAD
-# Each file that should CONTAIN the change:
-for f in <every file the fix touched that gained or changed content>; do
-  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-  grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
-done
-# Removal-only edits have no new phrase to find, and any surviving phrase passes even
-# if the removal was reverted. Assert the EXPECTED REMAINING COUNT — not absence,
-# which rejects a correct partial removal:
-for f in <every file you removed lines from>; do
-  # Existence FIRST: `git show HEAD:<gone>` fails, and without this assert an
-  # accidental whole-file deletion would reach the count check with an empty file
-  # and read as a clean removal. Whole-file deletions belong in the absence loop
-  # below, never here.
-  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
-  # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
-  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
-  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
-  # hits on one line count as one), and not absence: removing one of several
-  # identical lines legitimately leaves the phrase behind, and demanding zero
-  # rejects that correct commit.
-  [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
-    || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
-done
-# Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
-# design on a deleted path, so folding deletions into the loop above marks every correct
-# deletion as a loss:
-for f in <every path the change deletes>; do
-  git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
-done
+# ...the three loops, using `grep -Fq --` / `grep -Fo | wc -l || true` on a captured file.
 ```
 
 A clean `git status` is neither check. It is equally consistent with the edits

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -156,7 +156,7 @@ before you change a single file. If you must edit sooner, kill the reviewer **by
 the exact PID captured at launch, then reap it**, and accept the lost pass:
 
 ```bash
-kill "$CODEX_PID"
+kill "$CODEX_PID" 2>/dev/null || true   # already exited is fine, and not fatal
 CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # kill only SENDS; this waits for it
 ```
 
@@ -165,10 +165,12 @@ the `timeout` wrapper and the reviewer beneath it are still tearing down when it
 does — and an edit made in that gap is inside the very window the kill was meant
 to close.
 
-The `|| CODEX_RC=$?` is not decoration either, and it is the same rule as the
-`wait`s under "Running the panel": a TERM-killed process makes `wait` return
-**143**, so under `set -e` a bare `wait` exits the shell *at that line* — before
-the edit this hatch exists for, and with Fable still running unreaped.
+Neither `||` is decoration, and they guard different moments. `kill` fails when
+codex exited on its own between your decision and the signal — a race you cannot
+exclude — so an unguarded `kill` exits the shell before the `wait` ever runs. And
+`wait` on a TERM-killed process returns **143**, so an unguarded `wait` exits it
+before the edit this hatch exists for. Either way Fable is left running unreaped.
+Same rule as the `wait`s under "Running the panel".
 
 Not `pkill -f "codex review"` either: that matches your own shell and other
 sessions' reviewers running the same command, per the rule below.
@@ -196,7 +198,8 @@ exits **1**, so check it — an unchecked `git add -A && git commit` inside a
 larger block is how the message gets believed and the failure walks:
 
 ```bash
-git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it sweeps
+git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }   # in unrelated work
 ```
 
 Then still assert the content, because a *partial* loss commits cleanly at exit
@@ -208,6 +211,12 @@ git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the fix touched that gained or changed content>; do
   git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
+# Removal-only edits have no new phrase to find, and any surviving phrase passes even if
+# the removal was reverted. Assert the removed text is GONE:
+for f in <every file you removed lines from>; do
+  git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
+    && { echo "$f still contains text this change removed"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -222,7 +222,7 @@ git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the fix touched that gained or changed content>; do
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-  grep -q "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
+  grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
@@ -230,7 +230,11 @@ for f in <every file you removed lines from>; do
   # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
   # is skipped — an accidental whole-file deletion reads identically to a clean removal.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
+  _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
+  # COUNT, not absence: removing one of several identical lines legitimately leaves
+  # the phrase behind, and demanding zero rejects that correct commit.
+  [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
+    || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -152,12 +152,18 @@ non-zero exit.
 
 **An edit made to a tracked file while `codex review` is in flight is silently
 destroyed.** Both reviewers must have exited — `wait` returned for each PID —
-before you change a single file. If you must edit sooner, kill the reviewer **by
-the exact PID captured at launch, then reap it**, and accept the lost pass:
+before you change a single file. If you must edit sooner, kill **both** reviewers **by
+the exact PIDs captured at launch, then reap them**, and accept the lost pass:
 
 ```bash
-kill "$CODEX_PID" 2>/dev/null || true   # already exited is fine, and not fatal
-CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # kill only SENDS; this waits for it
+# BOTH reviewers, not just codex. The hatch abandons the pass, and this section's own
+# rule is that every reviewer has exited before you edit — leaving Fable alive holds a
+# Bash-capable process against the tree you are about to change, and unreaped besides.
+for _p in "$CODEX_PID" "$FABLE_PID"; do
+  kill "$_p" 2>/dev/null || true        # never `pkill -f`; already-exited is fine
+done
+CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # reaping is what closes the window
+FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?
 ```
 
 The `wait` is not decoration. `kill` returns as soon as SIGTERM is delivered, so

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -213,9 +213,11 @@ git show --stat --format= HEAD               # all the paths you meant, and only
 ```
 
 Then confirm the *content* landed, per file, by the check that fits it — a file that
-gained content must contain a distinctive new phrase; a file you only removed lines from
-must still exist **and** hold the expected remaining count of the deleted phrase; a
-deleted path must be absent. One does not substitute for another, and each has a way to
+gained content must contain a distinctive new phrase; a file you removed lines from must
+still exist **and** hold the expected remaining count of the deleted phrase; a deleted path
+must be absent. A file that BOTH gained and lost content needs both of the first two — the
+added phrase passing says nothing about whether the removal survived. One does not
+substitute for another, and each has a way to
 lie: `grep` defaults to regex (use `-Fq --`), `git show ... | grep` returns 141 under
 `pipefail` when grep exits early (capture to a file first), `grep -c` counts lines rather
 than occurrences, and demanding *zero* occurrences rejects a correct partial removal.

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -134,6 +134,10 @@ CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?
 FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?
 ```
 
+The group-kill in the escape hatch needs each reviewer to be its own process-group
+leader — `set -m` before the two launches, or `setsid` on each — otherwise `kill -- -$PID`
+has no group to signal. Without that, the hatch degrades to the plain TERM above.
+
 **Do not drop the `timeout`.** Either reviewer can hang indefinitely — no output, no
 exit, no error. Measured: an unbounded consistency pass ran **6h20m and wrote zero
 bytes** while comparable calls finished in 5-15 minutes; nothing reaped it, and the
@@ -161,6 +165,15 @@ the exact PIDs captured at launch, then reap them**, and accept the lost pass:
 # Bash-capable process against the tree you are about to change, and unreaped besides.
 for _p in "$CODEX_PID" "$FABLE_PID"; do
   kill "$_p" 2>/dev/null || true        # never `pkill -f`; already-exited is fine
+done
+# Bounded escalation. Signalling the `timeout` wrapper from outside forwards TERM but does
+# NOT start its --kill-after timer, so a reviewer that ignores TERM leaves wrapper and
+# child alive and the waits below block until the original 1500s deadline — which is
+# exactly the hung-reviewer case this hatch exists for. Give it a few seconds, then KILL
+# the process group.
+sleep 5
+for _p in "$CODEX_PID" "$FABLE_PID"; do
+  kill -0 "$_p" 2>/dev/null && kill -KILL -- "-$_p" 2>/dev/null || true
 done
 CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?   # reaping is what closes the window
 FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -152,35 +152,46 @@ non-zero exit.
 
 **An edit made to a tracked file while `codex review` is in flight is silently
 destroyed.** Both reviewers must have exited — `wait` returned for each PID —
-before you change a single file. If you must edit sooner, `pkill -f "codex
-review"` first and accept the lost pass.
+before you change a single file. If you must edit sooner, kill the reviewer **by
+the exact PID captured at launch** — `kill "$CODEX_PID"` — and accept the lost
+pass. Not `pkill -f "codex review"`: that matches your own shell and other
+sessions' reviewers running the same command, per the rule below.
 
 This loop is the most exposed skill in the repo to it: § 2 backgrounds both
 reviewers *by design*, and § 3 is entirely about editing. An agent that starts on
 codex's findings while Fable is still running is inside the hazard window with
 no warning.
 
-The loss does not present as a failure. It presents as a **successful commit**:
+What the loss looks like is a commit whose *message* reads like a no-op:
 
 ```console
 $ git add -A && git commit -m "fix the retry path"
 nothing to commit, working tree clean
 ```
 
-— which is indistinguishable from "already committed". `git status` is clean and
-the content is gone from both the working file and `HEAD`. Observed twice on a
-money-path branch, both times after the edits had been applied, verified on disk
-with `grep -c`, and compiled green (clippy clean, 867 tests passing). Gates that
-passed *before* the loss are not evidence.
+That text is indistinguishable from "already committed", `git status` is clean,
+and the content is gone from both the working file and `HEAD`. Observed twice on
+a money-path branch, both times after the edits had been applied, verified on
+disk with `grep -c`, and compiled green (clippy clean, 867 tests passing). Gates
+that passed *before* the loss are not evidence.
 
-So when you commit a fix, **assert the content landed, not the exit code**:
+**The prose lies; the exit code does not.** `git commit` with nothing staged
+exits **1**, so check it — an unchecked `git add -A && git commit` inside a
+larger block is how the message gets believed and the failure walks:
+
+```bash
+git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+```
+
+Then still assert the content, because a *partial* loss commits cleanly at exit
+0 — some files reverted, others not, one real commit carrying half the fix:
 
 ```bash
 git show HEAD:path/to/file | grep -c "<distinctive phrase from the fix>"   # must be >0
 ```
 
-A clean `git status` is not that assertion — it is equally consistent with the
-edits having been reverted underneath you.
+A clean `git status` is neither check. It is equally consistent with the edits
+having been reverted underneath you.
 
 **If you re-test this, do not plant the marker first.** An edit made *before* the
 review starts survives: it disappears mid-run and comes back at the end. Only

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -233,7 +233,9 @@ for f in <every file you removed lines from>; do
   # and read as a clean removal. Whole-file deletions belong in the absence loop
   # below, never here.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
+  # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
+  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
   # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
   # hits on one line count as one), and not absence: removing one of several
   # identical lines legitimately leaves the phrase behind, and demanding zero

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -109,13 +109,13 @@ RC_TIMEOUT=1500   # 25 min; a normal pass is 5-15
 TO=$(command -v timeout || command -v gtimeout) \
   || { echo "no GNU timeout (nor gtimeout) — bound the pass another way; see below"; exit 1; }
 
-"$TO" --kill-after=60 "$RC_TIMEOUT" \
+setsid "$TO" --kill-after=60 "$RC_TIMEOUT" \
   codex review --base "$DIFF_BASE" \
   -c 'model="gpt-5.6-sol"' -c 'model_reasoning_effort="xhigh"' \
   </dev/null >"$CODEX_OUT" 2>"$CODEX_ERR" &
 CODEX_PID=$!
 
-"$TO" --kill-after=60 "$RC_TIMEOUT" \
+setsid "$TO" --kill-after=60 "$RC_TIMEOUT" \
   claude -p "$(cat "$FABLE_PROMPT_FILE")" \
   --model fable \
   --effort high \
@@ -134,9 +134,13 @@ CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?
 FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?
 ```
 
-The group-kill in the escape hatch needs each reviewer to be its own process-group
-leader — `set -m` before the two launches, or `setsid` on each — otherwise `kill -- -$PID`
-has no group to signal. Without that, the hatch degrades to the plain TERM above.
+**`setsid` on each launch is load-bearing**, not decoration. It makes each reviewer its own
+process-group leader, which is what lets the escape hatch below signal the *group*. Without
+it the backgrounded processes inherit this shell's group, `kill -- -$PID` targets a group
+that does not exist, the failure is swallowed by the hatch's `|| true`, and a TERM-ignoring
+reviewer keeps the `wait` blocked until the full 1500-second timeout — the exact case the
+hatch exists for. (`set -m` before the launches is the alternative; this shell is
+non-interactive, so job control is off by default.)
 
 **Do not drop the `timeout`.** Either reviewer can hang indefinitely — no output, no
 exit, no error. Measured: an unbounded consistency pass ran **6h20m and wrote zero
@@ -587,7 +591,7 @@ files:
 ```bash
 TO=$(command -v timeout || command -v gtimeout) \
   || { echo "no GNU timeout — see the panel invocation above"; exit 1; }
-"$TO" --kill-after=60 1500 \
+setsid "$TO" --kill-after=60 1500 \
   claude -p "$(cat "$REVIEW_DIR/fable-consistency-prompt.txt")" \
   --model fable --effort high --output-format json \
   --tools "Bash,Read,Glob,Grep" --allowedTools "Bash,Read,Glob,Grep" \

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -204,8 +204,12 @@ exits **1**, so check it — an unchecked `git add -A && git commit` inside a
 larger block is how the message gets believed and the failure walks:
 
 ```bash
-git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it sweeps
-git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }   # in unrelated work
+git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it
+git diff --cached                            # sweeps in unrelated work. And READ this:
+                                             # on a path that was ALREADY dirty, staging
+                                             # it by name still takes the other agent's
+                                             # hunks in that same file.
+git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 ```
 
 Then still assert the content, because a *partial* loss commits cleanly at exit
@@ -221,6 +225,9 @@ done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
 for f in <every file you removed lines from>; do
+  # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
+  # is skipped — an accidental whole-file deletion reads identically to a clean removal.
+  git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
   git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
     && { echo "$f still contains text this change removed"; exit 1; }
 done

--- a/skills/multi-reviewer-loop/references/reviewer-panel.md
+++ b/skills/multi-reviewer-loop/references/reviewer-panel.md
@@ -103,19 +103,29 @@ returns non-zero when `FOCUS` is unset, which aborts the whole group under
 Both reviewers start together and neither sees the other's output.
 
 ```bash
+# Job control ON, before the launches. It puts each backgrounded reviewer in its OWN
+# process group, which is what lets the escape hatch below signal the group rather than
+# one pid. Verified: with `set -m` the child's PGID equals its PID and `kill -- -$PID`
+# succeeds; without it the child inherits this shell's group and the same kill fails with
+# "No such process" — swallowed by the hatch's `|| true`, so it looks like it escalated.
+#
+# `set -m`, NOT `setsid`: this skill supports macOS (that is what the `gtimeout` fallback
+# is for) and `setsid` is util-linux, absent there — prefixing the launches with it would
+# exit 127 before either reviewer starts, on a machine meeting every documented dependency.
+set -m
 RC_TIMEOUT=1500   # 25 min; a normal pass is 5-15
 # Homebrew coreutils installs GNU timeout as `gtimeout`; hardcoding `timeout` makes both
 # reviewers exit command-not-found on macOS and the loop can never reach clean.
 TO=$(command -v timeout || command -v gtimeout) \
   || { echo "no GNU timeout (nor gtimeout) — bound the pass another way; see below"; exit 1; }
 
-setsid "$TO" --kill-after=60 "$RC_TIMEOUT" \
+"$TO" --kill-after=60 "$RC_TIMEOUT" \
   codex review --base "$DIFF_BASE" \
   -c 'model="gpt-5.6-sol"' -c 'model_reasoning_effort="xhigh"' \
   </dev/null >"$CODEX_OUT" 2>"$CODEX_ERR" &
 CODEX_PID=$!
 
-setsid "$TO" --kill-after=60 "$RC_TIMEOUT" \
+"$TO" --kill-after=60 "$RC_TIMEOUT" \
   claude -p "$(cat "$FABLE_PROMPT_FILE")" \
   --model fable \
   --effort high \
@@ -134,13 +144,10 @@ CODEX_RC=0; wait "$CODEX_PID" || CODEX_RC=$?
 FABLE_RC=0; wait "$FABLE_PID" || FABLE_RC=$?
 ```
 
-**`setsid` on each launch is load-bearing**, not decoration. It makes each reviewer its own
-process-group leader, which is what lets the escape hatch below signal the *group*. Without
-it the backgrounded processes inherit this shell's group, `kill -- -$PID` targets a group
-that does not exist, the failure is swallowed by the hatch's `|| true`, and a TERM-ignoring
-reviewer keeps the `wait` blocked until the full 1500-second timeout — the exact case the
-hatch exists for. (`set -m` before the launches is the alternative; this shell is
-non-interactive, so job control is off by default.)
+**The `set -m` above is load-bearing**, not decoration: it is what makes the escape hatch's
+group-kill able to reach anything. Without it a TERM-ignoring reviewer keeps the `wait`
+blocked for the full 1500 seconds — the exact case the hatch exists for — and the failed
+group-kill is swallowed by its `|| true`, so it looks like it worked.
 
 **Do not drop the `timeout`.** Either reviewer can hang indefinitely — no output, no
 exit, no error. Measured: an unbounded consistency pass ran **6h20m and wrote zero
@@ -591,7 +598,7 @@ files:
 ```bash
 TO=$(command -v timeout || command -v gtimeout) \
   || { echo "no GNU timeout — see the panel invocation above"; exit 1; }
-setsid "$TO" --kill-after=60 1500 \
+"$TO" --kill-after=60 1500 \
   claude -p "$(cat "$REVIEW_DIR/fable-consistency-prompt.txt")" \
   --model fable --effort high --output-format json \
   --tools "Bash,Read,Glob,Grep" --allowedTools "Bash,Read,Glob,Grep" \

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -151,7 +151,9 @@ for f in <every file you removed lines from>; do
   # and read as a clean removal. Whole-file deletions belong in the absence loop
   # below, never here.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
+  # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
+  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
   # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
   # hits on one line count as one), and not absence: removing one of several
   # identical lines legitimately leaves the phrase behind, and demanding zero

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -121,19 +121,22 @@ this runs under `drive`; without it half the panel reviews without them.
 
 **The same prohibition binds you.** An edit made to a tracked file while `codex review`
 is running is silently destroyed, and rb-lite runs `codex review` inside every review
-round — so for the length of a run the repo is not yours to touch. The loss does not
-surface as an error; it surfaces as `nothing to commit, working tree clean` on a commit
-you expected to carry work, with the content absent from the file *and* from `HEAD`.
-Wait for the run to exit before editing anything, and when you commit the accepted diff
-(step 10.5) assert the content landed rather than trusting the exit code:
+round — so for the length of a run the repo is not yours to touch. The loss surfaces as
+`nothing to commit, working tree clean` on a commit you expected to carry work, with the
+content absent from the file *and* from `HEAD`. Wait for the run to exit before editing
+anything, and when you commit the accepted diff (step 10.5), check both things that
+message hides:
 
 ```bash
+git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 git show HEAD:path/to/file | grep -c "<distinctive phrase from the change>"   # must be >0
 ```
 
-A clean `git status` is not that assertion — it reads identically whether the work was
-committed or reverted underneath you. Detail, including the probe design that gives a
-false all-clear, is in
+`git commit` with nothing staged exits **1**, so the `||` catches a total loss however
+reassuring the message reads; the `grep` catches a partial one, which commits cleanly at
+exit 0 carrying only some of the change. A clean `git status` is neither check — it reads
+identically whether the work was committed or reverted underneath you. Detail, including
+the probe design that gives a false all-clear, is in
 [multi-reviewer-loop/references/reviewer-panel.md](../multi-reviewer-loop/references/reviewer-panel.md).
 
 "Customizing the panel" below shows the same two commands alongside OPTIONAL extras — a

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -129,7 +129,9 @@ message hides:
 
 ```bash
 git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-git show HEAD:path/to/file | grep -c "<distinctive phrase from the change>"   # must be >0
+for f in <every file the run changed>; do
+  git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
 ```
 
 `git commit` with nothing staged exits **1**, so the `||` catches a total loss however

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -129,8 +129,17 @@ message hides:
 
 ```bash
 git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-for f in <every file the run changed>; do
+# The commit's own file list first — every path you touched, and nothing you did not.
+git show --stat --format= HEAD
+# Each file that should CONTAIN the change:
+for f in <every file the run changed that gained or changed content>; do
   git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
+# Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
+# design on a deleted path, so folding deletions into the loop above marks every correct
+# deletion as a loss:
+for f in <every path the change deletes>; do
+  git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
 done
 ```
 

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -135,22 +135,27 @@ git diff --cached                            # sweeps in unrelated work. And REA
                                              # hunks in that same file.
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 # The commit's own file list first — every path you touched, and nothing you did not.
-_chk=$(mktemp)
+_chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the run changed that gained or changed content>; do
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
   grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
-# Removal-only edits have no new phrase to find, and any surviving phrase passes even if
-# the removal was reverted. Assert the removed text is GONE:
+# Removal-only edits have no new phrase to find, and any surviving phrase passes even
+# if the removal was reverted. Assert the EXPECTED REMAINING COUNT — not absence,
+# which rejects a correct partial removal:
 for f in <every file you removed lines from>; do
-  # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
-  # is skipped — an accidental whole-file deletion reads identically to a clean removal.
+  # Existence FIRST: `git show HEAD:<gone>` fails, and without this assert an
+  # accidental whole-file deletion would reach the count check with an empty file
+  # and read as a clean removal. Whole-file deletions belong in the absence loop
+  # below, never here.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
-  # COUNT, not absence: removing one of several identical lines legitimately leaves
-  # the phrase behind, and demanding zero rejects that correct commit.
+  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l)
+  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
+  # hits on one line count as one), and not absence: removing one of several
+  # identical lines legitimately leaves the phrase behind, and demanding zero
+  # rejects that correct commit.
   [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
     || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
 done

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -119,6 +119,23 @@ different trees — and any edit it made would bypass the implementer loop entir
 also told to read `AGENTS.md`, which is how a repo's own invariants reach the panel when
 this runs under `drive`; without it half the panel reviews without them.
 
+**The same prohibition binds you.** An edit made to a tracked file while `codex review`
+is running is silently destroyed, and rb-lite runs `codex review` inside every review
+round — so for the length of a run the repo is not yours to touch. The loss does not
+surface as an error; it surfaces as `nothing to commit, working tree clean` on a commit
+you expected to carry work, with the content absent from the file *and* from `HEAD`.
+Wait for the run to exit before editing anything, and when you commit the accepted diff
+(step 10.5) assert the content landed rather than trusting the exit code:
+
+```bash
+git show HEAD:path/to/file | grep -c "<distinctive phrase from the change>"   # must be >0
+```
+
+A clean `git status` is not that assertion — it reads identically whether the work was
+committed or reverted underneath you. Detail, including the probe design that gives a
+false all-clear, is in
+[multi-reviewer-loop/references/reviewer-panel.md](../multi-reviewer-loop/references/reviewer-panel.md).
+
 "Customizing the panel" below shows the same two commands alongside OPTIONAL extras — a
 skeptical third reviewer and a `my-linter --json | wrap-as-p-tags` placeholder — which are
 illustrative, not prerequisites. Pasting that block wholesale puts a command-not-found

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -128,8 +128,12 @@ anything, and when you commit the accepted diff (step 10.5), check both things t
 message hides:
 
 ```bash
-git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it sweeps
-git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }   # in unrelated work
+git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it
+git diff --cached                            # sweeps in unrelated work. And READ this:
+                                             # on a path that was ALREADY dirty, staging
+                                             # it by name still takes the other agent's
+                                             # hunks in that same file.
+git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 # The commit's own file list first — every path you touched, and nothing you did not.
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
@@ -139,6 +143,9 @@ done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
 for f in <every file you removed lines from>; do
+  # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
+  # is skipped — an accidental whole-file deletion reads identically to a clean removal.
+  git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
   git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
     && { echo "$f still contains text this change removed"; exit 1; }
 done

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -128,8 +128,10 @@ anything, and when you commit the accepted diff (step 10.5), check both things t
 message hides:
 
 ```bash
-git add -- <every path this change touched>   # not `git add -A`: on a dirty tree it
-git diff --cached                            # sweeps in unrelated work — and READ this,
+git add -- <every path this change touched>   # NOT `git add -A`: on a dirty tree that
+                                             # stages unrelated work. Even by name, a path
+                                             # already dirty brings the other agent's hunks.
+git diff --cached                            # read-only review of what you just staged;
                                              # since staging a path that was already
                                              # dirty takes the other agent's hunks too
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
@@ -137,9 +139,11 @@ git show --stat --format= HEAD               # all the paths you meant, and only
 ```
 
 Then confirm the *content* landed, per file, by the check that fits it — a file that
-gained content must contain a distinctive new phrase; a file you only removed lines from
-must still exist **and** hold the expected remaining count of the deleted phrase; a
-deleted path must be absent. One does not substitute for another, and each has a way to
+gained content must contain a distinctive new phrase; a file you removed lines from must
+still exist **and** hold the expected remaining count of the deleted phrase; a deleted path
+must be absent. A file that BOTH gained and lost content needs both of the first two — the
+added phrase passing says nothing about whether the removal survived. One does not
+substitute for another, and each has a way to
 lie: `grep` defaults to regex (use `-Fq --`), `git show ... | grep` returns 141 under
 `pipefail` when grep exits early (capture to a file first), `grep -c` counts lines rather
 than occurrences, and demanding *zero* occurrences rejects a correct partial removal.

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -140,7 +140,7 @@ git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the run changed that gained or changed content>; do
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-  grep -q "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
+  grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
@@ -148,7 +148,11 @@ for f in <every file you removed lines from>; do
   # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
   # is skipped — an accidental whole-file deletion reads identically to a clean removal.
   git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
+  _n=$(grep -Fc -- "<a distinctive phrase you deleted>" "$_chk" || true)
+  # COUNT, not absence: removing one of several identical lines legitimately leaves
+  # the phrase behind, and demanding zero rejects that correct commit.
+  [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
+    || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -128,12 +128,19 @@ anything, and when you commit the accepted diff (step 10.5), check both things t
 message hides:
 
 ```bash
-git add -A && git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
+git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it sweeps
+git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }   # in unrelated work
 # The commit's own file list first — every path you touched, and nothing you did not.
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the run changed that gained or changed content>; do
   git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+done
+# Removal-only edits have no new phrase to find, and any surviving phrase passes even if
+# the removal was reverted. Assert the removed text is GONE:
+for f in <every file you removed lines from>; do
+  git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
+    && { echo "$f still contains text this change removed"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -128,45 +128,25 @@ anything, and when you commit the accepted diff (step 10.5), check both things t
 message hides:
 
 ```bash
-git add -- <every path this change touched>   # NOT `git add -A` on a dirty tree: it
-git diff --cached                            # sweeps in unrelated work. And READ this:
-                                             # on a path that was ALREADY dirty, staging
-                                             # it by name still takes the other agent's
-                                             # hunks in that same file.
+git add -- <every path this change touched>   # not `git add -A`: on a dirty tree it
+git diff --cached                            # sweeps in unrelated work — and READ this,
+                                             # since staging a path that was already
+                                             # dirty takes the other agent's hunks too
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
-# The commit's own file list first — every path you touched, and nothing you did not.
+git show --stat --format= HEAD               # all the paths you meant, and only those
+```
+
+Then confirm the *content* landed, per file, by the check that fits it — a file that
+gained content must contain a distinctive new phrase; a file you only removed lines from
+must still exist **and** hold the expected remaining count of the deleted phrase; a
+deleted path must be absent. One does not substitute for another, and each has a way to
+lie: `grep` defaults to regex (use `-Fq --`), `git show ... | grep` returns 141 under
+`pipefail` when grep exits early (capture to a file first), `grep -c` counts lines rather
+than occurrences, and demanding *zero* occurrences rejects a correct partial removal.
+
+```bash
 _chk=$(mktemp); trap 'rm -f "$_chk"' EXIT
-git show --stat --format= HEAD
-# Each file that should CONTAIN the change:
-for f in <every file the run changed that gained or changed content>; do
-  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
-  grep -Fq -- "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
-done
-# Removal-only edits have no new phrase to find, and any surviving phrase passes even
-# if the removal was reverted. Assert the EXPECTED REMAINING COUNT — not absence,
-# which rejects a correct partial removal:
-for f in <every file you removed lines from>; do
-  # Existence FIRST: `git show HEAD:<gone>` fails, and without this assert an
-  # accidental whole-file deletion would reach the count check with an empty file
-  # and read as a clean removal. Whole-file deletions belong in the absence loop
-  # below, never here.
-  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
-  _n=$(grep -Fo -- "<a distinctive phrase you deleted>" "$_chk" | wc -l || true)
-  # `|| true` because grep exits 1 on no match, and under `pipefail` that aborts the
-  # whole check at exactly the case it must report: a COMPLETE removal, count 0.
-  # COUNT the OCCURRENCES, not the matching lines (`grep -c` reports lines, so two
-  # hits on one line count as one), and not absence: removing one of several
-  # identical lines legitimately leaves the phrase behind, and demanding zero
-  # rejects that correct commit.
-  [ "${_n:-0}" -eq <occurrences expected AFTER the removal> ] \
-    || { echo "$f: expected <n> occurrence(s) of the removed text, found ${_n:-0}"; exit 1; }
-done
-# Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
-# design on a deleted path, so folding deletions into the loop above marks every correct
-# deletion as a loss:
-for f in <every path the change deletes>; do
-  git show "HEAD:$f" >/dev/null 2>&1 && { echo "$f is still present"; exit 1; }
-done
+# ...the three loops, using `grep -Fq --` / `grep -Fo | wc -l || true` on a captured file.
 ```
 
 `git commit` with nothing staged exits **1**, so the `||` catches a total loss however

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -135,19 +135,20 @@ git diff --cached                            # sweeps in unrelated work. And REA
                                              # hunks in that same file.
 git commit -m "<msg>" || { echo "commit produced nothing"; exit 1; }
 # The commit's own file list first — every path you touched, and nothing you did not.
+_chk=$(mktemp)
 git show --stat --format= HEAD
 # Each file that should CONTAIN the change:
 for f in <every file the run changed that gained or changed content>; do
-  git show "HEAD:$f" | grep -q "<a distinctive phrase from that file>" || { echo "$f did not land"; exit 1; }
+  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f did not land"; exit 1; }
+  grep -q "<a distinctive phrase from that file>" "$_chk" || { echo "$f did not land"; exit 1; }
 done
 # Removal-only edits have no new phrase to find, and any surviving phrase passes even if
 # the removal was reverted. Assert the removed text is GONE:
 for f in <every file you removed lines from>; do
   # Existence FIRST. `git show HEAD:<gone>` fails, so grep returns nonzero and the `&&`
   # is skipped — an accidental whole-file deletion reads identically to a clean removal.
-  git show "HEAD:$f" >/dev/null 2>&1 || { echo "$f is missing from HEAD entirely"; exit 1; }
-  git show "HEAD:$f" | grep -q "<a distinctive phrase you deleted>" \
-    && { echo "$f still contains text this change removed"; exit 1; }
+  git show "HEAD:$f" >"$_chk" 2>/dev/null || { echo "$f is missing from HEAD entirely"; exit 1; }
+  grep -q "<a distinctive phrase you deleted>" "$_chk" && { echo "$f still contains text this change removed"; exit 1; }
 done
 # Each file the change DELETES is verified by ABSENCE — `git show HEAD:<path>` fails by
 # design on a deleted path, so folding deletions into the loop above marks every correct


### PR DESCRIPTION
Closes #21.

An edit made to a tracked file **while `codex review` is running** is silently
destroyed — and the loss presents as a *successful* commit:

```console
$ git add -A && git commit -m "..."
nothing to commit, working tree clean
```

which is indistinguishable from "already committed" if you don't look further.
`git status` is clean and the content is gone from both the working file and
`HEAD`. It cost two rounds of real work on a money-path branch; both times the
edits had been applied, verified on disk with `grep -c`, and compiled green
(clippy clean, 867 tests passing) before they vanished.

## Two rules, placed where the invocations and the commits actually are

**1. Do not edit while a review is in flight.**

| File | Where |
|---|---|
| `multi-reviewer-loop/SKILL.md` § 2 | at the command block that backgrounds both reviewers |
| `multi-reviewer-loop/SKILL.md` § 3 | as an explicit **entry condition**: both `wait`s returned |
| `orchestrating-with-rb-lite/SKILL.md` | beside the existing "the reviewer is READ-ONLY so it can't mutate the worktree" note — the same prohibition binds the operator, and rb-lite runs `codex review` every round |
| `drive/references/phases.md` | SPEC step 4 and HARDEN step 3, the two phases that review-then-edit in a loop |

`multi-reviewer-loop` is the most exposed skill in the repo: it backgrounds both
reviewers **by design**, codex's findings are readable while Fable is still
running, and the very next phase is nothing but editing. The skill was telling
agents to walk into the window.

**2. Assert the content landed, not the exit code.**

```bash
git show HEAD:<file> | grep -c "<distinctive phrase>"   # must be >0
```

A clean `git status` is not that assertion — it reads identically whether the
work was committed or reverted underneath you. Added to `drive`'s **Guard 1
(Evidence, not assertion)**, immediately above the `br` bullet, which is the same
shape: a command exiting 0 with the write never happening.

## The mis-designed probe, recorded on purpose

An edit made *before* the review starts **survives** — it disappears mid-run and
returns at the end. Only edits made *during* the run are lost. The first probe
planted a marker before launching codex, watched it come back, and concluded the
tool was innocent. That is a worse error than the original, because it would tell
the next reader to trust it. `reviewer-panel.md` now carries the correct probe
design and both observations:

```
planted mid-run                  count=1
t=125s, still inside the review  count=0
```

## What I deliberately did not claim

The **mechanism is unestablished**. `git stash list`, `git reflog`, `git worktree
list` show no trace, and codex's own 1.4 MB transcript contains only `git diff`
and `git show` — no stash, checkout, reset, or worktree. "Restores a snapshot
taken at start" fits every observation but was never confirmed at the
implementation level, so the docs say that outright rather than inventing a
cause. None of the guidance depends on which mechanism is right.

## The one discretionary change — easy to drop

`agents-md/references/discipline-block.md` gets **only the tool-agnostic half**:
a commit is not evidence its content reached `HEAD`. The block's own charter says
*"anything language-, tool-, or project-specific belongs outside the markers"*,
and `codex review` is a tool — so the "don't edit during a review" rule stayed
out of it. The commit-verification sentence is a direct extension of the block's
existing "Edits must be verified, not assumed" rule from the file to the commit.
It propagates to every repo that installs the block, so if you'd rather keep that
surface frozen, that hunk is self-contained and can go.

## Gates

```
skills/drive/scripts/drive-status.test                  passed 70,  failed 0
skills/pr-with-codex-bot-review/scripts/bot-gate.test    passed 104, failed 0
```

Docs-only; neither suite exercises this diff. All three new relative links
verified to resolve on disk rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Round 2 — bot findings, all fixed

- **[P1] Reap the reviewer, do not just signal it.** `kill` only *sends* SIGTERM and returns immediately, so the timeout wrapper and reviewer are still tearing down — the escape hatch reproduced the very window it exists to close. Now `kill` then `wait "$CODEX_PID"`, with the reason stated so nobody trims the wait later.
- **[P2] Verify every file, not a sample.** The guard grepped one path, so a revert of a *different* file passed both `git commit` (exit 0) and the grep — reporting success for exactly the partial loss it was written to catch. Closed as a class: the same single-file grep had been copied into four more files, and `grep -rn "git show HEAD:"` now returns nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Strengthened guidance for confirming commits contain all intended changes.
  - Added verification for added, modified, partially removed, and deleted files.
  - Clarified that a clean working tree does not confirm a successful commit.
  - Warned against editing repository files while reviews are active.
  - Documented safer reviewer-process handling, timeout recovery, and process cleanup.
  - Added safeguards against command-output and pipeline verification pitfalls.
  - Expanded final-gate and mid-review checks for detecting missing or partially lost changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->