### PR TITLE
A br flush writes the gitignored cache over the tracked issues.jsonl

### DIFF
--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -134,7 +134,10 @@ run `second-model-bead-audit` by default after the graph meets these gates.
 - Merge tiny beads only when the merge sharpens execution instead of blurring it.
 - Reconcile priority with graph reality so critical blockers are obvious.
 
-4. Apply only justified changes with `br`.
+4. Write the replay manifest **before** applying anything — one line per intended `br`
+   command, verbatim and complete (ids, field values, order). Step 6's round summary is
+   written after the flush and records decisions, not the commands; recovery discards the
+   working JSONL before you could read them back off it. Then apply the changes with `br`.
 
 5. Flush with an **explicit** `br sync --flush-only` and require it to succeed:
 

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -139,7 +139,9 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    the cache stale (a hand edit does not advance `updated_at`, so the two are
    indistinguishable by timestamp), and this skill rewrites long bead bodies for a living,
    which is exactly when opening the file is tempting. Write bead text with
-   `br update -d/--notes`, and `git diff .beads/issues.jsonl` before committing: a full
+   `br update -d/--notes`, and field-diff the tracked JSONL before committing (resolve it
+   with `br where --json | jq -r .jsonl_path`; the `.beads/` layout is only the default,
+   and a hardcoded path diffs nothing on the others): a full
    re-serialization with every id on both sides is normal, ids on only one side or a
    `description` you did not touch is the tell. Recovery — and why `br sync --import-only`
    cannot do it — is in

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -166,8 +166,10 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11, with one
    caveat: its replay step assumes a SINGLE mutation, the drain's case. A polish round
    batches several rewrites, so enumerate the complete intended delta (the step 4 replay manifest, NOT
-   the step 6 round summary — the summary records decisions, not commands, ids or order) before the `git checkout HEAD --`, or the restore discards this
-   round's legitimate work along with the damage.
+   the step 6 round summary — the summary records decisions, not commands, ids or order) before restoring — and restore from the side you established holds the good bodies, not
+   unconditionally from `HEAD`: when the index holds the last good export,
+   `git checkout HEAD --` overwrites that staged copy too, discarding the very source you
+   selected. Step 11 requires the choice explicitly; make it there.
 
 6. Write a round summary:
    - beads added, rewritten, merged, closed, or reprioritized

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -165,8 +165,8 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    cannot do it — is in
    [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11, with one
    caveat: its replay step assumes a SINGLE mutation, the drain's case. A polish round
-   batches several rewrites, so enumerate the complete intended delta (the round summary
-   in step 6 is that list) before the `git checkout HEAD --`, or the restore discards this
+   batches several rewrites, so enumerate the complete intended delta (the step 4 replay manifest, NOT
+   the step 6 round summary — the summary records decisions, not commands, ids or order) before the `git checkout HEAD --`, or the restore discards this
    round's legitimate work along with the damage.
 
 6. Write a round summary:

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -43,19 +43,11 @@ merely plausible.
 
 **Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
 auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
-very first `br update` — and because neither the index nor `HEAD` holds it, every later
-diff shows only your intended changes and the loss is undetectable, let alone recoverable.
-The window is open from the moment the session starts:
-
-```bash
-BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
-  || { echo "cannot resolve the beads JSONL path"; exit 1; }
-git status --porcelain -- "$BEADS_JSONL"
-```
-
-Not empty? Resolve it now — see recovery case (a) in
-[orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — before
-writing anything. After the first flush the choice is gone.
+first write — and since neither the index nor `HEAD` holds it, every later diff shows only
+your intended changes and the loss becomes *undetectable*. Run `git status --porcelain --
+"$(br where --json | jq -r .jsonl_path)"`; if it is not empty, resolve it first — recovery
+case (a) in [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11. After the first flush the choice
+is gone.
 
 ## Session shape
 

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -45,7 +45,7 @@ merely plausible.
 auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
 first write — and since neither the index nor `HEAD` holds it, every later diff shows only
 your intended changes and the loss becomes *undetectable*. Run `git status --porcelain --
-"$(br where --json | jq -r .jsonl_path)"`; if it is not empty, resolve it first — recovery
+"$(br where --json | jq -er .jsonl_path)"`; if it is not empty, resolve it first — recovery
 case (a) in [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11. After the first flush the choice
 is gone.
 
@@ -155,7 +155,7 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    indistinguishable by timestamp), and this skill rewrites long bead bodies for a living,
    which is exactly when opening the file is tempting. Write bead text with
    `br update -d/--notes`, and field-diff the tracked JSONL before committing (resolve it
-   with `br where --json | jq -r .jsonl_path`; the `.beads/` layout is only the default,
+   with `br where --json | jq -er .jsonl_path`; the `.beads/` layout is only the default,
    and a hardcoded path diffs nothing on the others): a full
    re-serialization with every id on both sides is normal, ids on only one side or a
    `description` you did not touch is the tell. Recovery — and why `br sync --import-only`

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -132,6 +132,19 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    so this either writes it or fails loudly. A round that applied no changes syncs cleanly
    and reports nothing — a healthy convergence signal, not a failed flush.
 
+   **But a flush writes the cache over the file.** The sync proves your mutation
+   persisted; it does not tell you what else it overwrote. Every `br` write re-exports
+   *all* beads from the gitignored `.beads/beads.db`, so a body the cache holds a stale
+   copy of is reverted — silently, exit 0. Hand-editing `.beads/issues.jsonl` is what makes
+   the cache stale (a hand edit does not advance `updated_at`, so the two are
+   indistinguishable by timestamp), and this skill rewrites long bead bodies for a living,
+   which is exactly when opening the file is tempting. Write bead text with
+   `br update -d/--notes`, and `git diff .beads/issues.jsonl` before committing: a full
+   re-serialization with every id on both sides is normal, ids on only one side or a
+   `description` you did not touch is the tell. Recovery — and why `br sync --import-only`
+   cannot do it — is in
+   [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
+
 6. Write a round summary:
    - beads added, rewritten, merged, closed, or reprioritized
    - findings ledger entries closed this round

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -143,7 +143,11 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    re-serialization with every id on both sides is normal, ids on only one side or a
    `description` you did not touch is the tell. Recovery — and why `br sync --import-only`
    cannot do it — is in
-   [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
+   [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11, with one
+   caveat: its replay step assumes a SINGLE mutation, the drain's case. A polish round
+   batches several rewrites, so enumerate the complete intended delta (the round summary
+   in step 6 is that list) before the `git checkout HEAD --`, or the restore discards this
+   round's legitimate work along with the damage.
 
 6. Write a round summary:
    - beads added, rewritten, merged, closed, or reprioritized

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -26,10 +26,16 @@ merely plausible.
 
 ## Preflight
 
-- Confirm `br` and `bv` are on `PATH`. If either is missing, stop and say so.
-- Record whether `codex`, `claude`, and `jq` are available for the final reviewer
-  panel. Missing panel tools do not block polishing, but they determine whether
-  the eventual audit can be full, degraded, or blocked.
+- Confirm `br`, `bv`, **and `jq`** are on `PATH`. If any is missing, stop and say so.
+  `jq` is not a panel tool here: every `br` write can silently revert other beads
+  (step 5), and both the damage check and the recovery resolve the graph's real path
+  through `br where --json | jq`. Without it you can still mutate the graph and then
+  cannot tell whether you destroyed anything — the one ordering that must not be
+  possible. If `br where --json` cannot be parsed on this host, do not write to the
+  graph at all.
+- Record whether `codex` and `claude` are available for the final reviewer panel.
+  Missing panel tools do not block polishing, but they determine whether the eventual
+  audit can be full, degraded, or blocked.
 - Re-read `AGENTS.md`, `README.md`, and the relevant plan/spec before editing the graph.
 - If there are no meaningful beads yet, redirect to `plan-to-beads-transfer`.
 - If polishing keeps surfacing architecture questions, step back into plan space instead of repeatedly fixing downstream symptoms.

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -40,6 +40,23 @@ merely plausible.
 - If there are no meaningful beads yet, redirect to `plan-to-beads-transfer`.
 - If polishing keeps surfacing architecture questions, step back into plan space instead of repeatedly fixing downstream symptoms.
 
+
+**Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
+auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
+very first `br update` — and because neither the index nor `HEAD` holds it, every later
+diff shows only your intended changes and the loss is undetectable, let alone recoverable.
+The window is open from the moment the session starts:
+
+```bash
+BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+  || { echo "cannot resolve the beads JSONL path"; exit 1; }
+git status --porcelain -- "$BEADS_JSONL"
+```
+
+Not empty? Resolve it now — see recovery case (a) in
+[orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — before
+writing anything. After the first flush the choice is gone.
+
 ## Session shape
 
 - Expect 2-3 serious polish passes per session before context quality drops.

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -249,8 +249,12 @@ A phase closes on evidence or it does not close.
   flush re-exports **every** bead from the gitignored `.beads/beads.db` over the tracked
   JSONL, so any body the cache holds a stale copy of is reverted, silently, at exit 0.
   Hand-editing `.beads/issues.jsonl` is what makes the cache stale — do not; use
-  `br update -d/--notes`. Then `git diff .beads/issues.jsonl` before committing and read
-  the field-level changes. Detail and recovery:
+  `br update -d/--notes`. Then field-diff the tracked JSONL before committing and read the
+  changes — resolving its path rather than assuming it, with
+  `br where --json | jq -r .jsonl_path`. `.beads/issues.jsonl` is only the default:
+  `.beads.jsonl` and `<name>.beads.jsonl` are supported too, and a hardcoded path diffs
+  nothing on those — a false all-clear in the direction that loses text. Detail and
+  recovery:
   [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
 
 

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -245,6 +245,14 @@ A phase closes on evidence or it does not close.
   before the first mutation — and got each of those wrong once, in review, across six
   copies of itself.
 
+  That sync proves *your* write landed. It does not tell you what else it overwrote: a
+  flush re-exports **every** bead from the gitignored `.beads/beads.db` over the tracked
+  JSONL, so any body the cache holds a stale copy of is reverted, silently, at exit 0.
+  Hand-editing `.beads/issues.jsonl` is what makes the cache stale — do not; use
+  `br update -d/--notes`. Then `git diff .beads/issues.jsonl` before committing and read
+  the field-level changes. Detail and recovery:
+  [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
+
 
 The rules above are what closes a *phase*. The fuller set on not lying about *edits* —
 `sed -i` succeeding on zero matches, `&` silently doubling a replacement — lives in the

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -234,6 +234,16 @@ A phase closes on evidence or it does not close.
   closed bead is not a closed bead until an explicit sync has confirmed the write:
 
   ```bash
+  # Divergence check FIRST — `br close` auto-flushes the cache over the tracked JSONL, so
+  # an unstaged hand-edit is destroyed by this very command and neither the index nor HEAD
+  # holds it. Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so
+  # a failed inspection would read as clean and let the write through.
+  BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+    || { echo "cannot resolve the beads JSONL — do NOT close"; exit 1; }
+  _st=$(git status --porcelain -- "$BEADS_JSONL") \
+    || { echo "cannot read the worktree — do NOT close"; exit 1; }
+  [ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
+    echo "JSONL differs from HEAD — resolve that BEFORE closing"; exit 1; }
   br close <id> || { echo "br close failed"; exit 1; }
   br sync --flush-only || { echo "closure not persisted to the JSONL"; exit 1; }
   ```

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -251,7 +251,7 @@ A phase closes on evidence or it does not close.
   Hand-editing `.beads/issues.jsonl` is what makes the cache stale — do not; use
   `br update -d/--notes`. Then field-diff the tracked JSONL before committing and read the
   changes — resolving its path rather than assuming it, with
-  `br where --json | jq -r .jsonl_path`. `.beads/issues.jsonl` is only the default:
+  `br where --json | jq -er .jsonl_path`. `.beads/issues.jsonl` is only the default:
   `.beads.jsonl` and `<name>.beads.jsonl` are supported too, and a hardcoded path diffs
   nothing on those — a false all-clear in the direction that loses text. Detail and
   recovery:

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -713,6 +713,12 @@ And verify the closure actually happened. `br close` exits 0 even when the flush
 writes the JSONL failed, because the error is caught and logged at debug level:
 
 ```bash
+# DIVERGENCE CHECK FIRST: `br close` auto-flushes, so an unstaged hand-edit in the JSONL is
+# destroyed by this very command and neither the index nor HEAD holds it — the diff below
+# would then be empty and the loss undetectable.
+BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
+[ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
+  || { echo "JSONL diverges from git — resolve it BEFORE closing"; exit 1; }
 br close <id> || { echo "br close failed"; exit 1; }
 br sync --flush-only || { echo "closure not persisted — auto-flush was swallowed"; exit 1; }
 ```

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -723,9 +723,18 @@ would report success on a closure that never happened.
 That proves the *closure* landed; it says nothing about what else the same flush wrote.
 Every `br` write re-exports **all** beads from the gitignored `.beads/beads.db` over the
 tracked JSONL, so any body the cache holds a stale copy of is reverted — silently, exit 0,
-and once committed it reads as an ordinary bead-state sync. So `git diff
-.beads/issues.jsonl` and read the field-level changes before staging: ids on only one side,
-or a `description` this phase did not write, is the tell. Never hand-edit that file (a hand
+and once committed it reads as an ordinary bead-state sync. So field-diff the tracked JSONL
+and read the field-level changes before staging — resolving its path first, since
+`.beads/issues.jsonl` is only the default and a hardcoded path diffs nothing on a
+`.beads.jsonl` layout:
+
+```bash
+BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
+git diff "$BEADS_JSONL"
+```
+
+Ids on only one side, or a `description` this phase did not write, is the tell. Never
+hand-edit that file (a hand
 edit does not advance `updated_at`, which is what makes the cache stale and undetectable);
 write bead text with `br update -d/--notes`. Recovery is in
 [orchestrating-with-rb-lite](../../orchestrating-with-rb-lite/SKILL.md) step 11.

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -716,9 +716,16 @@ writes the JSONL failed, because the error is caught and logged at debug level:
 # DIVERGENCE CHECK FIRST: `br close` auto-flushes, so an unstaged hand-edit in the JSONL is
 # destroyed by this very command and neither the index nor HEAD holds it — the diff below
 # would then be empty and the loss undetectable.
-BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
-[ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
-  || { echo "JSONL diverges from git — resolve it BEFORE closing"; exit 1; }
+BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+  || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
+# Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so a FAILED
+# inspection reads as a clean tree and lets the write through — the guard failing open at
+# exactly the moment it matters. Compare against HEAD, not the index: a damaged JSONL that
+# is staged leaves a worktree-vs-index diff empty while HEAD holds the good bodies.
+_st=$(git status --porcelain -- "$BEADS_JSONL") \
+  || { echo "cannot read the worktree — do NOT write"; exit 1; }
+[ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
+  echo "JSONL differs from HEAD — read that diff and resolve it BEFORE writing"; exit 1; }
 br close <id> || { echo "br close failed"; exit 1; }
 br sync --flush-only || { echo "closure not persisted — auto-flush was swallowed"; exit 1; }
 ```

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -720,6 +720,16 @@ br sync --flush-only || { echo "closure not persisted — auto-flush was swallow
 `||`, not `;`: a semicolon discards the exit status of the command before it, so the pair
 would report success on a closure that never happened.
 
+That proves the *closure* landed; it says nothing about what else the same flush wrote.
+Every `br` write re-exports **all** beads from the gitignored `.beads/beads.db` over the
+tracked JSONL, so any body the cache holds a stale copy of is reverted — silently, exit 0,
+and once committed it reads as an ordinary bead-state sync. So `git diff
+.beads/issues.jsonl` and read the field-level changes before staging: ids on only one side,
+or a `description` this phase did not write, is the tell. Never hand-edit that file (a hand
+edit does not advance `updated_at`, which is what makes the cache stale and undetectable);
+write bead text with `br update -d/--notes`. Recovery is in
+[orchestrating-with-rb-lite](../../orchestrating-with-rb-lite/SKILL.md) step 11.
+
 A flush
 over a graph that was already committed and unchanged legitimately reports nothing, so a
 blanket "must be non-empty" would fail a healthy preflight.

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -761,13 +761,62 @@ implement → review loop for each bead.
 
     Verify it landed with a checked *explicit* sync: it propagates a real exit code, which
     the automatic flush after `br update` does not — that one swallows its error. The
-    mutation is already in the shared DB, so the sync either writes it out or fails loudly,
-    and nothing needs to inspect the file:
+    mutation is already in the shared DB, so the sync either writes it out or fails loudly:
 
     ```bash
     br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
     br sync --flush-only || { echo "not persisted"; exit 1; }
     ```
+
+    **That sync proves the closure reached the file. It says nothing about what else the
+    same write overwrote — so inspect the file anyway.** Every `br` write flushes the whole
+    gitignored `.beads/beads.db` cache over the tracked `.beads/issues.jsonl`, so a write to
+    **one** bead rewrites **all** of them from the cache, and any body the cache holds a
+    stale copy of is reverted. Observed on `br 0.2.19`: closing a single bead silently
+    reverted ~40 KB of specification text across three *other* beads and deleted a fourth
+    outright. Exit 0, success message, nothing failed. This step is the last write of every
+    bead, which is how the drain routes you into it every time.
+
+    Hand-editing `.beads/issues.jsonl` is what makes the cache stale — and the task
+    template below half-invites it: it tells the *implementer* to treat `.beads/` as an
+    "orchestration/state" directory rather than product code, which the **operator** can
+    read as "this is just state, edit it freely." It is not. A hand edit does not advance
+    `updated_at`, so cache and file hold different bodies under identical timestamps and
+    nothing can tell them apart. **Write bead text through `br update -d/--notes`; never
+    through the file.** If a body is long enough that editing the file is tempting, that is
+    exactly the body worth losing least.
+
+    The advertised guard does not cover this. `br sync --help` documents a *"Stale DB
+    Guard: refuses to export if JSONL has issues missing from DB"* — an **id**-level check,
+    so same-id-different-body is unguarded by design, and that is the case that loses the
+    text. In the observed run the id-level case did not fire either: a bead present in the
+    JSONL and absent from the DB was dropped by the auto-flush, which is the guard's
+    literal precondition.
+
+    So field-diff before committing any `br` write:
+
+    ```bash
+    git diff .beads/issues.jsonl
+    ```
+
+    Parse the `+`/`-` lines as JSON, key by `id`, and assert the only changed fields are the
+    ones you meant to change. A full-file re-serialization with every id on both sides is
+    normal; ids on only one side, or a `description` you did not touch, is the tell.
+
+    If it has already diverged, **rebuild the cache** — `issues.jsonl` is tracked truth and
+    `beads.db` is a gitignored cache, so the file wins. `br sync --import-only` alone cannot
+    repair it: it compares `updated_at`, and equal timestamps with different bodies report
+    `Skipped: N (up-to-date)` forever.
+
+    ```bash
+    cp .beads/beads.db /tmp/beads.db.bak
+    rm -f .beads/beads.db .beads/beads.db-wal .beads/beads.db-shm
+    br sync --import-only     # "Imported from JSONL (via automatic recovery)"
+    ```
+
+    Then verify the restored bodies against the file before any further `br` write. This is
+    **not** the pre-0.1.45 corruption bug in "Tool dependencies": no `ISSUE_NOT_FOUND`, no
+    branch reset involved, and every command reported success.
 
     Closing on the feature branch before the merge is **not** a safe shortcut, however
     transactional it looks — the beads DB is shared across branches with no git
@@ -956,6 +1005,9 @@ phrases like "X happens when Y", not only test function names.>
   otherwise interfere with the surrounding orchestration.
 - Treat `.rb-lite/`, `.ralph-burning/`, `.git/ralph-burning-live/`, and
   `.beads/` as orchestration/state directories, not product code to review.
+  That is a *reviewing* scope rule, not an editing licence — nobody, implementer
+  or operator, hand-edits `.beads/issues.jsonl`; bead text is written with
+  `br update -d/--notes` or it gets silently reverted by the next flush (step 11).
   This does NOT forbid ordinary git usage: **`git add` any new SOURCE file you
   create** so it appears in the reviewed diff (`git diff <base>` omits untracked
   files — an unstaged new module reads to reviewers as "missing, won't compile").

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -793,10 +793,21 @@ implement → review loop for each bead.
     JSONL and absent from the DB was dropped by the auto-flush, which is the guard's
     literal precondition.
 
-    So field-diff before committing any `br` write:
+    So field-diff before committing any `br` write — **resolving the path first**, because
+    `.beads/issues.jsonl` is only the default layout and a hardcoded path diffs *nothing*
+    on a `.beads.jsonl` or `<name>.beads.jsonl` repo. An empty diff then reads as "no
+    collateral damage" and you never enter recovery at all, which is the failure this whole
+    step exists to prevent:
 
     ```bash
-    git diff .beads/issues.jsonl
+    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+      || { echo "cannot resolve the beads JSONL path — do NOT judge the flush blind"; exit 1; }
+    BEADS_DB=$(br where --json | jq -r '.db_path // empty')
+    # Read `br where --json` yourself for the DB field name your version emits; if it
+    # reports none, the cache sits beside the JSONL. Never assume `.beads/beads.db`.
+    [ -n "$BEADS_DB" ] || BEADS_DB="$(dirname "$BEADS_JSONL")/beads.db"
+
+    git diff "$BEADS_JSONL"
     ```
 
     Parse the `+`/`-` lines as JSON, key by `id`, and assert the only changed fields are the
@@ -806,23 +817,12 @@ implement → review loop for each bead.
     Recovery depends on **which of the two has the good text**, and getting that backwards
     cements the loss. Establish it before running anything:
 
-    **Resolve the real paths first — `.beads/issues.jsonl` is a default, not a guarantee.**
-    `.beads.jsonl` and `<name>.beads.jsonl` layouts are supported and this repo's own
-    `drive-status` recognizes them (`_BEAD_RE`). A recovery that hardcodes the default
-    restores and deletes paths that do not exist, while the commands after it keep using
-    the *actual* stale cache and damaged file — so it reports success and leaves the loss
-    in place. Ask the tool, exactly as `second-model-bead-audit` already does:
-
-    ```bash
-    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
-      || { echo "cannot resolve the beads JSONL path — do NOT run the recipe blind"; exit 1; }
-    BEADS_DB=$(br where --json | jq -r '.db_path // empty')
-    # Read `br where --json` yourself for the DB field name your version emits; if it
-    # reports none, the cache sits beside the JSONL. Never assume `.beads/beads.db`.
-    [ -n "$BEADS_DB" ] || BEADS_DB="$(dirname "$BEADS_JSONL")/beads.db"
-    ```
-
-    Use `$BEADS_JSONL` and `$BEADS_DB` for every step below — the field-diff above included.
+    `$BEADS_JSONL` and `$BEADS_DB` from the detection step above carry through every command
+    below. A recovery that hardcodes the default restores and deletes paths that do not
+    exist while the commands after it keep using the *actual* stale cache and damaged file —
+    reporting success and leaving the loss in place. `drive-status`'s own `_BEAD_RE`
+    recognizes all three layouts; `second-model-bead-audit` already asks `br where` rather
+    than assuming.
 
     **(a) The cache is stale and the file is still good** — you have hand-edited the JSONL
     and no flush has happened yet. Rebuild the cache from the file. `br sync --import-only`

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -875,8 +875,13 @@ implement → review loop for each bead.
     # REBUILD: identical for both sources. Do not skip this on the staged path.
     cp "$BEADS_DB" /tmp/beads.db.bak
     rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
-    br sync --import-only
-    br update <bead-id> -s closed              # redo the intended write(s), through the CLI
+    # CHECK BOTH. The stale database is already deleted at this point, so an import that
+    # fails on an unreadable or invalid JSONL leaves an empty cache — and the flush below
+    # would then write THAT over the file you just restored, destroying the recovery with
+    # the recovery. Same for a failed replay: exit before any flush.
+    br sync --import-only || { echo "import failed — do NOT flush; the JSONL is your only
+      copy right now"; exit 1; }
+    br update <bead-id> -s closed || { echo "replay failed — do NOT flush"; exit 1; }
     br sync --flush-only || { echo "not persisted"; exit 1; }
     git diff "$BEADS_JSONL"                    # confirm ONLY the intended fields moved
     ```

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -831,9 +831,13 @@ implement → review loop for each bead.
     surviving cache makes the import skip equal-timestamp records and report success);
     **check the import and the replay before any flush** (the stale DB is already deleted,
     so a failed import leaves an empty one and the flush writes *that* over what you just
-    restored); and **replay the complete intended delta**, not one command — the drain's
-    case is a single closure, but `plan-to-beads-transfer` and `bead-polish-loop` batch, so
-    `git checkout HEAD --` there discards their legitimate work along with the damage.
+    restored); and **rebuild the cache BEFORE replaying anything** — restore, delete and
+    re-import the DB, and only then replay. Restoring the file and replaying straight away
+    lets the first `br` command auto-flush the *still-stale* cache over what you just
+    restored, destroying the recovery with the recovery. And **replay the complete intended
+    delta**, not one command: the drain's case is a single closure, but
+    `plan-to-beads-transfer` and `bead-polish-loop` batch, so restoring from git there
+    discards their legitimate work unless the whole manifest is replayed.
 
     **A round summary is not a replay manifest.** It records what you decided, not the
     generated ids, the exact field values, or the order they were written in — and recovery

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -769,6 +769,11 @@ implement → review loop for each bead.
     mutation is already in the shared DB, so the sync either writes it out or fails loudly:
 
     ```bash
+    # DIVERGENCE CHECK FIRST — `br update` auto-flushes, so an unstaged hand-edit in the
+    # JSONL is destroyed by this very command, and neither the index nor HEAD holds it.
+    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') || { echo "cannot resolve the JSONL"; exit 1; }
+    [ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
+      || { echo "JSONL diverges from git — resolve it BEFORE writing (recovery case (a))"; exit 1; }
     br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
     br sync --flush-only || { echo "not persisted"; exit 1; }
     ```

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -771,9 +771,16 @@ implement → review loop for each bead.
     ```bash
     # DIVERGENCE CHECK FIRST — `br update` auto-flushes, so an unstaged hand-edit in the
     # JSONL is destroyed by this very command, and neither the index nor HEAD holds it.
-    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') || { echo "cannot resolve the JSONL"; exit 1; }
-    [ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
-      || { echo "JSONL diverges from git — resolve it BEFORE writing (recovery case (a))"; exit 1; }
+        BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+      || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
+    # Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so a FAILED
+    # inspection reads as a clean tree and lets the write through — the guard failing open at
+    # exactly the moment it matters. Compare against HEAD, not the index: a damaged JSONL that
+    # is staged leaves a worktree-vs-index diff empty while HEAD holds the good bodies.
+    _st=$(git status --porcelain -- "$BEADS_JSONL") \
+      || { echo "cannot read the worktree — do NOT write"; exit 1; }
+    [ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
+      echo "JSONL differs from HEAD — read that diff and resolve it BEFORE writing"; exit 1; }
     br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
     br sync --flush-only || { echo "not persisted"; exit 1; }
     ```
@@ -827,6 +834,13 @@ implement → review loop for each bead.
     restored); and **replay the complete intended delta**, not one command — the drain's
     case is a single closure, but `plan-to-beads-transfer` and `bead-polish-loop` batch, so
     `git checkout HEAD --` there discards their legitimate work along with the damage.
+
+    **A round summary is not a replay manifest.** It records what you decided, not the
+    generated ids, the exact field values, or the order they were written in — and recovery
+    discards the working JSONL before you can go back and read them off it. So batching
+    callers must write the manifest *before* the first mutation: one line per intended `br`
+    command, complete enough to re-run verbatim. A coverage matrix or a round summary
+    reconstructed afterwards is a description of the work, not a copy of it.
 
     Git is the whole recovery, which is why the field-diff must happen **before** you stage
     anything: an uncommitted hand-edit that a flush overwrote is simply gone. That is the

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -820,18 +820,28 @@ implement → review loop for each bead.
     **(b) The flush already ran and the diff above shows the damage** — then the working
     copy of `issues.jsonl` **is** the damaged artifact, not the truth. Importing it here
     would copy the loss into a fresh database and a later commit would cement it. **Restore
-    the file from git first, then re-apply the mutation you actually wanted, and only then
-    rebuild the cache:**
+    the file from git first, then re-apply every mutation you actually wanted, and only
+    then rebuild the cache:**
 
     ```bash
     git checkout HEAD -- .beads/issues.jsonl   # the last good committed state
     cp .beads/beads.db /tmp/beads.db.bak
     rm -f .beads/beads.db .beads/beads.db-wal .beads/beads.db-shm
     br sync --import-only
-    br update <bead-id> -s closed              # redo the intended write, through the CLI
+    br update <bead-id> -s closed              # redo the intended write(s), through the CLI
     br sync --flush-only || { echo "not persisted"; exit 1; }
-    git diff .beads/issues.jsonl               # confirm ONLY that field moved
+    git diff .beads/issues.jsonl               # confirm ONLY the intended fields moved
     ```
+
+    **Enumerate the intended delta before you delete anything.** The single `br update`
+    above is the *drain's* case, where the round's whole intent is one closure. Callers
+    that batch — `plan-to-beads-transfer` writing a graph, `bead-polish-loop` rewriting
+    several bodies in a round — have many deliberate mutations in flight, and
+    `git checkout HEAD --` discards all of them along with the damage. Before the checkout,
+    write down the complete field-level delta you meant to produce (the round summary those
+    skills already require is exactly that list), then replay it through `br` afterwards.
+    Recovering by restoring git and replaying one command is only safe when one command is
+    all you did.
 
     Git is the whole recovery here, which is why the field-diff has to happen **before** you
     stage anything: an uncommitted hand-edit that a flush overwrote is simply gone — no

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -803,10 +803,13 @@ implement → review loop for each bead.
     ones you meant to change. A full-file re-serialization with every id on both sides is
     normal; ids on only one side, or a `description` you did not touch, is the tell.
 
-    If it has already diverged, **rebuild the cache** — `issues.jsonl` is tracked truth and
-    `beads.db` is a gitignored cache, so the file wins. `br sync --import-only` alone cannot
-    repair it: it compares `updated_at`, and equal timestamps with different bodies report
-    `Skipped: N (up-to-date)` forever.
+    Recovery depends on **which of the two has the good text**, and getting that backwards
+    cements the loss. Establish it before running anything:
+
+    **(a) The cache is stale and the file is still good** — you have hand-edited the JSONL
+    and no flush has happened yet. Rebuild the cache from the file. `br sync --import-only`
+    alone cannot do it: it compares `updated_at`, and equal timestamps with different bodies
+    report `Skipped: N (up-to-date)` forever, so the stale DB has to go first.
 
     ```bash
     cp .beads/beads.db /tmp/beads.db.bak
@@ -814,9 +817,30 @@ implement → review loop for each bead.
     br sync --import-only     # "Imported from JSONL (via automatic recovery)"
     ```
 
-    Then verify the restored bodies against the file before any further `br` write. This is
-    **not** the pre-0.1.45 corruption bug in "Tool dependencies": no `ISSUE_NOT_FOUND`, no
-    branch reset involved, and every command reported success.
+    **(b) The flush already ran and the diff above shows the damage** — then the working
+    copy of `issues.jsonl` **is** the damaged artifact, not the truth. Importing it here
+    would copy the loss into a fresh database and a later commit would cement it. **Restore
+    the file from git first, then re-apply the mutation you actually wanted, and only then
+    rebuild the cache:**
+
+    ```bash
+    git checkout HEAD -- .beads/issues.jsonl   # the last good committed state
+    cp .beads/beads.db /tmp/beads.db.bak
+    rm -f .beads/beads.db .beads/beads.db-wal .beads/beads.db-shm
+    br sync --import-only
+    br update <bead-id> -s closed              # redo the intended write, through the CLI
+    br sync --flush-only || { echo "not persisted"; exit 1; }
+    git diff .beads/issues.jsonl               # confirm ONLY that field moved
+    ```
+
+    Git is the whole recovery here, which is why the field-diff has to happen **before** you
+    stage anything: an uncommitted hand-edit that a flush overwrote is simply gone — no
+    cache holds it and no commit holds it. That is the sharpest reason never to write bead
+    text through the file.
+
+    Either way, verify the restored bodies before the next `br` write. This is **not** the
+    pre-0.1.45 corruption bug in "Tool dependencies": no `ISSUE_NOT_FOUND`, no branch reset
+    involved, and every command reported success.
 
     Closing on the feature branch before the merge is **not** a safe shortcut, however
     transactional it looks — the beads DB is shared across branches with no git

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -773,182 +773,62 @@ implement → review loop for each bead.
     br sync --flush-only || { echo "not persisted"; exit 1; }
     ```
 
-    **Check for divergence BEFORE the first `br` write, not at commit time.** `br update`
-    auto-flushes, so a hand-edit sitting unstaged in the JSONL is destroyed by the very
-    first mutation — and neither the index nor `HEAD` holds it, so the post-write diff then
-    shows only your intended change and there is nothing left to recover. The window is
-    open from the moment the session starts:
-
-    ```bash
-    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
-      || { echo "cannot resolve the beads JSONL path"; exit 1; }
-    git status --porcelain -- "$BEADS_JSONL"   # any unstaged/uncommitted bead text?
-    ```
-
-    If that is not empty, resolve it **now** — recovery case (a) below — before running any
-    `br` command. After the first flush the choice is gone.
+    **Check for divergence BEFORE the first `br` write.** `br update` auto-flushes, so a
+    hand-edit sitting unstaged in the JSONL is destroyed by the very first mutation — and
+    since neither the index nor `HEAD` holds it, every later diff shows only your intended
+    change, which makes the loss *undetectable*, not merely unrecoverable. Resolve the real
+    path (`br where --json | jq -er .jsonl_path`; `.beads/issues.jsonl` is only the default
+    layout, and a hardcoded path diffs nothing on a `.beads.jsonl` repo — a false
+    all-clear) and run `git status --porcelain` on it before any `br` command.
 
     **That sync proves the closure reached the file. It says nothing about what else the
-    same write overwrote — so inspect the file anyway.** Every `br` write flushes the whole
-    gitignored `.beads/beads.db` cache over the tracked `.beads/issues.jsonl`, so a write to
-    **one** bead rewrites **all** of them from the cache, and any body the cache holds a
-    stale copy of is reverted. Observed on `br 0.2.19`: closing a single bead silently
-    reverted ~40 KB of specification text across three *other* beads and deleted a fourth
-    outright. Exit 0, success message, nothing failed. This step is the last write of every
+    same write overwrote.** Every `br` write flushes the whole gitignored cache over the
+    tracked JSONL, so a write to **one** bead rewrites **all** of them, and any body the
+    cache holds a stale copy of is reverted. Observed on `br 0.2.19`: closing a single bead
+    silently reverted ~40 KB of specification text across three *other* beads and deleted a
+    fourth. Exit 0, success message, nothing failed. This step is the last write of every
     bead, which is how the drain routes you into it every time.
 
-    Hand-editing `.beads/issues.jsonl` is what makes the cache stale — and the task
-    template below half-invites it: it tells the *implementer* to treat `.beads/` as an
-    "orchestration/state" directory rather than product code, which the **operator** can
-    read as "this is just state, edit it freely." It is not. A hand edit does not advance
+    Hand-editing the JSONL is what makes the cache stale — a hand edit does not advance
     `updated_at`, so cache and file hold different bodies under identical timestamps and
-    nothing can tell them apart. **Write bead text through `br update -d/--notes`; never
-    through the file.** If a body is long enough that editing the file is tempting, that is
-    exactly the body worth losing least.
+    nothing can tell them apart. **Write bead text through `br update -d/--notes`, never
+    the file.** The task template's ".beads/ is orchestration state" line is a *reviewing*
+    scope rule, not an editing licence. And the advertised guard does not help: `br sync
+    --help`'s "Stale DB Guard" is an **id**-level check, so same-id-different-body — the
+    case that loses text — is unguarded by design.
 
-    The advertised guard does not cover this. `br sync --help` documents a *"Stale DB
-    Guard: refuses to export if JSONL has issues missing from DB"* — an **id**-level check,
-    so same-id-different-body is unguarded by design, and that is the case that loses the
-    text. In the observed run the id-level case did not fire either: a bead present in the
-    JSONL and absent from the DB was dropped by the auto-flush, which is the guard's
-    literal precondition.
+    So field-diff the resolved path before committing any `br` write. A full-file
+    re-serialization with every id on both sides is normal; ids on only one side, or a
+    `description` you did not touch, is the tell.
 
-    So field-diff before committing any `br` write — **resolving the path first**, because
-    `.beads/issues.jsonl` is only the default layout and a hardcoded path diffs *nothing*
-    on a `.beads.jsonl` or `<name>.beads.jsonl` repo. An empty diff then reads as "no
-    collateral damage" and you never enter recovery at all, which is the failure this whole
-    step exists to prevent:
+    **Recovery depends on which side holds the good text, and guessing cements the loss.**
 
-    ```bash
-    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
-      || { echo "cannot resolve the beads JSONL path — do NOT judge the flush blind"; exit 1; }
-    # Read `br where --json` yourself and use whatever DB field YOUR version emits — the
-    # name below is a guess at the schema, not a contract.
-    BEADS_DB=$(br where --json | jq -r '.db_path // empty')
-    # Do NOT fall back to a derived path. `dirname` of a FLAT `.beads.jsonl` is the repo
-    # root, so the guess lands on `<repo>/beads.db` while the real cache sits under
-    # `.beads/` — recovery would then back up and delete the wrong file and re-import
-    # against the untouched stale database, preserving exactly the loss it is undoing.
-    [ -n "$BEADS_DB" ] || { echo "br where reports no database path — locate it yourself
-      and set BEADS_DB explicitly; do NOT guess, and do NOT run the recipe without it"; exit 1; }
+    - **(a) cache stale, file still good** — rebuild the cache from the file.
+      `br sync --import-only` alone cannot do it: it compares `updated_at`, so equal
+      timestamps with different bodies report `Skipped: N (up-to-date)` forever. The stale
+      DB has to go first.
+    - **(b) the flush already ran and the diff shows damage** — the working copy *is* the
+      damaged artifact. Restore it from git first, then replay every mutation you meant,
+      then rebuild. Read `git diff --cached` and `git diff` and decide explicitly which of
+      the index or `HEAD` holds the good bodies; a staged copy only proves a choice exists,
+      and an earlier flush may have been staged before anyone noticed.
 
-    git diff "$BEADS_JSONL"
-    ```
+    Four things the recipe must do in both cases, each learned by getting it wrong: back up
+    the cache and **check the copy succeeded**; **verify the DB and its `-wal`/`-shm`
+    siblings are actually gone** (`rm -f` is silent on a permissions failure, and a
+    surviving cache makes the import skip equal-timestamp records and report success);
+    **check the import and the replay before any flush** (the stale DB is already deleted,
+    so a failed import leaves an empty one and the flush writes *that* over what you just
+    restored); and **replay the complete intended delta**, not one command — the drain's
+    case is a single closure, but `plan-to-beads-transfer` and `bead-polish-loop` batch, so
+    `git checkout HEAD --` there discards their legitimate work along with the damage.
 
-    Parse the `+`/`-` lines as JSON, key by `id`, and assert the only changed fields are the
-    ones you meant to change. A full-file re-serialization with every id on both sides is
-    normal; ids on only one side, or a `description` you did not touch, is the tell.
+    Git is the whole recovery, which is why the field-diff must happen **before** you stage
+    anything: an uncommitted hand-edit that a flush overwrote is simply gone. That is the
+    sharpest reason never to write bead text through the file.
 
-    Recovery depends on **which of the two has the good text**, and getting that backwards
-    cements the loss. Establish it before running anything:
-
-    `$BEADS_JSONL` and `$BEADS_DB` from the detection step above carry through every command
-    below. A recovery that hardcodes the default restores and deletes paths that do not
-    exist while the commands after it keep using the *actual* stale cache and damaged file —
-    reporting success and leaving the loss in place. `drive-status`'s own `_BEAD_RE`
-    recognizes all three layouts; `second-model-bead-audit` already asks `br where` rather
-    than assuming.
-
-    **(a) The cache is stale and the file is still good** — you have hand-edited the JSONL
-    and no flush has happened yet. Rebuild the cache from the file. `br sync --import-only`
-    alone cannot do it: it compares `updated_at`, and equal timestamps with different bodies
-    report `Skipped: N (up-to-date)` forever, so the stale DB has to go first.
-
-    ```bash
-    cp "$BEADS_DB" /tmp/beads.db.bak || { echo "cannot back up the cache — stop"; exit 1; }
-    rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
-    # The removal must have WORKED. `rm -f` reports nothing on a permissions failure, and
-    # a surviving cache makes the import below skip every equal-timestamp record and
-    # report success — after which the flush writes the same stale bodies back over the
-    # file you just restored.
-    for _db in "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"; do
-      [ -e "$_db" ] && { echo "$_db still exists — do NOT import against a stale cache"; exit 1; }
-    done
-    # Checked, for the same reason as case (b): the stale cache is already deleted, so an
-    # import failing on an unreadable JSONL leaves an EMPTY one — and the next `br` write
-    # flushes that over the file whose hand-edits this case exists to preserve.
-    br sync --import-only || { echo "import failed — do NOT run any br command that
-      flushes; the JSONL is your only copy, and /tmp/beads.db.bak is the old cache"; exit 1; }
-    ```
-
-    **(b) The flush already ran and the diff above shows the damage** — then the working
-    copy of the JSONL **is** the damaged artifact, not the truth. Importing it here would
-    copy the loss into a fresh database and a later commit would cement it. **Restore the
-    file from git first, then re-apply every mutation you actually wanted, and only then
-    rebuild the cache:**
-
-    **If the good copy is STAGED, do not reach for `HEAD`.** A body edit staged before an
-    unrelated flush leaves the truth in the *index*, and the field-diff above compares the
-    damaged worktree against exactly that. `git checkout HEAD --` overwrites worktree AND
-    index with the older commit, destroying the only recoverable source — the one thing
-    replaying mutations cannot rebuild. Check first, and restore from the index when it
-    holds the good copy:
-
-    Only the restore SOURCE is conditional. Everything after it — deleting the cache,
-    re-importing, replaying the intended mutations, verifying — has to run either way, or
-    the staged path restores the text and leaves the stale database authoritative, and the
-    next `br` write overwrites the recovery:
-
-    **A staged copy is not evidence the index is good.** An earlier flush may have been
-    staged before anyone noticed, in which case the index holds the damage and `HEAD` holds
-    the truth. Presence tells you a choice exists; only reading tells you which side to
-    take. Inspect both, decide explicitly, and record why:
-
-    ```bash
-    git diff --cached -- "$BEADS_JSONL"   # index vs HEAD — is the staged copy the good one?
-    git diff -- "$BEADS_JSONL"            # worktree vs index — what the flush just did
-    ```
-
-    ```bash
-    # SOURCE: set this from what the two diffs above showed. Do NOT infer it from the mere
-    # presence of a staged version, and do not leave it unset — the default is a refusal,
-    # because guessing here restores the damaged side and the rebuild then preserves it.
-    GOOD=            # HEAD | index
-    case "$GOOD" in
-      HEAD)  git checkout HEAD -- "$BEADS_JSONL" ;;   # last good COMMITTED state
-      index) git checkout -- "$BEADS_JSONL"      ;;   # index -> worktree
-      *)     echo "read both diffs and set GOOD=HEAD or GOOD=index first"; exit 1 ;;
-    esac
-
-    # REBUILD: identical for both sources. Do not skip this on the staged path.
-    cp "$BEADS_DB" /tmp/beads.db.bak || { echo "cannot back up the cache — stop"; exit 1; }
-    rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
-    # The removal must have WORKED. `rm -f` reports nothing on a permissions failure, and
-    # a surviving cache makes the import below skip every equal-timestamp record and
-    # report success — after which the flush writes the same stale bodies back over the
-    # file you just restored.
-    for _db in "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"; do
-      [ -e "$_db" ] && { echo "$_db still exists — do NOT import against a stale cache"; exit 1; }
-    done
-    # CHECK BOTH. The stale database is already deleted at this point, so an import that
-    # fails on an unreadable or invalid JSONL leaves an empty cache — and the flush below
-    # would then write THAT over the file you just restored, destroying the recovery with
-    # the recovery. Same for a failed replay: exit before any flush.
-    br sync --import-only || { echo "import failed — do NOT flush; the JSONL is your only
-      copy right now"; exit 1; }
-    br update <bead-id> -s closed || { echo "replay failed — do NOT flush"; exit 1; }
-    br sync --flush-only || { echo "not persisted"; exit 1; }
-    git diff "$BEADS_JSONL"                    # confirm ONLY the intended fields moved
-    ```
-
-    **Enumerate the intended delta before you delete anything.** The single `br update`
-    above is the *drain's* case, where the round's whole intent is one closure. Callers
-    that batch — `plan-to-beads-transfer` writing a graph, `bead-polish-loop` rewriting
-    several bodies in a round — have many deliberate mutations in flight, and
-    `git checkout HEAD --` discards all of them along with the damage. Before the checkout,
-    write down the complete field-level delta you meant to produce (the round summary those
-    skills already require is exactly that list), then replay it through `br` afterwards.
-    Recovering by restoring git and replaying one command is only safe when one command is
-    all you did.
-
-    Git is the whole recovery here, which is why the field-diff has to happen **before** you
-    stage anything: an uncommitted hand-edit that a flush overwrote is simply gone — no
-    cache holds it and no commit holds it. That is the sharpest reason never to write bead
-    text through the file.
-
-    Either way, verify the restored bodies before the next `br` write. This is **not** the
-    pre-0.1.45 corruption bug in "Tool dependencies": no `ISSUE_NOT_FOUND`, no branch reset
-    involved, and every command reported success.
+    This is **not** the pre-0.1.45 corruption bug in "Tool dependencies": no
+    `ISSUE_NOT_FOUND`, no branch reset, and every command reported success.
 
     Closing on the feature branch before the merge is **not** a safe shortcut, however
     transactional it looks — the beads DB is shared across branches with no git

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -840,8 +840,15 @@ implement → review loop for each bead.
     report `Skipped: N (up-to-date)` forever, so the stale DB has to go first.
 
     ```bash
-    cp "$BEADS_DB" /tmp/beads.db.bak
+    cp "$BEADS_DB" /tmp/beads.db.bak || { echo "cannot back up the cache — stop"; exit 1; }
     rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
+    # The removal must have WORKED. `rm -f` reports nothing on a permissions failure, and
+    # a surviving cache makes the import below skip every equal-timestamp record and
+    # report success — after which the flush writes the same stale bodies back over the
+    # file you just restored.
+    for _db in "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"; do
+      [ -e "$_db" ] && { echo "$_db still exists — do NOT import against a stale cache"; exit 1; }
+    done
     # Checked, for the same reason as case (b): the stale cache is already deleted, so an
     # import failing on an unreadable JSONL leaves an EMPTY one — and the next `br` write
     # flushes that over the file whose hand-edits this case exists to preserve.
@@ -877,8 +884,15 @@ implement → review loop for each bead.
     fi
 
     # REBUILD: identical for both sources. Do not skip this on the staged path.
-    cp "$BEADS_DB" /tmp/beads.db.bak
+    cp "$BEADS_DB" /tmp/beads.db.bak || { echo "cannot back up the cache — stop"; exit 1; }
     rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
+    # The removal must have WORKED. `rm -f` reports nothing on a permissions failure, and
+    # a surviving cache makes the import below skip every equal-timestamp record and
+    # report success — after which the flush writes the same stale bodies back over the
+    # file you just restored.
+    for _db in "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"; do
+      [ -e "$_db" ] && { echo "$_db still exists — do NOT import against a stale cache"; exit 1; }
+    done
     # CHECK BOTH. The stale database is already deleted at this point, so an import that
     # fails on an unreadable or invalid JSONL leaves an empty cache — and the flush below
     # would then write THAT over the file you just restored, destroying the recovery with

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -858,15 +858,21 @@ implement → review loop for each bead.
     replaying mutations cannot rebuild. Check first, and restore from the index when it
     holds the good copy:
 
-    ```bash
-    git diff --cached --quiet -- "$BEADS_JSONL" || echo "GOOD COPY IS STAGED — use the index"
-    git checkout -- "$BEADS_JSONL"             # index -> worktree, keeps the staged truth
-    ```
-
-    Only when the index has nothing newer does the committed state apply:
+    Only the restore SOURCE is conditional. Everything after it — deleting the cache,
+    re-importing, replaying the intended mutations, verifying — has to run either way, or
+    the staged path restores the text and leaves the stale database authoritative, and the
+    next `br` write overwrites the recovery:
 
     ```bash
-    git checkout HEAD -- "$BEADS_JSONL"        # the last good committed state
+    # SOURCE: index when it holds the good copy, HEAD otherwise.
+    if git diff --cached --quiet -- "$BEADS_JSONL"; then
+      git checkout HEAD -- "$BEADS_JSONL"      # nothing staged: last good committed state
+    else
+      echo "good copy is STAGED — restoring from the index, not HEAD"
+      git checkout -- "$BEADS_JSONL"           # index -> worktree, keeps the staged truth
+    fi
+
+    # REBUILD: identical for both sources. Do not skip this on the staged path.
     cp "$BEADS_DB" /tmp/beads.db.bak
     rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
     br sync --import-only

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -773,6 +773,21 @@ implement → review loop for each bead.
     br sync --flush-only || { echo "not persisted"; exit 1; }
     ```
 
+    **Check for divergence BEFORE the first `br` write, not at commit time.** `br update`
+    auto-flushes, so a hand-edit sitting unstaged in the JSONL is destroyed by the very
+    first mutation — and neither the index nor `HEAD` holds it, so the post-write diff then
+    shows only your intended change and there is nothing left to recover. The window is
+    open from the moment the session starts:
+
+    ```bash
+    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+      || { echo "cannot resolve the beads JSONL path"; exit 1; }
+    git status --porcelain -- "$BEADS_JSONL"   # any unstaged/uncommitted bead text?
+    ```
+
+    If that is not empty, resolve it **now** — recovery case (a) below — before running any
+    `br` command. After the first flush the choice is gone.
+
     **That sync proves the closure reached the file. It says nothing about what else the
     same write overwrote — so inspect the file anyway.** Every `br` write flushes the whole
     gitignored `.beads/beads.db` cache over the tracked `.beads/issues.jsonl`, so a write to
@@ -874,14 +889,26 @@ implement → review loop for each bead.
     the staged path restores the text and leaves the stale database authoritative, and the
     next `br` write overwrites the recovery:
 
+    **A staged copy is not evidence the index is good.** An earlier flush may have been
+    staged before anyone noticed, in which case the index holds the damage and `HEAD` holds
+    the truth. Presence tells you a choice exists; only reading tells you which side to
+    take. Inspect both, decide explicitly, and record why:
+
     ```bash
-    # SOURCE: index when it holds the good copy, HEAD otherwise.
-    if git diff --cached --quiet -- "$BEADS_JSONL"; then
-      git checkout HEAD -- "$BEADS_JSONL"      # nothing staged: last good committed state
-    else
-      echo "good copy is STAGED — restoring from the index, not HEAD"
-      git checkout -- "$BEADS_JSONL"           # index -> worktree, keeps the staged truth
-    fi
+    git diff --cached -- "$BEADS_JSONL"   # index vs HEAD — is the staged copy the good one?
+    git diff -- "$BEADS_JSONL"            # worktree vs index — what the flush just did
+    ```
+
+    ```bash
+    # SOURCE: set this from what the two diffs above showed. Do NOT infer it from the mere
+    # presence of a staged version, and do not leave it unset — the default is a refusal,
+    # because guessing here restores the damaged side and the rebuild then preserves it.
+    GOOD=            # HEAD | index
+    case "$GOOD" in
+      HEAD)  git checkout HEAD -- "$BEADS_JSONL" ;;   # last good COMMITTED state
+      index) git checkout -- "$BEADS_JSONL"      ;;   # index -> worktree
+      *)     echo "read both diffs and set GOOD=HEAD or GOOD=index first"; exit 1 ;;
+    esac
 
     # REBUILD: identical for both sources. Do not skip this on the staged path.
     cp "$BEADS_DB" /tmp/beads.db.bak || { echo "cannot back up the cache — stop"; exit 1; }

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -806,31 +806,49 @@ implement → review loop for each bead.
     Recovery depends on **which of the two has the good text**, and getting that backwards
     cements the loss. Establish it before running anything:
 
+    **Resolve the real paths first — `.beads/issues.jsonl` is a default, not a guarantee.**
+    `.beads.jsonl` and `<name>.beads.jsonl` layouts are supported and this repo's own
+    `drive-status` recognizes them (`_BEAD_RE`). A recovery that hardcodes the default
+    restores and deletes paths that do not exist, while the commands after it keep using
+    the *actual* stale cache and damaged file — so it reports success and leaves the loss
+    in place. Ask the tool, exactly as `second-model-bead-audit` already does:
+
+    ```bash
+    BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+      || { echo "cannot resolve the beads JSONL path — do NOT run the recipe blind"; exit 1; }
+    BEADS_DB=$(br where --json | jq -r '.db_path // empty')
+    # Read `br where --json` yourself for the DB field name your version emits; if it
+    # reports none, the cache sits beside the JSONL. Never assume `.beads/beads.db`.
+    [ -n "$BEADS_DB" ] || BEADS_DB="$(dirname "$BEADS_JSONL")/beads.db"
+    ```
+
+    Use `$BEADS_JSONL` and `$BEADS_DB` for every step below — the field-diff above included.
+
     **(a) The cache is stale and the file is still good** — you have hand-edited the JSONL
     and no flush has happened yet. Rebuild the cache from the file. `br sync --import-only`
     alone cannot do it: it compares `updated_at`, and equal timestamps with different bodies
     report `Skipped: N (up-to-date)` forever, so the stale DB has to go first.
 
     ```bash
-    cp .beads/beads.db /tmp/beads.db.bak
-    rm -f .beads/beads.db .beads/beads.db-wal .beads/beads.db-shm
+    cp "$BEADS_DB" /tmp/beads.db.bak
+    rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
     br sync --import-only     # "Imported from JSONL (via automatic recovery)"
     ```
 
     **(b) The flush already ran and the diff above shows the damage** — then the working
-    copy of `issues.jsonl` **is** the damaged artifact, not the truth. Importing it here
-    would copy the loss into a fresh database and a later commit would cement it. **Restore
-    the file from git first, then re-apply every mutation you actually wanted, and only
-    then rebuild the cache:**
+    copy of the JSONL **is** the damaged artifact, not the truth. Importing it here would
+    copy the loss into a fresh database and a later commit would cement it. **Restore the
+    file from git first, then re-apply every mutation you actually wanted, and only then
+    rebuild the cache:**
 
     ```bash
-    git checkout HEAD -- .beads/issues.jsonl   # the last good committed state
-    cp .beads/beads.db /tmp/beads.db.bak
-    rm -f .beads/beads.db .beads/beads.db-wal .beads/beads.db-shm
+    git checkout HEAD -- "$BEADS_JSONL"        # the last good committed state
+    cp "$BEADS_DB" /tmp/beads.db.bak
+    rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
     br sync --import-only
     br update <bead-id> -s closed              # redo the intended write(s), through the CLI
     br sync --flush-only || { echo "not persisted"; exit 1; }
-    git diff .beads/issues.jsonl               # confirm ONLY the intended fields moved
+    git diff "$BEADS_JSONL"                    # confirm ONLY the intended fields moved
     ```
 
     **Enumerate the intended delta before you delete anything.** The single `br update`

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -842,7 +842,11 @@ implement → review loop for each bead.
     ```bash
     cp "$BEADS_DB" /tmp/beads.db.bak
     rm -f "$BEADS_DB" "$BEADS_DB-wal" "$BEADS_DB-shm"
-    br sync --import-only     # "Imported from JSONL (via automatic recovery)"
+    # Checked, for the same reason as case (b): the stale cache is already deleted, so an
+    # import failing on an unreadable JSONL leaves an EMPTY one — and the next `br` write
+    # flushes that over the file whose hand-edits this case exists to preserve.
+    br sync --import-only || { echo "import failed — do NOT run any br command that
+      flushes; the JSONL is your only copy, and /tmp/beads.db.bak is the old cache"; exit 1; }
     ```
 
     **(b) The flush already ran and the diff above shows the damage** — then the working

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -820,8 +820,9 @@ implement → review loop for each bead.
       timestamps with different bodies report `Skipped: N (up-to-date)` forever. The stale
       DB has to go first.
     - **(b) the flush already ran and the diff shows damage** — the working copy *is* the
-      damaged artifact. Restore it from git first, then replay every mutation you meant,
-      then rebuild. Read `git diff --cached` and `git diff` and decide explicitly which of
+      damaged artifact. Restore it from the good side, **rebuild the cache**, and only then
+      replay: replaying first lets the still-stale cache auto-flush over what you just
+      restored. Read `git diff --cached` and `git diff` and decide explicitly which of
       the index or `HEAD` holds the good bodies; a staged copy only proves a choice exists,
       and an earlier flush may have been staged before anyone noticed.
 

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -142,8 +142,13 @@ supplies those to the rb-lite process. For source/path installs, check the host 
 If you skip the file, you get rb-lite's built-in three-reviewer default, unpinned Gemini
 included. That is a choice, not a default this skill endorses — make it deliberately.
 
-Backlog-drain mode additionally needs `br` for bead selection/state and `gh`
-for PR creation/checks/merge. Require **`br` ≥ 0.1.45**: older builds corrupt
+Backlog-drain mode additionally needs `br` for bead selection/state, `gh`
+for PR creation/checks/merge, and **`jq` in the HOST shell**. That last one is not
+covered by the Nix-wrapper exemption above: the wrapper supplies `jq` to rb-lite, not
+to you, and step 11's collateral-damage check and its whole recovery resolve the graph's
+real path through `br where --json | jq`. Without host `jq` a drain can run `br update`
+and flush — silently reverting unrelated bead bodies — and only then fail at the command
+that would have located the damage. Check it before the first bead, not after. Require **`br` ≥ 0.1.45**: older builds corrupt
 their DB after branch resets, so `br update`/`br close` start returning
 `ISSUE_NOT_FOUND` while `br show`/`br list` keep working — which hides the
 failure until bead state is already lost. Both drain modes reset branches after
@@ -802,10 +807,15 @@ implement → review loop for each bead.
     ```bash
     BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
       || { echo "cannot resolve the beads JSONL path — do NOT judge the flush blind"; exit 1; }
+    # Read `br where --json` yourself and use whatever DB field YOUR version emits — the
+    # name below is a guess at the schema, not a contract.
     BEADS_DB=$(br where --json | jq -r '.db_path // empty')
-    # Read `br where --json` yourself for the DB field name your version emits; if it
-    # reports none, the cache sits beside the JSONL. Never assume `.beads/beads.db`.
-    [ -n "$BEADS_DB" ] || BEADS_DB="$(dirname "$BEADS_JSONL")/beads.db"
+    # Do NOT fall back to a derived path. `dirname` of a FLAT `.beads.jsonl` is the repo
+    # root, so the guess lands on `<repo>/beads.db` while the real cache sits under
+    # `.beads/` — recovery would then back up and delete the wrong file and re-import
+    # against the untouched stale database, preserving exactly the loss it is undoing.
+    [ -n "$BEADS_DB" ] || { echo "br where reports no database path — locate it yourself
+      and set BEADS_DB explicitly; do NOT guess, and do NOT run the recipe without it"; exit 1; }
 
     git diff "$BEADS_JSONL"
     ```
@@ -840,6 +850,20 @@ implement → review loop for each bead.
     copy the loss into a fresh database and a later commit would cement it. **Restore the
     file from git first, then re-apply every mutation you actually wanted, and only then
     rebuild the cache:**
+
+    **If the good copy is STAGED, do not reach for `HEAD`.** A body edit staged before an
+    unrelated flush leaves the truth in the *index*, and the field-diff above compares the
+    damaged worktree against exactly that. `git checkout HEAD --` overwrites worktree AND
+    index with the older commit, destroying the only recoverable source — the one thing
+    replaying mutations cannot rebuild. Check first, and restore from the index when it
+    holds the good copy:
+
+    ```bash
+    git diff --cached --quiet -- "$BEADS_JSONL" || echo "GOOD COPY IS STAGED — use the index"
+    git checkout -- "$BEADS_JSONL"             # index -> worktree, keeps the staged truth
+    ```
+
+    Only when the index has nothing newer does the committed state apply:
 
     ```bash
     git checkout HEAD -- "$BEADS_JSONL"        # the last good committed state

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -46,6 +46,11 @@ loop:
 - You know both refs: the *work branch* being hardened and the *review base*
   (usually the default branch). Ask once if either is unclear — the loop runs
   many subcommands and a silent misconfiguration is expensive.
+- **`jq` is on the HOST `PATH`.** Not a backlog-drain-only prerequisite: section 3 runs
+  `br create` and flushes before anything resolves the graph's path, and that resolution
+  is `br where --json | jq` in *your* shell — the Nix wrapper supplies jq to rb-lite, not
+  to you. Without it this loop mutates the graph and only then fails at the command that
+  would have located the damage. Check before section 3, not after.
 - `br` is **≥ 0.1.45**. Older versions corrupt their DB after branch resets:
   `br update`/`br close` start returning `ISSUE_NOT_FOUND` while `br show` and
   `br list` keep working, which hides the problem until you have lost bead state.

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -232,7 +232,7 @@ Then flush and commit — `br` never touches git, that part is yours:
 ```bash
 br sync --flush-only || { echo "findings not persisted"; exit 1; }
 BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
-git diff "$BEADS_JSONL"
+git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
 ```
 
 **Stop the block here and read that diff.** This is a real split, not a comment: run the
@@ -242,7 +242,11 @@ next line stages, commits and pushes the collateral damage, which is the loss th
 exists to catch. Prose underneath a `git add` cannot stop a shell.
 
 ```bash
-git add "$BEADS_JSONL"
+# The split above is a real gate, not a suggestion: an automated runner executing block
+# after block reaches `git add` regardless of what the diff showed. Require the reviewer
+# to record what they saw before anything is staged.
+: "${BEADS_DIFF_REVIEWED:?read the diff above, then set this to what you found}"
+git add -- "$BEADS_JSONL"
 git commit -m "chore(beads): record review findings (iteration <N>, codex+fable)"
 git push
 ```

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -251,7 +251,13 @@ exists to catch. Prose underneath a `git add` cannot stop a shell.
 # The split above is a real gate, not a suggestion: an automated runner executing block
 # after block reaches `git add` regardless of what the diff showed. Require the reviewer
 # to record what they saw before anything is staged.
-: "${BEADS_DIFF_REVIEWED:?read the diff above, then set this to what you found}"
+# Bind the acknowledgement to THIS pass. The loop runs in one shell, so a value set in
+# iteration 1 would satisfy every later iteration and let an unreviewed diff stage,
+# commit and push — the gate passing on the strength of a decision about a different
+# graph. Unset it before the diff, and record the pass it belongs to.
+unset BEADS_DIFF_REVIEWED
+# ...print and read the diff, then:
+: "${BEADS_DIFF_REVIEWED:?read THIS pass's diff, then set it to \"pass $ITERATION: <what you found>\"}"
 git add -- "$BEADS_JSONL"
 git commit -m "chore(beads): record review findings (iteration <N>, codex+fable)"
 git push

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -190,7 +190,7 @@ it still chooses how far to read, so run the grep yourself. Classes that repeat:
 auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
 first write — and since neither the index nor `HEAD` holds it, every later diff shows only
 your intended changes and the loss becomes *undetectable*. Run `git status --porcelain --
-"$(br where --json | jq -r .jsonl_path)"`; if it is not empty, resolve it first — recovery
+"$(br where --json | jq -er .jsonl_path)"`; if it is not empty, resolve it first — recovery
 case (a) in [orchestrating-with-rb-lite](../SKILL.md) step 11. After the first flush the choice
 is gone.
 

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -217,8 +217,9 @@ Then flush and commit — `br` never touches git, that part is yours:
 
 ```bash
 br sync --flush-only || { echo "findings not persisted"; exit 1; }
-git diff .beads/issues.jsonl          # READ THIS — see below
-git add .beads/issues.jsonl
+BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
+git diff "$BEADS_JSONL"               # READ THIS — see below
+git add "$BEADS_JSONL"
 git commit -m "chore(beads): record review findings (iteration <N>, codex+fable)"
 git push
 ```

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -216,11 +216,23 @@ extra round trip.
 Then flush and commit — `br` never touches git, that part is yours:
 
 ```bash
-br sync --flush-only
+br sync --flush-only || { echo "findings not persisted"; exit 1; }
+git diff .beads/issues.jsonl          # READ THIS — see below
 git add .beads/issues.jsonl
 git commit -m "chore(beads): record review findings (iteration <N>, codex+fable)"
 git push
 ```
+
+Do not stage that file unread. The flush re-exports **every** bead from the
+gitignored `.beads/beads.db` cache over the tracked JSONL, so a body the cache
+holds a stale copy of is reverted here — silently, at exit 0, and once committed
+the loss looks like an ordinary bead-state sync. Minting findings as beads is
+when bodies are longest, so this iteration is when the loss costs most. Check the
+field-level changes: a full re-serialization with every id on both sides is
+normal; ids on only one side, or a `description` this iteration did not write, is
+the tell. Never hand-edit the JSONL — that is what makes the cache stale, since a
+hand edit does not advance `updated_at`. Recovery is in
+[SKILL.md](../SKILL.md) step 11.
 
 If the iteration ran degraded, say which reviewer was missing in that commit
 message. Months later it explains why iteration N looks thin.

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -188,19 +188,11 @@ it still chooses how far to read, so run the grep yourself. Classes that repeat:
 
 **Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
 auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
-very first `br update` — and because neither the index nor `HEAD` holds it, every later
-diff shows only your intended changes and the loss is undetectable, let alone recoverable.
-The window is open from the moment the session starts:
-
-```bash
-BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
-  || { echo "cannot resolve the beads JSONL path"; exit 1; }
-git status --porcelain -- "$BEADS_JSONL"
-```
-
-Not empty? Resolve it now — see recovery case (a) in
-[orchestrating-with-rb-lite](../SKILL.md) step 11 — before
-writing anything. After the first flush the choice is gone.
+first write — and since neither the index nor `HEAD` holds it, every later diff shows only
+your intended changes and the loss becomes *undetectable*. Run `git status --porcelain --
+"$(br where --json | jq -r .jsonl_path)"`; if it is not empty, resolve it first — recovery
+case (a) in [orchestrating-with-rb-lite](../SKILL.md) step 11. After the first flush the choice
+is gone.
 
 ## 3. Mint one bead per real finding
 

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -218,7 +218,16 @@ Then flush and commit — `br` never touches git, that part is yours:
 ```bash
 br sync --flush-only || { echo "findings not persisted"; exit 1; }
 BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
-git diff "$BEADS_JSONL"               # READ THIS — see below
+git diff "$BEADS_JSONL"
+```
+
+**Stop the block here and read that diff.** This is a real split, not a comment: run the
+lines above, read the output, and continue below only once you have. Pasted as one block —
+or run non-interactively, where the pager never pauses — the diff scrolls past and the very
+next line stages, commits and pushes the collateral damage, which is the loss this check
+exists to catch. Prose underneath a `git add` cannot stop a shell.
+
+```bash
 git add "$BEADS_JSONL"
 git commit -m "chore(beads): record review findings (iteration <N>, codex+fable)"
 git push

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -194,6 +194,12 @@ your intended changes and the loss becomes *undetectable*. Run `git status --por
 case (a) in [orchestrating-with-rb-lite](../SKILL.md) step 11. After the first flush the choice
 is gone.
 
+**Start a replay manifest before minting.** Section 3 runs one `br create` per finding,
+each auto-flushing, and the damage check comes after all of them. If it fires, step 11's
+recovery deletes the cache and requires every intended mutation replayed — so record the
+`br` commands with their generated ids and field values as you go. Without it, restoring
+the good JSONL discards the whole iteration's legitimate bead additions.
+
 ## 3. Mint one bead per real finding
 
 ```bash

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -185,6 +185,23 @@ it still chooses how far to read, so run the grep yourself. Classes that repeat:
 - redaction on every sibling endpoint returning the same struct
 - scheme/domain/host scoping at every write site of the same cookie
 
+
+**Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
+auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
+very first `br update` — and because neither the index nor `HEAD` holds it, every later
+diff shows only your intended changes and the loss is undetectable, let alone recoverable.
+The window is open from the moment the session starts:
+
+```bash
+BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+  || { echo "cannot resolve the beads JSONL path"; exit 1; }
+git status --porcelain -- "$BEADS_JSONL"
+```
+
+Not empty? Resolve it now — see recovery case (a) in
+[orchestrating-with-rb-lite](../SKILL.md) step 11 — before
+writing anything. After the first flush the choice is gone.
+
 ## 3. Mint one bead per real finding
 
 ```bash

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -99,7 +99,11 @@ Stop and report plan gaps when any of these are still fuzzy:
     and `git diff .beads/issues.jsonl` before committing — ids on only one side, or a
     `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
     cannot do it, is in
-    [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
+    [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — but note
+    its replay step assumes a SINGLE mutation, the drain's case. A transfer has a whole
+    graph in flight, so enumerate the complete intended delta (your coverage matrix is
+    that list) before the `git checkout HEAD --`, or the restore discards every bead this
+    transfer wrote along with the damage.
 11. If the repo workflow supports it, run `br lint` after major rewrites to catch missing sections.
 
 ## Quality bar

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -37,7 +37,7 @@ Turn plan-space intent into bead-space executable memory without losing anything
 auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
 first write — and since neither the index nor `HEAD` holds it, every later diff shows only
 your intended changes and the loss becomes *undetectable*. Run `git status --porcelain --
-"$(br where --json | jq -r .jsonl_path)"`; if it is not empty, resolve it first — recovery
+"$(br where --json | jq -er .jsonl_path)"`; if it is not empty, resolve it first — recovery
 case (a) in [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11. After the first flush the choice
 is gone.
 
@@ -111,7 +111,7 @@ Stop and report plan gaps when any of these are still fuzzy:
     what makes the cache stale: a hand edit does not advance `updated_at`, so the two
     become indistinguishable by timestamp. Write every body through `br update -d/--notes`,
     and field-diff the tracked JSONL before committing (resolve it with
-    `br where --json | jq -r .jsonl_path`; `.beads/` is only the default layout, and a
+    `br where --json | jq -er .jsonl_path`; `.beads/` is only the default layout, and a
     hardcoded path diffs nothing on the others) — ids on only one side, or a
     `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
     cannot do it, is in

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -76,6 +76,13 @@ Stop and report plan gaps when any of these are still fuzzy:
    - use tasks for independently claimable work packets
    - use subtasks only when they sharpen sequencing instead of hiding it
    - when one plan concept fans out into multiple deliverables, choose a canonical root bead that carries the full why/constraints/test story and let dependents carry the local details they need
+**Start the replay manifest before step 4, and keep it current.** Steps 4 and 7 write
+beads and auto-flush, so by step 9 the damage may already be done; recovery discards the
+working JSONL before you could read the generated ids back off it. One line per intended
+`br` command, complete enough to re-run verbatim, appended as each id is assigned. The
+coverage matrix maps plan elements to beads — it does not preserve ids, field values, or
+order.
+
 4. Create or update actual beads only with `br`.
 5. Write each material bead so it is self-contained. Use [references/bead-description-template.md](references/bead-description-template.md), and elaborate beyond the source plan whenever that removes ambiguity.
 6. Preserve important intent, not just surface tasks:
@@ -90,11 +97,7 @@ Stop and report plan gaps when any of these are still fuzzy:
    - plan -> beads: every important plan element lands somewhere
    - beads -> plan: every bead has clear backing in the plan or an explicitly approved delta
    - if the audit feels suspiciously short or self-satisfied, assume coverage is incomplete and rerun more exhaustively
-9. Before the first `br` write, record the exact list of intended mutations — the `br`
-   commands with their ids and field values, in order. The coverage matrix maps plan
-   elements to beads; it does not preserve generated ids or field values, and recovery
-   discards the working JSONL before you could recover them from it.
-9a. Split, merge, rewrite, or close beads until the graph can stand on its own as executable memory.
+9. Split, merge, rewrite, or close beads until the graph can stand on its own as executable memory.
 10. Flush with an **explicit** `br sync --flush-only` and require it to succeed:
 
     ```bash

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -88,6 +88,18 @@ Stop and report plan gaps when any of these are still fuzzy:
     mutation is still in the shared DB, so this sync either writes it or fails loudly. A
     re-run whose graph already matches the plan syncs cleanly and writes nothing; that is
     a no-op, not a failure.
+
+    **A flush also writes the cache over the file.** The sync proves your mutation
+    persisted; it does not tell you what else it overwrote. Every `br` write re-exports
+    *all* beads from the gitignored `.beads/beads.db`, so a body the cache holds a stale
+    copy of is reverted — silently, exit 0. Transferring a plan means writing long
+    specification bodies, and pasting one into `.beads/issues.jsonl` by hand is precisely
+    what makes the cache stale: a hand edit does not advance `updated_at`, so the two
+    become indistinguishable by timestamp. Write every body through `br update -d/--notes`,
+    and `git diff .beads/issues.jsonl` before committing — ids on only one side, or a
+    `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
+    cannot do it, is in
+    [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
 11. If the repo workflow supports it, run `br lint` after major rewrites to catch missing sections.
 
 ## Quality bar

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -32,6 +32,23 @@ Turn plan-space intent into bead-space executable memory without losing anything
 - If the session was compacted, or the plan changed materially since the last pass, reread before editing.
 - Refuse the transfer if core workflows, boundaries, constraints, failure modes, sequencing, or verification are still unstable. Report plan gaps instead of encoding guesses into beads.
 
+
+**Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
+auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
+very first `br create`/`br update` — and because neither the index nor `HEAD` holds it,
+every later diff shows only your intended changes and the loss is undetectable, let alone
+recoverable. The window is open from the moment the session starts:
+
+```bash
+BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+  || { echo "cannot resolve the beads JSONL path"; exit 1; }
+git status --porcelain -- "$BEADS_JSONL"
+```
+
+Not empty? Resolve it now — see recovery case (a) in
+[orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — before
+writing anything. After the first flush the choice is gone.
+
 ## Translation readiness test
 
 Only transfer when most of the hard thinking already happened in plan space.

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -22,7 +22,12 @@ Turn plan-space intent into bead-space executable memory without losing anything
 
 ## Preflight
 
-- Confirm `br` and `bv` are on `PATH`. If either is missing, stop and say so.
+- Confirm `br`, `bv`, **and `jq`** are on `PATH`. If any is missing, stop and say so.
+  `jq` is load-bearing, not optional: every `br` write can silently revert other beads
+  (step 10), and both the damage check and the recovery resolve the graph's real path
+  through `br where --json | jq`. Without it a transfer can write a whole graph and then
+  be unable to tell whether it destroyed one — the ordering that must not be possible.
+  If `br where --json` cannot be parsed on this host, do not write to the graph.
 - Re-read `AGENTS.md`, `README.md`, and every relevant plan/spec file before mutating the graph.
 - If the session was compacted, or the plan changed materially since the last pass, reread before editing.
 - Refuse the transfer if core workflows, boundaries, constraints, failure modes, sequencing, or verification are still unstable. Report plan gaps instead of encoding guesses into beads.

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -124,8 +124,9 @@ order.
     cannot do it, is in
     [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — but note
     its replay step assumes a SINGLE mutation, the drain's case. A transfer has a whole
-    graph in flight, so enumerate the complete intended delta (your coverage matrix is
-    that list) before the `git checkout HEAD --`, or the restore discards every bead this
+    graph in flight, so enumerate the complete intended delta (the replay manifest you started before step 4 —
+    NOT the coverage matrix, which maps plan elements to beads and preserves no ids, field
+    values or ordering) before the `git checkout HEAD --`, or the restore discards every bead this
     transfer wrote along with the damage.
 11. If the repo workflow supports it, run `br lint` after major rewrites to catch missing sections.
 

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -90,7 +90,11 @@ Stop and report plan gaps when any of these are still fuzzy:
    - plan -> beads: every important plan element lands somewhere
    - beads -> plan: every bead has clear backing in the plan or an explicitly approved delta
    - if the audit feels suspiciously short or self-satisfied, assume coverage is incomplete and rerun more exhaustively
-9. Split, merge, rewrite, or close beads until the graph can stand on its own as executable memory.
+9. Before the first `br` write, record the exact list of intended mutations — the `br`
+   commands with their ids and field values, in order. The coverage matrix maps plan
+   elements to beads; it does not preserve generated ids or field values, and recovery
+   discards the working JSONL before you could recover them from it.
+9a. Split, merge, rewrite, or close beads until the graph can stand on its own as executable memory.
 10. Flush with an **explicit** `br sync --flush-only` and require it to succeed:
 
     ```bash

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -126,8 +126,10 @@ order.
     its replay step assumes a SINGLE mutation, the drain's case. A transfer has a whole
     graph in flight, so enumerate the complete intended delta (the replay manifest you started before step 4 —
     NOT the coverage matrix, which maps plan elements to beads and preserves no ids, field
-    values or ordering) before the `git checkout HEAD --`, or the restore discards every bead this
-    transfer wrote along with the damage.
+    values or ordering) before restoring — and restore from the source you established holds the good bodies,
+    which is not automatically `HEAD`: if the index holds the last good export and HEAD
+    an older one, `git checkout HEAD --` overwrites the good staged copy too. Step 11
+    requires that choice explicitly; make it there rather than assuming.
 11. If the repo workflow supports it, run `br lint` after major rewrites to catch missing sections.
 
 ## Quality bar

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -96,7 +96,9 @@ Stop and report plan gaps when any of these are still fuzzy:
     specification bodies, and pasting one into `.beads/issues.jsonl` by hand is precisely
     what makes the cache stale: a hand edit does not advance `updated_at`, so the two
     become indistinguishable by timestamp. Write every body through `br update -d/--notes`,
-    and `git diff .beads/issues.jsonl` before committing — ids on only one side, or a
+    and field-diff the tracked JSONL before committing (resolve it with
+    `br where --json | jq -r .jsonl_path`; `.beads/` is only the default layout, and a
+    hardcoded path diffs nothing on the others) — ids on only one side, or a
     `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
     cannot do it, is in
     [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — but note

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -35,19 +35,11 @@ Turn plan-space intent into bead-space executable memory without losing anything
 
 **Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
 auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
-very first `br create`/`br update` — and because neither the index nor `HEAD` holds it,
-every later diff shows only your intended changes and the loss is undetectable, let alone
-recoverable. The window is open from the moment the session starts:
-
-```bash
-BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
-  || { echo "cannot resolve the beads JSONL path"; exit 1; }
-git status --porcelain -- "$BEADS_JSONL"
-```
-
-Not empty? Resolve it now — see recovery case (a) in
-[orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — before
-writing anything. After the first flush the choice is gone.
+first write — and since neither the index nor `HEAD` holds it, every later diff shows only
+your intended changes and the loss becomes *undetectable*. Run `git status --porcelain --
+"$(br where --json | jq -r .jsonl_path)"`; if it is not empty, resolve it first — recovery
+case (a) in [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11. After the first flush the choice
+is gone.
 
 ## Translation readiness test
 

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -160,8 +160,14 @@ recorded acceptance of the reduced review coverage.
    # again, so the diff comes back empty and the loss is undetectable. Recovery is in
    # ../orchestrating-with-rb-lite/SKILL.md step 11.
    BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
-   [ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
-     || { echo "JSONL diverges from git — resolve it BEFORE flushing"; exit 1; }
+   # INSPECT, do not gate on cleanliness: the normal bead-polish-loop handoff arrives with
+   # the round's intended `br` edits uncommitted, so demanding a clean file would block the
+   # audit after every non-noop round. `git status` cannot tell an intended mutation from a
+   # hand edit — only reading the diff can. Compare against HEAD, not the index: a damaged
+   # JSONL that is staged makes a worktree-vs-index diff empty while HEAD still holds the
+   # good bodies.
+   git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
+   : "${BEADS_DIFF_REVIEWED:?read the diff above, then set this to how you resolved it}"
    br sync --flush-only || { echo "flush failed"; exit 1; }
    br list --limit 0 --json -a
    bv --robot-triage

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -153,6 +153,12 @@ recorded acceptance of the reduced review coverage.
    # An explicit sync propagates a real exit code, so require success. (Only the automatic
    # post-mutation flush swallows its error.) An unchanged graph legitimately reports no
    # diff, so do not also demand that the JSONL changed here.
+   # A flush writes the whole gitignored beads.db cache over the tracked issues.jsonl, so
+   # any bead body hand-edited into the file (which does not advance updated_at) is
+   # silently reverted here — exit 0, no warning. `git diff .beads/issues.jsonl` after
+   # this and check the field-level changes before capturing a baseline: an audit over a
+   # truncated graph reviews text the reviewers will never see. See
+   # ../orchestrating-with-rb-lite/SKILL.md step 11 for recovery.
    br sync --flush-only || { echo "flush failed"; exit 1; }
    br list --limit 0 --json -a
    bv --robot-triage

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -169,6 +169,12 @@ recorded acceptance of the reduced review coverage.
    git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
    : "${BEADS_DIFF_REVIEWED:?read the diff above, then set this to how you resolved it}"
    br sync --flush-only || { echo "flush failed"; exit 1; }
+   # AND AGAIN AFTER. A clean pre-flush diff only means the worktree matched git — it says
+   # nothing about the gitignored cache, so a stale DB introduces the damage HERE. Read
+   # this before consuming the graph; auditing a truncated one reviews text the reviewers
+   # will never see.
+   git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT audit"; exit 1; }
+   : "${BEADS_POSTFLUSH_REVIEWED:?read the post-flush diff above before auditing}"
    br list --limit 0 --json -a
    bv --robot-triage
    bv --robot-plan

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -153,13 +153,15 @@ recorded acceptance of the reduced review coverage.
    # An explicit sync propagates a real exit code, so require success. (Only the automatic
    # post-mutation flush swallows its error.) An unchanged graph legitimately reports no
    # diff, so do not also demand that the JSONL changed here.
-   # A flush writes the whole gitignored beads.db cache over the tracked issues.jsonl, so
-   # any bead body hand-edited into the file (which does not advance updated_at) is
-   # silently reverted here — exit 0, no warning. `git diff "$(br where --json | jq -r
-   # .jsonl_path)"` after
-   # this and check the field-level changes before capturing a baseline: an audit over a
-   # truncated graph reviews text the reviewers will never see. See
-   # ../orchestrating-with-rb-lite/SKILL.md step 11 for recovery.
+   # A flush writes the whole gitignored beads.db cache over the tracked JSONL, so any bead
+   # body hand-edited into the file (which does not advance updated_at) is silently
+   # reverted — exit 0, no warning — and an audit over a truncated graph reviews text the
+   # reviewers will never see. Check BEFORE flushing: afterwards the file matches the index
+   # again, so the diff comes back empty and the loss is undetectable. Recovery is in
+   # ../orchestrating-with-rb-lite/SKILL.md step 11.
+   BEADS_JSONL=$(br where --json | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
+   [ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
+     || { echo "JSONL diverges from git — resolve it BEFORE flushing"; exit 1; }
    br sync --flush-only || { echo "flush failed"; exit 1; }
    br list --limit 0 --json -a
    bv --robot-triage

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -155,7 +155,8 @@ recorded acceptance of the reduced review coverage.
    # diff, so do not also demand that the JSONL changed here.
    # A flush writes the whole gitignored beads.db cache over the tracked issues.jsonl, so
    # any bead body hand-edited into the file (which does not advance updated_at) is
-   # silently reverted here — exit 0, no warning. `git diff .beads/issues.jsonl` after
+   # silently reverted here — exit 0, no warning. `git diff "$(br where --json | jq -r
+   # .jsonl_path)"` after
    # this and check the field-level changes before capturing a baseline: an audit over a
    # truncated graph reviews text the reviewers will never see. See
    # ../orchestrating-with-rb-lite/SKILL.md step 11 for recovery.

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -150,8 +150,16 @@ BEADS_JSONL=$(br where --json | jq -er '.jsonl_path')
 # `description` this session did not write, is the tell. Recovery:
 # ../../orchestrating-with-rb-lite/SKILL.md step 11.
 git diff -- "$BEADS_JSONL"
-# Do not continue past this line until you have read that output.
+```
 
+**Stop the block here.** The line above is a real gate, not a comment: run the snapshot
+block only up to this point, read the diff, and continue *in a second invocation* once you
+have. A comment does not pause a shell — pasted as one block, the diff scrolls past and the
+copy below snapshots whatever the flush produced, which is the entire failure this check
+exists to catch. If you must automate it, make the continuation conditional on an explicit
+recorded acknowledgement rather than on the diff having been printed.
+
+```bash
 cp "$BEADS_JSONL" "$GRAPH_JSONL"
 GRAPH_FINGERPRINT=$(fingerprint_file "$GRAPH_JSONL") || {
   echo "Could not fingerprint initial graph snapshot" >&2

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -138,8 +138,20 @@ for src in "${SOURCE_FILES[@]}"; do
   printf '%s\t%s\n' "$live_fp" "$src" >>"$SOURCE_STATE_BEFORE"
 done
 
-br sync --flush-only
+br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
 BEADS_JSONL=$(br where --json | jq -er '.jsonl_path')
+
+# STOP HERE AND READ THIS DIFF before snapshotting. The flush just re-exported EVERY bead
+# from the gitignored cache over the tracked JSONL, so any body the cache held a stale copy
+# of was silently reverted — exit 0, no warning. Snapshot now and the panel audits the
+# truncated graph, which is the one failure an audit cannot catch by reading: the text it
+# would have objected to is already gone. Field-diff it, key the +/- lines by `id`, and
+# assert only the fields you meant to change moved. Ids on one side only, or a
+# `description` this session did not write, is the tell. Recovery:
+# ../../orchestrating-with-rb-lite/SKILL.md step 11.
+git diff -- "$BEADS_JSONL"
+# Do not continue past this line until you have read that output.
+
 cp "$BEADS_JSONL" "$GRAPH_JSONL"
 GRAPH_FINGERPRINT=$(fingerprint_file "$GRAPH_JSONL") || {
   echo "Could not fingerprint initial graph snapshot" >&2

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -158,6 +158,12 @@ BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
 # clean-looking diff and flush the damage.
 git status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
 git diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
+# Keep a copy of what the worktree held BEFORE the flush. Neither git ref works as the
+# post-flush baseline: if the index holds an earlier damaged export and the worktree holds
+# the good recovery, HEAD-vs-worktree looks fine beforehand, the flush replaces the good
+# copy with the indexed damage, and a worktree-vs-index diff afterwards is EMPTY because
+# both now hold it. Only the pre-flush bytes can show that.
+cp "$BEADS_JSONL" "$AUDIT_DIR/preflush.jsonl" || { echo "cannot preserve the pre-flush graph" >&2; exit 1; }
 : "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
 br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
 
@@ -180,6 +186,10 @@ exists to catch. If you must automate it, make the continuation conditional on a
 recorded acknowledgement rather than on the diff having been printed.
 
 ```bash
+# Compare against the PRE-FLUSH bytes, not against the index. This is the only baseline
+# that can show a flush replacing a good worktree copy with an indexed damaged one.
+diff -u "$AUDIT_DIR/preflush.jsonl" "$BEADS_JSONL" \
+  || : "${BEADS_POSTFLUSH_REVIEWED:?the flush changed the graph — read that diff, then set this}"
 cp "$BEADS_JSONL" "$GRAPH_JSONL"
 GRAPH_FINGERPRINT=$(fingerprint_file "$GRAPH_JSONL") || {
   echo "Could not fingerprint initial graph snapshot" >&2

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -153,8 +153,11 @@ BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
 # The question is not "is it dirty" but "is any of this dirt something the cache will
 # destroy" — i.e. hand-edited bead text, which never advances `updated_at`. Read the diff
 # and continue only once you can say which it is.
-git status --porcelain -- "$BEADS_JSONL"
-git diff -- "$BEADS_JSONL"
+# Against HEAD, not the index: a damaged JSONL that is STAGED makes a worktree-vs-index
+# diff empty while HEAD still holds the good bodies, so the operator would acknowledge a
+# clean-looking diff and flush the damage.
+git status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
+git diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
 : "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
 br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
 

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -144,7 +144,10 @@ done
 # truncated graph having "checked". The check has to precede the write it guards.
 BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
   || { echo "cannot resolve the beads JSONL path" >&2; exit 1; }
-git status --porcelain -- "$BEADS_JSONL"   # not empty? resolve it before flushing
+# ABORT on divergence — printing it is not enough. The next line flushes the cache over
+# this file, and run as one block the status scrolls past and the only good copy is gone.
+[ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
+  || { echo "JSONL diverges from git — resolve it BEFORE flushing (recovery case (a))" >&2; exit 1; }
 br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
 
 # STOP HERE AND READ THIS DIFF before snapshotting. The flush just re-exported EVERY bead

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -138,8 +138,14 @@ for src in "${SOURCE_FILES[@]}"; do
   printf '%s\t%s\n' "$live_fp" "$src" >>"$SOURCE_STATE_BEFORE"
 done
 
+# RESOLVE AND INSPECT BEFORE FLUSHING. The flush writes the cache over the tracked file,
+# so an unstaged hand-edit is destroyed HERE — and the diff below then compares the file
+# against an index that already matches it, comes back empty, and the audit snapshots the
+# truncated graph having "checked". The check has to precede the write it guards.
+BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
+  || { echo "cannot resolve the beads JSONL path" >&2; exit 1; }
+git status --porcelain -- "$BEADS_JSONL"   # not empty? resolve it before flushing
 br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
-BEADS_JSONL=$(br where --json | jq -er '.jsonl_path')
 
 # STOP HERE AND READ THIS DIFF before snapshotting. The flush just re-exported EVERY bead
 # from the gitignored cache over the tracked JSONL, so any body the cache held a stale copy

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -144,10 +144,18 @@ done
 # truncated graph having "checked". The check has to precede the write it guards.
 BEADS_JSONL=$(br where --json | jq -er '.jsonl_path') \
   || { echo "cannot resolve the beads JSONL path" >&2; exit 1; }
-# ABORT on divergence — printing it is not enough. The next line flushes the cache over
-# this file, and run as one block the status scrolls past and the only good copy is gone.
-[ -z "$(git status --porcelain -- "$BEADS_JSONL")" ] \
-  || { echo "JSONL diverges from git — resolve it BEFORE flushing (recovery case (a))" >&2; exit 1; }
+# INSPECT before flushing — the next line writes the cache over this file, so anything in
+# the worktree that the cache does not know about is gone afterwards, with no diff left to
+# show it. Do NOT gate on a clean file: the normal `bead-polish-loop` handoff arrives with
+# the round's intended `br` edits uncommitted, so demanding cleanliness would block the
+# audit after every non-noop round.
+#
+# The question is not "is it dirty" but "is any of this dirt something the cache will
+# destroy" — i.e. hand-edited bead text, which never advances `updated_at`. Read the diff
+# and continue only once you can say which it is.
+git status --porcelain -- "$BEADS_JSONL"
+git diff -- "$BEADS_JSONL"
+: "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
 br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
 
 # STOP HERE AND READ THIS DIFF before snapshotting. The flush just re-exported EVERY bead


### PR DESCRIPTION
Closes #20.

A single `br update` on **one** bead silently reverted ~40 KB of specification
text across **three other** beads and deleted a fourth outright. Exit 0, success
message, nothing failed. It was visible only by field-diffing
`.beads/issues.jsonl` before committing — committed, it would have looked like an
ordinary bead-state sync.

**Every skill in this repo that writes beads told you to run the flush. None told
you to look at what it wrote.**

## Mechanism

`.beads/beads.db` is a gitignored SQLite cache; `.beads/issues.jsonl` is what git
tracks and what reviewers read. Every `br` write flushes the **cache** over the
**file** — so writing an unrelated bead rewrites all of them. Hand-editing the
JSONL is what makes the cache stale, and a hand edit does not advance
`updated_at`, so cache and file hold different bodies under identical timestamps
and nothing can distinguish them.

Three things compound it:

1. **Any write flushes everything.** You do not have to touch the damaged bead to damage it.
2. **The advertised guard misses it by design.** `br sync --help`'s *"Stale DB Guard: refuses to export if JSONL has issues missing from DB"* is an **id**-level check; same-id-different-body is the case that loses text. In the observed run the id-level case did not fire either — a bead present in the JSONL and absent from the DB was dropped by the auto-flush, which is the guard's literal precondition.
3. **`br sync --import-only` cannot repair it.** It compares `updated_at`; equal timestamps with different bodies report `Skipped: N (up-to-date)` forever. Recovery means deleting the cache and re-importing, since the tracked file is truth.

## Placement

Full mechanism, field-diff procedure and recovery live once, in
**`orchestrating-with-rb-lite` step 11** — the drain's last write, which routes
you into the hazard on *every* bead. Compact pointers at each of the other write
sites, because a reader who jumps to a numbered step must see it there:

| Skill | Site | Why it matters there |
|---|---|---|
| `bead-polish-loop` | step 5 flush | rewrites long bead bodies for a living — peak temptation to open the file |
| `plan-to-beads-transfer` | step 10 flush | pasting a spec body in by hand is exactly how the cache goes stale |
| `second-model-bead-audit` | step 5 baseline flush | an audit over a truncated graph reviews text the reviewers never see |
| `drive` | Guard 1, `br` bullet | sits directly beside the *other* `br` exit-0 trap |
| `drive/references/phases.md` | LAND closure | |
| `harden-until-clean.md` | findings commit | |

This follows the repo's existing pattern — the "automatic flush swallows its
error" hazard is already inlined at each of these sites rather than centralised.

## Two defects found while editing those sites

- **`harden-until-clean.md` staged `.beads/issues.jsonl` with no diff at all**, and ran its flush **without a `||` check** — against the repo's own stated rule, and in the one iteration where bodies are longest (minting findings as beads). Fixed both.
- **The task template's `.beads/` line is a *reviewing* scope rule** — "orchestration/state directories, not product code to review" — but read by the **operator** it sounds like an editing licence. Now says so explicitly.

## One correction to the issue text

The issue quotes the task template as saying *"the bead text is updated by the
operator, not by you"*. That string is **not in the skill** — `grep` across the
repo returns nothing. The template now reads "Treat `.rb-lite/` … and `.beads/`
as orchestration/state directories, not product code to review." The point stands
verbatim, so I kept it and quoted what the file actually says rather than
shipping a quote of text that does not exist.

## Scope note

Not the pre-0.1.45 DB-corruption bug already documented in "Tool dependencies":
no `ISSUE_NOT_FOUND`, no branch reset involved, and every command reported
success. Both warnings now sit near each other, so each says which failure it
guards.

## Gates

```
skills/drive/scripts/drive-status.test                  passed 70,  failed 0
skills/pr-with-codex-bot-review/scripts/bot-gate.test    passed 104, failed 0
```

All six new cross-skill relative links verified to resolve on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Round 2 — bot findings, all fixed

- **[P2] The recovery replay assumes one mutation.** Step 11 replays `br update <id> -s closed` because the drain's whole round intent *is* one closure — but this PR pointed `plan-to-beads-transfer` and `bead-polish-loop` at it, and those batch. Following it there restores git and replays one command, discarding every deliberate addition and rewrite: **a second data loss, caused by the recovery for the first.** Step 11 now says to enumerate the complete intended field-level delta before the checkout, and both batching callers carry the caveat pointing at the list they already produce.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stronger preflight checks for required command-line tools and valid data locations.
  * Added safeguards to detect unsaved or divergent tracking data before changes are applied.
  * Added explicit review steps and post-sync inspection to identify unexpected updates.
  * Added replay manifests to support recovery from interrupted multi-step changes.

* **Documentation**
  * Clarified supported update workflows and prohibited manual editing of tracked data.
  * Improved closure, auditing, synchronization, and cache-overwrite guidance to reduce accidental data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->