### PR TITLE
bot-gate: exit 4 when a round finished but nothing attributes it, plus the degraded-forge procedure

### DIFF
--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -112,6 +112,13 @@ If none resolve, you are running from a checkout rather than an install: run
 `<skill-dir>/scripts/drive-status` explicitly. If you cannot locate it, say so — do not
 infer the phase by hand.
 
+**If you are recalling this skill rather than reading it now, re-read the on-disk copy
+before following it.** A copy loaded earlier in a session, or carried through a context
+summarisation, may predate a script that replaced prose — this skill and
+`pr-with-codex-bot-review` both moved load-bearing logic out of their text and into
+`scripts/`, and remembered prose is then a version that was retired for being wrong. The
+tell is a procedure you can recite in full without having opened a file this turn.
+
 It prints repo, branch, cleanliness, gate command, bead counts, PR state, spec files, the
 cleared SHA, and an inferred phase. `scripts/drive-status.test` covers the derivation —
 one case per real defect, against scratch repos and a stubbed `gh`, each shown to go red against a

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -435,9 +435,14 @@ Collect across pages and take `last`: the endpoint returns reviews oldest-first,
 several rounds a bare stream prints one SHA per round with no indication which is current.
 (`--slurp` cannot combine with `--jq`, hence the pipe.)
 
-If the codex bot reacted `+1` with no wrapper, you have no SHA anchor — it leaves no
-wrapper on a clean round, so nothing proves which tree it read. `@codex review` to get one,
-or accept that round explicitly and record why.
+If the codex bot reacted `+1` with no wrapper, you have no SHA anchor — nothing proves
+which tree that round read. `bot-gate` reports this as its own verdict,
+`BLOCKED_UNATTRIBUTED` at **exit 4**: still a refusal, but one that says waiting will not
+fix it, because the missing signal is the one that would attribute the round. Do not put
+this phase in a poll loop on exit 4. `@codex review` to force a fresh wrapper, or follow
+the degraded-forge procedure in `pr-with-codex-bot-review` § 8b and record what you
+substituted. A plain exit 1 with no wrapper is the other case — the bot has not reviewed
+this tip — and there, waiting is exactly right.
 
 CodeRabbit's status is a **PR-level signal**, not per-commit: it lands on whatever head
 exists when the bot posts it, so a green on the tip is not evidence about the tip. ADR 0004

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -437,12 +437,14 @@ several rounds a bare stream prints one SHA per round with no indication which i
 
 If the codex bot reacted `+1` with no wrapper, you have no SHA anchor — nothing proves
 which tree that round read. `bot-gate` reports this as its own verdict,
-`BLOCKED_UNATTRIBUTED` at **exit 4**: still a refusal, but one that says waiting will not
-fix it, because the missing signal is the one that would attribute the round. Do not put
-this phase in a poll loop on exit 4. `@codex review` to force a fresh wrapper, or follow
-the degraded-forge procedure in `pr-with-codex-bot-review` § 8b and record what you
-substituted. A plain exit 1 with no wrapper is the other case — the bot has not reviewed
-this tip — and there, waiting is exactly right.
+`BLOCKED_UNATTRIBUTED` at **exit 4**: still a refusal, but one saying that more waiting
+may not fix it, because the missing signal is the one that would attribute the round. Do
+not sit in a poll loop on exit 4. `@codex review` to force a fresh wrapper — try that
+first, since exit 4 also fires when a sticky older 👍 merely post-dates your local commit.
+If no wrapper follows, confirm a real incident and use the degraded-forge procedure in
+`pr-with-codex-bot-review` § 8b, recording what you substituted. A plain exit 1 with no
+wrapper is the other case — the bot has not reviewed this tip — and there, waiting is
+exactly right.
 
 CodeRabbit's status is a **PR-level signal**, not per-commit: it lands on whatever head
 exists when the bot posts it, so a green on the tip is not evidence about the tip. ADR 0004

--- a/skills/pr-with-codex-bot-review/SKILL.md
+++ b/skills/pr-with-codex-bot-review/SKILL.md
@@ -573,20 +573,31 @@ condition:
 
      **Exit 4 refuses the merge exactly as 1 does** — any caller doing `bot-gate <PR> &&
      gh pr merge` is unaffected. It exists for a caller that *loops*: exit 1 usually means
-     wait, exit 4 means waiting cannot help, because the signal that would attribute the
-     round is the one that is missing. It fires only when every other conjunct already
-     holds and the bot's `+1` post-dates the tip's commit — per the bot's own about-box,
-     *"if Codex has suggestions, it will comment; otherwise it will react with 👍"*, so a
-     👍 is a completed round, attached to the PR and never to a commit. A 👍 older than the
-     tip provably belongs to an earlier tree and leaves a plain exit 1. See § 8b.
+     wait, exit 4 means waiting **may** not help, because the signal that would attribute
+     the round is the one that is missing. It fires only when every other conjunct already
+     holds, the bot's `+1` post-dates the tip's commit, and no `eyes` reaction is at or
+     after that `+1`. Per the bot's own about-box — *"if Codex has suggestions, it will
+     comment; otherwise it will react with 👍"* — a 👍 is a completed round, attached to
+     the PR and never to a commit. A 👍 older than the tip provably belongs to an earlier
+     tree and leaves a plain exit 1. See § 8b.
 
-     Two honesty notes about that path. It is derived from the bot's **documented
-     contract**, not from an observation here — this repo's own 19-round sample on PR #16
-     saw the `+1` fire zero times, so the exit-4 branch has never been exercised against
-     live traffic. And a reactions query that fails on this path leaves the plain exit 1
-     rather than escalating to 3: the reaction can only make an already-blocking answer
-     *more specific*, so refusing a decidable PR because a warning could not be refined
-     would be the wrong trade.
+     **Try `@codex review` before treating exit 4 as an outage.** Three honesty notes:
+
+     - **The bound is a lower one, and it admits a false positive.** The honest boundary is
+       when the tip became the PR head, and nothing reports that — GitHub's timeline
+       carries `head_ref_force_pushed` but not an ordinary push, the same gap the
+       round-start list already documents. So: commit locally, the bot thumbs the *old*
+       remote head, then you push. The 👍 survives (one reaction per user per item, so the
+       bot cannot refresh or remove it) and satisfies the comparison though nothing read
+       this tip. It is kept because the failure is one-directional — it can only turn a
+       block into a differently-worded block — and § 8b's first instruction, confirm a real
+       incident on the status page, is exactly what disproves it.
+     - **It has never met live traffic.** Derived from the bot's documented contract, not
+       from an observation here: this repo's own 19-round sample on PR #16 saw the `+1` fire
+       zero times.
+     - **A failed reactions read leaves the plain exit 1**, not 3. The reaction can only
+       make an already-blocking answer *more specific*, so refusing a decidable PR because a
+       warning could not be refined would be the wrong trade.
 
      `--no-coderabbit` is gone, and rejected as an unknown option with exit 2 rather than
      accepted and ignored. It existed to assert a fact no query could establish — whether
@@ -856,9 +867,12 @@ did.
 | Gate says | Means | Do |
 |---|---|---|
 | `BLOCKED`, wrapper 0, no other signal | the bot has not reviewed this tip | wait, or `@codex review` |
-| `BLOCKED_UNATTRIBUTED` (exit 4) | a round *completed* — its 👍 post-dates the tip — but nothing says which tree it read | waiting cannot fix this; go on |
+| `BLOCKED_UNATTRIBUTED` (exit 4) | a round *completed* — its 👍 post-dates the tip — but nothing says which tree it read | `@codex review` first; if no wrapper comes, go on |
 
 Exit 4 is still a refusal. It changes what you do next, never whether the gate approved.
+And it is not proof of an outage: the 👍 is sticky and bounded only by the tip's local
+commit time, so it can also be an *older* head thumbed after you committed (§ 7). That is
+precisely why the next step is to confirm the incident rather than assume it.
 
 **Second, confirm it is actually an incident**, not a quiet bot. Check
 <https://www.githubstatus.com> and say what you saw. "The wrapper is missing" is not

--- a/skills/pr-with-codex-bot-review/SKILL.md
+++ b/skills/pr-with-codex-bot-review/SKILL.md
@@ -8,11 +8,14 @@ description: >-
   codex bot's actual behavior — auto-fires on substantive code PRs, often silent on
   docs-only PRs, line-level findings live in PR review comments not the review body —
   re-triggering with `@codex review`, addressing findings via amend + force-push, knowing
-  when to merge despite bot silence, and the squash-merge + branch-reset pattern. Use
-  this skill whenever the user asks to open a PR, "ship this", "merge it", "let the bot
-  review", "land the change", or right after substantial code work that's ready for
-  review. Also when the user asks why the bot "isn't reviewing" or how to interpret what
-  it left behind.
+  when to merge despite bot silence, and the squash-merge + branch-reset pattern. THE
+  MERGE DECISION IS MADE BY THE BUNDLED `scripts/bot-gate`, NOT BY JUDGMENT — run it and
+  quote its output; the manual reaction-and-comment procedure it replaced is gone, and
+  was wrong three different ways before it was. Use this skill whenever the user asks to
+  open a PR, "ship this", "merge it", "let the bot review", "land the change", or right
+  after substantial code work that's ready for review. Also when the user asks why the
+  bot "isn't reviewing", how to interpret what it left behind, or what to do when GitHub
+  itself is degraded and no review can be attributed to the tree being merged.
 argument-hint: "[pr-number-or-branch]"
 allowed-tools:
   - Bash
@@ -26,6 +29,22 @@ allowed-tools:
 
 Drive a PR through CI and the `chatgpt-codex-connector` review bot to a clean merge,
 without bouncing off the bot's quirks.
+
+> **If you are recalling this procedure rather than reading it now, stop and re-read the
+> on-disk `SKILL.md` first.** The merge decision moved out of prose and into
+> **`scripts/bot-gate`**. A copy of this skill loaded earlier in a session — or carried
+> through a context summarisation — may still describe the manual procedure it replaced:
+> `gh api .../reactions`, `gh api .../pulls/N/comments`, judge by hand. Following that
+> from memory is not "a slightly older doc". `bot-gate`'s own header records that this
+> logic *"was written three times as prose and was wrong three different ways"* — an
+> unenforcing version, an unsatisfiable version, and one that broke past 100 comments —
+> so remembered prose is one of three known-wrong gates. This has already cost a real
+> merge: a PR landed on a `+1` and a human-pasted approval while the only wrapper the API
+> held named the **parent** of the merged head. The gate would have blocked it; it was
+> never run.
+>
+> The countermeasure is in § 8: a merge report must **quote `bot-gate`'s output**. An
+> agent that skipped the gate cannot produce that quote, which is the point.
 
 ## When this applies
 
@@ -540,8 +559,34 @@ condition:
      reaches zero — § 6 tells you to *answer* a misread finding, and both it and your
      reply stay anchored), then it broke past 100 comments (`--paginate` with `--jq`
      emits one result per page). Shell embedded in documentation cannot be run, so none
-     of those were caught by reading. Exit codes: 0 no pending evidence (NOT clearance — see above), 1 blocked, 2 usage, 3 cannot
-     determine — and "cannot determine" is never clearance.
+     of those were caught by reading.
+
+     Exit codes:
+
+     | Code | Verdict | Means |
+     |---|---|---|
+     | 0 | `NO_PENDING_EVIDENCE` | not clearance — see above |
+     | 1 | `BLOCKED` | a conjunct is unmet; usually **wait** |
+     | 2 | — | usage error |
+     | 3 | — | cannot determine, and that is never clearance |
+     | 4 | `BLOCKED_UNATTRIBUTED` | a round finished; nothing says which tree it read |
+
+     **Exit 4 refuses the merge exactly as 1 does** — any caller doing `bot-gate <PR> &&
+     gh pr merge` is unaffected. It exists for a caller that *loops*: exit 1 usually means
+     wait, exit 4 means waiting cannot help, because the signal that would attribute the
+     round is the one that is missing. It fires only when every other conjunct already
+     holds and the bot's `+1` post-dates the tip's commit — per the bot's own about-box,
+     *"if Codex has suggestions, it will comment; otherwise it will react with 👍"*, so a
+     👍 is a completed round, attached to the PR and never to a commit. A 👍 older than the
+     tip provably belongs to an earlier tree and leaves a plain exit 1. See § 8b.
+
+     Two honesty notes about that path. It is derived from the bot's **documented
+     contract**, not from an observation here — this repo's own 19-round sample on PR #16
+     saw the `+1` fire zero times, so the exit-4 branch has never been exercised against
+     live traffic. And a reactions query that fails on this path leaves the plain exit 1
+     rather than escalating to 3: the reaction can only make an already-blocking answer
+     *more specific*, so refusing a decidable PR because a warning could not be refined
+     would be the wrong trade.
 
      `--no-coderabbit` is gone, and rejected as an unknown option with exit 2 rather than
      accepted and ignored. It existed to assert a fact no query could establish — whether
@@ -723,6 +768,10 @@ while [ "$_n" -lt 60 ]; do
 done
 [ "$_ST" = "MERGED" ] || { echo "PR still not merged (state=$_ST) — do NOT proceed"; exit 1; }
 
+# Keep $GATE_JSON: the merge report has to QUOTE it (see below). Do not re-run the gate to
+# produce the quote — the PR is merged by now, so a fresh run describes a different world.
+printf '%s\n' "$GATE_JSON" > "${TMPDIR:-/tmp}/merge-evidence-<N>.json"
+
 # Re-fetch after the merge: the ref above predates the squash commit. Reset from where the
 # merge actually landed — `origin` is your fork and may not contain it at all. Fetch before
 # checkout, because in a single-branch fork clone neither a local `$BASE` nor `origin/$BASE`
@@ -772,6 +821,74 @@ matters; discard only after looking, because `git checkout -- .` is not recovera
 
 `checkout -B` rather than `pull` because squash-merge rewrites history — the branch is
 repointed at the merge target, not merged with it.
+
+### 8a. The merge report must quote the gate
+
+Whatever you report after merging — to the user, in a `DRIVE.md` entry, in a comment —
+**quote `bot-gate`'s actual output**: the `verdict`, the `tip`, and the observation window.
+
+```text
+merged <N> at <REVIEWED_TIP>
+gate: NO_PENDING_EVIDENCE  (observed 2026-08-06T20:43:04Z .. 2026-08-06T20:43:08Z)
+```
+
+This is not paperwork. It is the only part of the procedure an agent that **skipped the
+gate cannot fake without lying outright** — every other step leaves an artifact the agent
+could plausibly reconstruct after the fact, and "I checked the reactions and it looked
+fine" is exactly the report that preceded the merge described at the top of this file. If
+you cannot produce the quote, you did not run the gate, and the merge is unevidenced
+regardless of how it turned out.
+
+Report the verdict you actually got. `BLOCKED_UNATTRIBUTED` merged under § 8b is a
+legitimate outcome to report; laundering it into `NO_PENDING_EVIDENCE` is not.
+
+### 8b. When the forge itself is degraded
+
+`bot-gate`'s first condition is *a wrapper exists whose reviewed commit equals the tip*.
+During a GitHub incident that condition can be **unsatisfiable no matter how long you
+wait** — not because the bot disapproves, but because the forge is not answering. Observed:
+the checks rollup showed only CodeRabbit while two CI jobs never appeared at all, and the
+review wrapper for the merged head never became visible, though one naming its *parent*
+did.
+
+**First, tell the two apart.** Waiting is the right move for one and useless for the other:
+
+| Gate says | Means | Do |
+|---|---|---|
+| `BLOCKED`, wrapper 0, no other signal | the bot has not reviewed this tip | wait, or `@codex review` |
+| `BLOCKED_UNATTRIBUTED` (exit 4) | a round *completed* — its 👍 post-dates the tip — but nothing says which tree it read | waiting cannot fix this; go on |
+
+Exit 4 is still a refusal. It changes what you do next, never whether the gate approved.
+
+**Second, confirm it is actually an incident**, not a quiet bot. Check
+<https://www.githubstatus.com> and say what you saw. "The wrapper is missing" is not
+evidence of an outage; a degraded component on the status page, or CI jobs absent from a
+rollup that should list them, is.
+
+**Locally-run CI can substitute — with what it substitutes recorded.** Running the repo's
+own gates yourself is strictly stronger evidence than a green check mark, because you
+watched it. What makes it admissible is the record, and it must pin the tree:
+
+- the **exact commands**, each with its real exit code (never piped through `tail`/`grep`)
+- the **head SHA they ran against**, and that it equals the SHA you are merging — a local
+  run on an earlier head proves nothing about the tree that lands
+- **which jobs the forge would have run that you did not**, named
+
+Local CI substitutes for **CI**. It does not substitute for the **review**, which is a
+different claim: no local command tells you what a reviewer would have said.
+
+**A human-relayed bot verdict is admissible only for the part you can check.** A pasted
+*"Reviewed commit: `<sha>`"* is a claim about a message you cannot see — but the SHA in it
+is verifiable against your local head, and a mismatch settles it immediately. So:
+cross-check the SHA and say you did; treat the relay as evidence about **which tree** was
+read, and the human as the party attesting that it was read at all. A relay with no SHA,
+or one whose SHA does not match, advances nothing.
+
+**Record it as a degraded merge.** Write down, in the report § 8a asks for: the gate's real
+verdict and exit code, what you ran locally with which SHA, what the status page said, and
+who attested to what. The failure this section exists to prevent is not merging during an
+outage — that is sometimes correct — it is **improvising a merge policy during one and
+leaving no trace of the trade you made.**
 
 ## Iteration patterns observed
 

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate
@@ -855,7 +855,8 @@ PR_HEAD_FINAL=$(gh pr view "$PR" -R "$REPO" --json headRefOid -q .headRefOid 2>/
 # tree it read. Both states below present identically as a missing wrapper:
 #
 #   (a) the bot has not reviewed this tip          -> waiting is the right move
-#   (b) a round completed but nothing attributes it -> waiting cannot help
+#   (b) a round completed but nothing attributes it -> waiting MAY not help (see the
+#                                                     residual below); force a wrapper first
 #
 # Only (a) is a reason to keep polling. During a forge incident the API keeps answering
 # 200 while new review wrappers stop appearing, so a caller looping until a wrapper shows
@@ -877,8 +878,36 @@ if [[ "$WRAPPER_TIP" -eq 0 ]]; then
   # the commit provably belongs to an earlier tree and leaves a plain BLOCK. Committer
   # date, not author date — a rebase or amend rewrites the former and preserves the
   # latter, and it is the rewritten commit that got pushed.
-  _TIP_AT=$(git show -s --format=%cI "$TIP" 2>/dev/null) || _TIP_AT=""
-  _TIP_EPOCH=$(iso_to_epoch "$_TIP_AT") || _TIP_EPOCH=""
+  #
+  # DOCUMENTED RESIDUAL — this is a LOWER bound, not the real one. The honest boundary is
+  # when the tip became the PR head, and nothing reliably reports that: GitHub's PR
+  # timeline carries `head_ref_force_pushed` but not an ordinary push, the same gap the
+  # round-start list already documents. So this admits one false positive: commit locally
+  # at T0, the bot thumbs the OLD remote head at T1 > T0, push the tip at T2. The `+1`
+  # survives — GitHub allows one reaction per user per item, so the bot cannot refresh or
+  # remove it — and satisfies the comparison though no round has read this tip.
+  #
+  # Kept anyway, because the failure is bounded and one-directional: it can only turn a
+  # BLOCK into a *differently-worded* BLOCK. The cost is a caller that stops polling early
+  # and consults § 8b, whose first instruction is to confirm an incident on the status page
+  # — which is exactly what disproves this case. Tightening it would need a boundary the
+  # forge does not expose, and inventing one would be the over-claim ADR 0004 exists to
+  # prevent. The report below says "may" for this reason; do not strengthen that wording
+  # without a real head-change timestamp behind it.
+  #
+  # `%ct` (Unix seconds), NOT `%cI`. `%cI` renders in the COMMIT's own stored offset: `Z`
+  # when the committer was on UTC, but `2050-06-01T05:00:00-07:00` when they were not — and
+  # the BSD arm of iso_to_epoch matches only the literal-Z pattern, so that second form is
+  # unparseable there. The result would be a branch that works on GNU userland, works on a
+  # macOS clone whose commits happen to be UTC, and silently degrades to plain BLOCKED on a
+  # macOS clone whose commits are not, with no error to notice. `%ct` has no rendering and
+  # no parse step, so none of that applies.
+  #
+  # Not caught by bot-gate.test on GNU userland: `date -u -d` accepts BOTH forms, so the
+  # reversion stays green here. The suite pins the COMPARISON (see its boundary cases); this
+  # choice is pinned by review only.
+  _TIP_EPOCH=$(git show -s --format=%ct "$TIP" 2>/dev/null) || _TIP_EPOCH=""
+  [[ "$_TIP_EPOCH" =~ ^[0-9]+$ ]] || _TIP_EPOCH=""
   if _REACT=$(gh api --paginate --slurp "repos/$REPO/issues/$PR/reactions" 2>/dev/null) \
      && printf '%s' "$_REACT" | jq -e . >/dev/null 2>&1; then
     # Undated reactions are dropped rather than treated as "now": an undatable signal
@@ -890,6 +919,31 @@ if [[ "$WRAPPER_TIP" -eq 0 ]]; then
     if [[ -n "$_THUMBS_AT" && -n "$_TIP_EPOCH" ]]; then
       _THUMBS_EPOCH=$(iso_to_epoch "$_THUMBS_AT") || _THUMBS_EPOCH=""
       [[ -n "$_THUMBS_EPOCH" ]] && (( _THUMBS_EPOCH >= _TIP_EPOCH )) && THUMBS_UNATTRIBUTED=true
+    fi
+    # An `eyes` at or after the `+1` says a round is running NOW, and then waiting is
+    # exactly the right move — which is the opposite of what exit 4 tells the caller.
+    # ROUND_ACTIVE cannot catch this: it is gated on WRAPPER_AT, which is empty on every
+    # path that reaches here, so it is false by construction rather than by evidence. This
+    # read is the only place the two reactions are visible together.
+    #
+    # Same three-way split the hoisted reactions block uses: no reaction, an undatable one,
+    # and a dated one are different states. An `eyes` that exists but cannot be placed in
+    # time is a round that may be running, so it withdraws the exit-4 claim too — this
+    # branch only ever fires on positive evidence, and "I cannot tell" is not that.
+    _EYES2=$(printf '%s' "$_REACT" | jq -r --arg bot "$BOT_LOGIN" '
+      [.[][] | select(.user.login==$bot) | select(.content=="eyes")] as $e
+      | if ($e | length) == 0 then ""
+        elif any($e[]; ((.created_at // "") | length) == 0) then "malformed"
+        else ([$e[].created_at] | max) end' 2>/dev/null) || _EYES2="malformed"
+    if $THUMBS_UNATTRIBUTED && [[ -n "$_EYES2" ]]; then
+      if [[ "$_EYES2" == "malformed" ]]; then
+        THUMBS_UNATTRIBUTED=false
+      else
+        _EYES2_EPOCH=$(iso_to_epoch "$_EYES2") || _EYES2_EPOCH=""
+        if [[ -z "$_EYES2_EPOCH" ]]; then THUMBS_UNATTRIBUTED=false
+        elif (( _EYES2_EPOCH >= _THUMBS_EPOCH )); then THUMBS_UNATTRIBUTED=false
+        fi
+      fi
     fi
   fi
 fi
@@ -941,7 +995,7 @@ else
   printf '\nverdict: %s\n' "$VERDICT"
   [[ "$VERDICT" == "NO_PENDING_EVIDENCE" ]] && printf '  = %s\n' "$CLAIM"
   if $THUMBS_UNATTRIBUTED; then
-    printf '  ⚠ a codex round COMPLETED after this tip was committed — its 👍 says it found\n    nothing — but no wrapper names the tip, so nothing says which tree that round read.\n    Waiting will not resolve this: the signal that would attribute it is the one that is\n    missing. `@codex review` to force a fresh wrapper, or follow the degraded-forge\n    procedure in SKILL.md and record what you substituted.\n'
+    printf '  ⚠ a codex round COMPLETED after this tip was committed — its 👍 says it found\n    nothing — but no wrapper names the tip, so nothing says which tree that round read,\n    and waiting MAY not fix it: the signal that would attribute the round is the missing\n    one. Caveat: the 👍 is sticky and only bounded by the local commit time, so it can\n    also be an older head thumbed after you committed. `@codex review` to force a fresh\n    wrapper — do that first. If it does not come, confirm a real incident on the status\n    page and follow the degraded-forge procedure in SKILL.md, recording what you\n    substituted.\n'
   elif [[ "$WRAPPER_TIP" -eq 0 ]]; then
     printf '  ⚠ no review from the codex bot names this tip, so nothing proves WHICH tree it read.\n    Push or `@codex review` to get one, or accept the round explicitly and say so.\n'
   fi

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate
@@ -844,6 +844,56 @@ PR_HEAD_FINAL=$(gh pr view "$PR" -R "$REPO" --json headRefOid -q .headRefOid 2>/
 [[ "$PR_HEAD_FINAL" == "$TIP" ]] \
   || { echo "BLOCKED: PR head moved from ${TIP:0:10} to ${PR_HEAD_FINAL:0:10} while signals were collected" >&2; exit 3; }
 
+# ── Unattributed round evidence: "not reviewed" vs "cannot be told whether it reviewed" ──
+#
+# Read ONLY when no wrapper names the tip, which is exactly when the reactions block above
+# did not run, so this costs an extra request on no other path.
+#
+# The codex bot's own about-box states the contract: "If Codex has suggestions, it will
+# comment; otherwise it will react with 👍." A `+1` is therefore a COMPLETED round that
+# found nothing — and it is attached to the PR, not to a commit, so it can never say WHICH
+# tree it read. Both states below present identically as a missing wrapper:
+#
+#   (a) the bot has not reviewed this tip          -> waiting is the right move
+#   (b) a round completed but nothing attributes it -> waiting cannot help
+#
+# Only (a) is a reason to keep polling. During a forge incident the API keeps answering
+# 200 while new review wrappers stop appearing, so a caller looping until a wrapper shows
+# up waits forever on a condition that cannot be met — not because the bot disapproves,
+# but because the forge is not saying. That caller needs to be told which block it has.
+#
+# This NEVER clears anything. It refines an already-blocking verdict into a more specific
+# one, so exit 4 is a strictly-non-zero peer of exit 1, and every other conjunct must
+# already hold before it applies — an unresolved thread or an in-flight round is
+# actionable, and must not be dressed up as an attribution problem.
+#
+# A failed or unparseable query therefore leaves the plain BLOCK standing instead of
+# exiting 3. Escalating "I could not read a reaction" into an infrastructure error would
+# refuse a decidable PR over a signal that can only ever make the answer more specific,
+# never more permissive.
+THUMBS_UNATTRIBUTED=false
+if [[ "$WRAPPER_TIP" -eq 0 ]]; then
+  # The tip's own commit date bounds what the reaction could be about: a `+1` older than
+  # the commit provably belongs to an earlier tree and leaves a plain BLOCK. Committer
+  # date, not author date — a rebase or amend rewrites the former and preserves the
+  # latter, and it is the rewritten commit that got pushed.
+  _TIP_AT=$(git show -s --format=%cI "$TIP" 2>/dev/null) || _TIP_AT=""
+  _TIP_EPOCH=$(iso_to_epoch "$_TIP_AT") || _TIP_EPOCH=""
+  if _REACT=$(gh api --paginate --slurp "repos/$REPO/issues/$PR/reactions" 2>/dev/null) \
+     && printf '%s' "$_REACT" | jq -e . >/dev/null 2>&1; then
+    # Undated reactions are dropped rather than treated as "now": an undatable signal
+    # cannot be shown to post-date the tip, and this branch only ever fires on evidence.
+    _THUMBS_AT=$(printf '%s' "$_REACT" | jq -r --arg bot "$BOT_LOGIN" '
+      [.[][] | select(.user.login==$bot) | select(.content=="+1")
+       | select(((.created_at // "") | length) > 0) | .created_at] | max // ""' 2>/dev/null) \
+      || _THUMBS_AT=""
+    if [[ -n "$_THUMBS_AT" && -n "$_TIP_EPOCH" ]]; then
+      _THUMBS_EPOCH=$(iso_to_epoch "$_THUMBS_AT") || _THUMBS_EPOCH=""
+      [[ -n "$_THUMBS_EPOCH" ]] && (( _THUMBS_EPOCH >= _TIP_EPOCH )) && THUMBS_UNATTRIBUTED=true
+    fi
+  fi
+fi
+
 # WRAPPER_AT is required alongside the count: it is the reference point the active-round
 # check needs, so a wrapper without one means that check never ran, and a check that did
 # not run has not passed.
@@ -852,6 +902,10 @@ if [[ "$WRAPPER_TIP" -gt 0 ]] && [[ -n "$WRAPPER_AT" ]] && [[ "$PENDING_ON_TIP" 
    && ! $RERUN_REQUESTED && ! $ROUND_ACTIVE \
    && ! $RETARGETED_AFTER_REVIEW && [[ "$UNRESOLVED" -eq 0 ]]; then
   VERDICT="NO_PENDING_EVIDENCE"
+elif [[ "$WRAPPER_TIP" -eq 0 ]] && $THUMBS_UNATTRIBUTED && [[ "$PENDING_ON_TIP" -eq 0 ]] \
+   && ! $RERUN_REQUESTED && ! $ROUND_ACTIVE \
+   && ! $RETARGETED_AFTER_REVIEW && [[ "$UNRESOLVED" -eq 0 ]]; then
+  VERDICT="BLOCKED_UNATTRIBUTED"
 fi
 OBSERVED_TO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -871,10 +925,12 @@ if $JSON; then
         --argjson w "$WRAPPER_TIP" --argjson u "$UNRESOLVED" --argjson pending "$PENDING_ON_TIP" \
         --arg from "$OBSERVED_FROM" --arg to "$OBSERVED_TO" --arg claim "$CLAIM" \
         --arg cr_skipped "$CR_SKIPPED" --arg round_active "$ROUND_ACTIVE" --arg retargeted "$RETARGETED_AFTER_REVIEW" --arg rerun "$RERUN_REQUESTED" --arg skiplist "$CR_SKIPLIST" \
+        --arg unattributed "$THUMBS_UNATTRIBUTED" \
     '{tip:$tip,verdict:$v,claim:(if $claim=="" then null else $claim end),observed_from:$from,observed_to:$to,
       wrapper_on_tip:$w,unresolved_bot_threads:$u,
       coderabbit:$cr,coderabbit_skipped:($cr_skipped=="true"),round_active:($round_active=="true"),retargeted_after_review:($retargeted=="true"),
       rerun_requested:($rerun=="true"),pending_review_on_tip:($pending > 0),
+      unattributed_round:($unattributed=="true"),
       coderabbit_skipped_files:($skiplist|split("\n")|map(select(length>0)))}'
 else
   printf 'tip              %s\n' "${TIP:0:10}"
@@ -884,7 +940,11 @@ else
   printf 'observed         %s .. %s\n' "$OBSERVED_FROM" "$OBSERVED_TO"
   printf '\nverdict: %s\n' "$VERDICT"
   [[ "$VERDICT" == "NO_PENDING_EVIDENCE" ]] && printf '  = %s\n' "$CLAIM"
-  [[ "$WRAPPER_TIP" -eq 0 ]] && printf '  ⚠ no review from the codex bot names this tip, so nothing proves WHICH tree it read.\n    Push or `@codex review` to get one, or accept the round explicitly and say so.\n'
+  if $THUMBS_UNATTRIBUTED; then
+    printf '  ⚠ a codex round COMPLETED after this tip was committed — its 👍 says it found\n    nothing — but no wrapper names the tip, so nothing says which tree that round read.\n    Waiting will not resolve this: the signal that would attribute it is the one that is\n    missing. `@codex review` to force a fresh wrapper, or follow the degraded-forge\n    procedure in SKILL.md and record what you substituted.\n'
+  elif [[ "$WRAPPER_TIP" -eq 0 ]]; then
+    printf '  ⚠ no review from the codex bot names this tip, so nothing proves WHICH tree it read.\n    Push or `@codex review` to get one, or accept the round explicitly and say so.\n'
+  fi
   [[ "$UNRESOLVED" -gt 0 ]] && printf '  ⚠ %s UNRESOLVED bot thread(s). Fix each, or answer it with evidence and resolve the\n    thread — resolving is how you record that it was dispositioned.\n' "$UNRESOLVED"
   [[ "$CR_STATE" == "query-failed" ]] && printf '  · CodeRabbit status could not be queried.\n'
   $RERUN_REQUESTED && printf '  ⚠ an `@codex review` request is not provably answered — either it is newer than the\n    wrapper, or no completed round separates it from an earlier round-start, so the\n    wrapper after it may belong to a round that was already running. Wait, or\n    `@codex review` once more and wait for that wrapper.\n'
@@ -901,5 +961,15 @@ fi
 # the verdict — "I could not find out" is not "not done". It no longer can, so failing to
 # read it is missing REPORT data, not doubt about the answer, and exiting 3 would refuse a
 # decidable PR because a warning could not be printed. Exit follows the verdict.
-[[ "$VERDICT" == "NO_PENDING_EVIDENCE" ]] && exit 0
-exit 1
+# Explicit dispatch, not `[[ ... ]] && exit N` chained twice. That form only reaches the
+# fallthrough because this script runs without `set -e`; adding a second link would make
+# the final exit status depend on which test failed rather than on the verdict.
+#
+# Exit 4 is BLOCKED_UNATTRIBUTED — still non-zero, still refuses the merge, and any caller
+# doing `bot-gate <pr> && gh pr merge` is unaffected. It exists so a caller that LOOPS can
+# tell a block that waiting will fix from one that it cannot.
+case "$VERDICT" in
+  NO_PENDING_EVIDENCE)  exit 0 ;;
+  BLOCKED_UNATTRIBUTED) exit 4 ;;
+  *)                    exit 1 ;;
+esac

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate.test
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate.test
@@ -925,6 +925,83 @@ PATH="$WORK/bin:$PATH" FIX="$FIX" "$GATE" 16 --settle-seconds 0 >/dev/null 2>&1
 [[ $? == 2 ]] && { PASS=$((PASS+1)); echo "  ok   --settle-seconds is rejected, not ignored  (exit 2)"; } \
               || { FAIL=$((FAIL+1)); echo "  FAIL --settle-seconds is rejected, not ignored"; }
 
+# ── BLOCKED_UNATTRIBUTED (exit 4) ─────────────────────────────────────────────────────
+#
+# "The bot has not reviewed this tip" and "a round finished but nothing says which tree it
+# read" both present as a missing wrapper, and only the first is a reason to keep waiting.
+# A caller that loops until a wrapper appears waits forever on the second — which is what a
+# forge incident produces: the API keeps answering 200 while wrappers stop appearing.
+#
+# The +1 is what separates them. Per the bot's own about-box, it reacts 👍 only when it has
+# no suggestions, so a 👍 is a COMPLETED round — attached to the PR, never to a commit.
+#
+# A far-future literal, not $NOW_UTC: the fixture repo's commit is created after NOW_UTC is
+# sampled, so "now" can land a second BEFORE the tip and this fixture would pass or fail on
+# the clock. Fixed constants keep it deterministic on any machine.
+FAR_UTC="2099-01-01T00:00:00Z"
+thumbs() { printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":"%s"}]]' "$1"; }
+
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+thumbs "$FAR_UTC" > "$FIX/reactions.json"
+check "a 👍 after the tip, no wrapper, is exit 4" 4
+
+# The timestamp bound is the whole claim. A 👍 that PREDATES the tip's commit provably
+# belongs to an earlier tree, so it distinguishes nothing and must leave the plain block.
+# Without this the check would fire on any PR the bot ever thumbed, at any tip.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+thumbs "$OLD_UTC" > "$FIX/reactions.json"
+check "a 👍 older than the tip stays exit 1" 1
+
+# An undated 👍 cannot be shown to post-date the tip. This branch fires only on evidence,
+# so an undatable reaction is dropped rather than read as "now" — the direction that would
+# claim attribution nobody established.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":null}]]' > "$FIX/reactions.json"
+check "an undated 👍 stays exit 1" 1
+
+# Exit 4 is strictly more specific than exit 1, never more permissive: every OTHER conjunct
+# must already hold. An unresolved thread is actionable and says nothing about attribution,
+# so dressing it up as an attribution problem would send the caller to the degraded-forge
+# procedure instead of to the thread it has to answer.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 3 > "$FIX/threads.json"
+thumbs "$FAR_UTC" > "$FIX/reactions.json"
+check "unresolved threads outrank the 👍 (exit 1)" 1
+
+# Same for a round still in flight: waiting IS the right move there, which is precisely
+# what exit 4 tells the caller not to do. A PENDING review is excluded from the wrapper
+# count, so WRAPPER_TIP is 0 here and only the conjunct ordering keeps this out of exit 4.
+new_fix; threads 0 > "$FIX/threads.json"
+printf '[[{"user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"state":"PENDING","commit_id":"%s","body":"draft"}]]' "$TIP" > "$FIX/reviews.json"
+thumbs "$FAR_UTC" > "$FIX/reactions.json"
+check "a pending review outranks the 👍 (exit 1)" 1
+
+# A failed reactions read must NOT escalate to exit 3 on this path. The reaction can only
+# ever make an already-blocking answer more specific, so refusing the whole PR because a
+# warning could not be refined would turn a decidable block into an infrastructure error.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+echo 'x' > "$FIX/reactionsfail"
+check "a reactions failure with no wrapper is exit 1, not 3" 1
+
+# ...and an unparseable body takes the same path, for the same reason.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+printf 'not json at all' > "$FIX/reactions.json"
+check "an unparseable reactions body with no wrapper is exit 1" 1
+
+# The clearing path is untouched: with a wrapper naming the tip, a 👍 is irrelevant and the
+# gate still clears. The new read is scoped to WRAPPER_TIP -eq 0, so it costs nothing here.
+new_fix; wrapper "chatgpt-codex-connector[bot]" "$OLD_UTC" > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+thumbs "$FAR_UTC" > "$FIX/reactions.json"
+check "a 👍 alongside a real wrapper still clears" 0
+
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+thumbs "$FAR_UTC" > "$FIX/reactions.json"
+J=$(PATH="$WORK/bin:$PATH" FIX="$FIX" "$GATE" 16 --json 2>/dev/null)
+if printf '%s' "$J" | jq -e '(.verdict=="BLOCKED_UNATTRIBUTED") and (.unattributed_round==true) and (.claim==null)' >/dev/null 2>&1; then
+  PASS=$((PASS+1)); echo "  ok   JSON names the unattributed verdict        (exit 4)"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL JSON names the unattributed verdict"
+fi
+
 echo
 echo "passed $PASS, failed $FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate.test
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate.test
@@ -993,6 +993,60 @@ new_fix; wrapper "chatgpt-codex-connector[bot]" "$OLD_UTC" > "$FIX/reviews.json"
 thumbs "$FAR_UTC" > "$FIX/reactions.json"
 check "a 👍 alongside a real wrapper still clears" 0
 
+# An `eyes` at or after the `+1` means a round is running RIGHT NOW — and then waiting is
+# exactly right, the opposite of what exit 4 tells the caller. ROUND_ACTIVE cannot catch
+# this: it is gated on WRAPPER_AT, empty on every path that reaches exit 4, so it is false
+# by construction rather than by evidence.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":"%s"},{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"eyes","created_at":"%s"}]]' \
+  "$FAR_UTC" "2099-06-01T00:00:00Z" > "$FIX/reactions.json"
+check "an eyes AFTER the 👍 blocks exit 4" 1
+
+# ...but an eyes BEFORE it is the round that produced the 👍, so exit 4 still stands.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":"%s"},{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"eyes","created_at":"2098-06-01T00:00:00Z"}]]' \
+  "$FAR_UTC" > "$FIX/reactions.json"
+check "an eyes BEFORE the 👍 keeps exit 4" 4
+
+# An eyes that exists but cannot be placed in time is a round that MAY be running. This
+# branch fires only on positive evidence, so "I cannot tell" withdraws the claim.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":"%s"},{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"eyes","created_at":null}]]' \
+  "$FAR_UTC" > "$FIX/reactions.json"
+check "an undatable eyes withdraws exit 4" 1
+
+# The boundary itself, in a repo whose commit date is PINNED, so the comparison is exact
+# rather than "far future vs the year 2000". These three cases pin the `>=` — dropping it
+# to `>` reddens the middle one — and none of them needs `date` at all.
+#
+# What they do NOT pin, stated because a green suite reads like coverage: the gate's choice
+# of `%ct` over `%cI` for the tip date. `%cI` renders in the commit's own offset, so a
+# non-UTC committer yields `...-07:00`, which the BSD arm of iso_to_epoch cannot parse —
+# but `date -u -d` on GNU accepts both forms, so reverting it stays green here (verified by
+# mutation, including under TZ=America/Los_Angeles). That choice is held by review, not by
+# this file. A test that cannot fail against the defect it names is not covering it.
+(
+  PINNED="2050-06-01T12:00:00Z"
+  git init -q "$WORK/repo2"; cd "$WORK/repo2"
+  GIT_COMMITTER_DATE="$PINNED" GIT_AUTHOR_DATE="$PINNED" \
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m pinned
+  TIP=$(git rev-parse HEAD)
+
+  new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+  printf '%s' "$TIP" > "$FIX/prhead.txt"
+  thumbs "2050-06-01T11:59:59Z" > "$FIX/reactions.json"
+  check "👍 one second BEFORE the tip is exit 1" 1
+
+  thumbs "$PINNED" > "$FIX/reactions.json"
+  check "👍 exactly AT the tip is exit 4 (>=)" 4
+
+  thumbs "2050-06-01T12:00:01Z" > "$FIX/reactions.json"
+  check "👍 one second AFTER the tip is exit 4" 4
+  printf '%s %s\n' "$PASS" "$FAIL" > "$WORK/subshell-tally"
+)
+read -r PASS FAIL < "$WORK/subshell-tally"
+cd "$WORK/repo"
+
 new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
 thumbs "$FAR_UTC" > "$FIX/reactions.json"
 J=$(PATH="$WORK/bin:$PATH" FIX="$FIX" "$GATE" 16 --json 2>/dev/null)


### PR DESCRIPTION
Closes #23. Closes #24.

Two failures from the same day, both the same shape: **an agent that could not tell "there is no signal" from "I am not being told."**

## #24 — the gate was unsatisfiable during an outage

`bot-gate`'s first condition is *a wrapper naming the tip*. During a GitHub incident that cannot be met **no matter how long you wait** — the API keeps answering `200` while new wrappers stop appearing. A caller polling for one waits forever on a condition the forge will never produce.

**New verdict `BLOCKED_UNATTRIBUTED`, exit 4.**

| Code | Verdict | Means |
|---|---|---|
| 0 | `NO_PENDING_EVIDENCE` | not clearance |
| 1 | `BLOCKED` | a conjunct is unmet; usually **wait** |
| 4 | `BLOCKED_UNATTRIBUTED` | a round finished; nothing says which tree it read |

It fires only when every other conjunct already holds, no wrapper names the tip, and the bot's `+1` **post-dates the tip's commit**. Per the bot's own about-box — *"if Codex has suggestions, it will comment; otherwise it will react with 👍"* — a 👍 is a *completed* round, attached to the PR and never to a commit. A 👍 older than the tip provably belongs to an earlier tree and leaves a plain exit 1.

**Exit 4 refuses the merge exactly as 1 does.** Any caller doing `bot-gate <PR> && gh pr merge` is unaffected. It exists for a caller that *loops*: exit 1 means wait, exit 4 means waiting cannot help, because the signal that would attribute the round is the missing one.

### Two things I deliberately did not claim

**It has never met live traffic.** The branch is derived from the bot's *documented contract*, not from an observation here — this repo's own 19-round sample on PR #16 saw the `+1` fire **zero times**. The skill says so rather than implying it was measured.

**bot-gate still cannot detect an outage.** An incident that hides a wrapper is indistinguishable, from the API's own responses, from a bot that never reviewed. Inventing a detector would be exactly the over-claim ADR 0004 exists to prevent. So § 8b sends you to the *status page* — a missing wrapper is not evidence of an outage; a degraded component, or CI jobs absent from a rollup that should list them, is.

### § 8b, the degraded-forge procedure

Answers the three questions the issue asked:

- **Locally-run CI can substitute — for CI.** It is stronger than a green check mark because you watched it. What makes it admissible is the record: exact commands with real exit codes, **the head SHA they ran against** (a local run on an earlier head proves nothing about the tree that lands), and which forge jobs went unrun. It does **not** substitute for the review — no local command tells you what a reviewer would have said.
- **A human-relayed verdict is admissible only for the checkable part.** A pasted `Reviewed commit: <sha>` is a claim about a message you cannot see, but the SHA is verifiable against local HEAD and a mismatch settles it. Cross-check it and say you did.
- **Record it as a degraded merge.** The failure this prevents is not merging during an outage — that is sometimes correct — it is improvising a merge policy during one and leaving no trace of the trade.

## #23 — the skill in context can be superseded

A PR merged on the *manual* reaction-and-comment procedure that `scripts/bot-gate` replaced. The copy in context predated the script, so nothing prompted a look. The gate would have blocked that merge: the only wrapper the API held named the **parent** of the merged head.

- **`description` now states the merge decision is `bot-gate`'s, not judgment's** — descriptions survive into listings, so an agent working from a summarised context still learns a script exists.
- **A verify-before-you-follow block** at the top of both script-shipping skills. The tell it names: *a procedure you can recite in full without having opened a file this turn.*
- **§ 8a — the merge report must QUOTE the gate's verdict, tip and window.** This is the countermeasure that actually bites: it is the one step an agent who skipped the gate cannot produce without lying outright. Every other step leaves an artifact that could be reconstructed after the fact.

## Verification

9 new fixtures, **113 pass / 0 fail** (was 104). Each shown red against its own fix rather than merely passing:

| Mutation | Fixtures that went red |
|---|---|
| delete the `BLOCKED_UNATTRIBUTED` branch | exit-4 case, JSON verdict |
| drop the tip-timestamp bound | 👍 older than the tip |
| admit undated reactions | undated 👍 |
| drop the other conjuncts from the `elif` | unresolved threads, pending review |
| escalate the reactions failure to exit 3 | both query-failure cases |

Tree restored and re-verified at 113/113 after each. `drive-status.test` 70/70.

The fixtures use a fixed far-future literal rather than `$NOW_UTC`: the fixture repo's commit is created *after* `NOW_UTC` is sampled, so "now" can land a second before the tip and the case would pass or fail on the clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
