### PR TITLE
bot-gate: a clean round can never clear its own gate — filter the bot's own comments from the trigger scan

### DIFF
--- a/skills/pr-with-codex-bot-review/scripts/bot-gate
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate
@@ -321,14 +321,21 @@ done < <(printf '%s' "$REVIEWS" | jq -r --arg bot "$BOT_LOGIN" '
 # can then never answer. The verdict's channel-merge above already counts these comments
 # as wrappers; the coverage lists must see them for the same reason. The sha in the marker
 # is abbreviated, so the tip-scoped match is a prefix match (the capture requires >=7 hex).
+#
+# ONLY the current tip's clean comments, though, and only into both lists together. A
+# normal (non-force) push is invisible to the start-event scan, so a PRIOR-tip clean
+# comment accepted as the pre-request anchor can certify a "quiet" gap that the push's
+# auto round is actually running in — crediting that round's later clean comment to a
+# request whose own round is still pending. Dropping prior-tip clean comments is
+# fail-closed: it removes anchors, never adds them.
 while IFS= read -r _wt; do
   [[ -n "$_wt" ]] || continue
   [[ "$_wt" == "@undated@" ]] && { WRAPPER_UNDATED=true; continue; }
   _wtip="${_wt%%$'\t'*}"; _wts="${_wt#*$'\t'}"
+  [[ "$TIP" == "$_wtip"* ]] || continue
   _we=$(iso_to_epoch "$_wts") || { WRAPPER_UNDATED=true; continue; }
   WRAPPER_EPOCHS="${WRAPPER_EPOCHS}${WRAPPER_EPOCHS:+$'\n'}${_we}"
-  [[ "$TIP" == "$_wtip"* ]] \
-    && WRAPPER_TIP_EPOCHS="${WRAPPER_TIP_EPOCHS}${WRAPPER_TIP_EPOCHS:+$'\n'}${_we}"
+  WRAPPER_TIP_EPOCHS="${WRAPPER_TIP_EPOCHS}${WRAPPER_TIP_EPOCHS:+$'\n'}${_we}"
 done < <(printf '%s' "$ALL_COMMENTS" | jq -r --arg bot "$BOT_LOGIN" '
   .[][] | select(.user.login==$bot)
   | select((.body // "") | test("Reviewed commit"))

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate
@@ -314,6 +314,27 @@ done < <(printf '%s' "$REVIEWS" | jq -r --arg bot "$BOT_LOGIN" '
   .[][] | select(.user.login==$bot) | select(.user.type=="Bot")
   | (if ((.submitted_at // "") | length) == 0 then "@undated@"
      else ((.commit_id // "") + "\t" + .submitted_at) end)' 2>/dev/null)
+# Clean-round comments are round ENDS too — a round that found nothing still finished.
+# Feeding only review objects into these lists left a PR whose every round is clean with
+# an EMPTY anchor list, so `_round_covered` returned 1 for every request forever: the
+# documented escape (`@codex review` once more) posts a request that its own clean round
+# can then never answer. The verdict's channel-merge above already counts these comments
+# as wrappers; the coverage lists must see them for the same reason. The sha in the marker
+# is abbreviated, so the tip-scoped match is a prefix match (the capture requires >=7 hex).
+while IFS= read -r _wt; do
+  [[ -n "$_wt" ]] || continue
+  [[ "$_wt" == "@undated@" ]] && { WRAPPER_UNDATED=true; continue; }
+  _wtip="${_wt%%$'\t'*}"; _wts="${_wt#*$'\t'}"
+  _we=$(iso_to_epoch "$_wts") || { WRAPPER_UNDATED=true; continue; }
+  WRAPPER_EPOCHS="${WRAPPER_EPOCHS}${WRAPPER_EPOCHS:+$'\n'}${_we}"
+  [[ "$TIP" == "$_wtip"* ]] \
+    && WRAPPER_TIP_EPOCHS="${WRAPPER_TIP_EPOCHS}${WRAPPER_TIP_EPOCHS:+$'\n'}${_we}"
+done < <(printf '%s' "$ALL_COMMENTS" | jq -r --arg bot "$BOT_LOGIN" '
+  .[][] | select(.user.login==$bot)
+  | select((.body // "") | test("Reviewed commit"))
+  | ((.body | capture("Reviewed commit:\\*{0,2}[[:space:]]*`?(?<sha>[0-9a-f]{7,40})")).sha) as $sha
+  | (if ((.created_at // "") | length) == 0 then "@undated@"
+     else ($sha + "\t" + .created_at) end)' 2>/dev/null)
 
 # A wrapper AFTER a request does not show the REQUESTED round ended: rounds carry no
 # identity, so that wrapper can end a round that was already in flight when the request

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate
@@ -572,9 +572,15 @@ if [[ -n "$WRAPPER_AT" ]] && [[ -n "${ALL_COMMENTS:-}" ]]; then
   # One list for both is wrong in whichever direction it is tuned. Anchoring both (as the
   # first fix for the clearing hole did) means `@codex review please` — a real trigger —
   # stops blocking.
+  # The bot's own comments are never triggers: its clean-round wrapper quotes the literal
+  # command in its About-Codex boilerplate, so without this filter every clean round is
+  # counted as a fresh request newer than the wrapper announcing it, RERUN_REQUESTED
+  # latches true, and a clean round can never clear its own gate.
   _mk_triggers() {  # $1 = jq test expression
     printf '%s' "$ALL_COMMENTS" \
-      | jq -r --arg re "$1" '.[][] | select((.body // "") | test($re; "i"))
+      | jq -r --arg re "$1" --arg bot "$BOT_LOGIN" '.[][]
+               | select((.user.login // "") != $bot)
+               | select((.body // "") | test($re; "i"))
                | if ((.created_at // "") | length) == 0 then "@undated@" else .created_at end' 2>/dev/null
   }
   _TRIGGERS=$(_mk_triggers "@codex[[:space:]]+review") \

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate.test
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate.test
@@ -216,6 +216,30 @@ new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
 clean_round_boiler "${TIP:0:10}" "$NOW_UTC" > "$FIX/issues.json"
 check "a clean round's own boilerplate is not a trigger" 0
 
+# Clean rounds must also ANSWER requests: they are round ends, so they belong in the
+# coverage anchor lists. With only review-object wrappers feeding those lists, a PR whose
+# every round is clean had an empty anchor list and every request was permanently
+# unanswerable — the escape request's own clean round could never cover it.
+clean_sandwich() {  # $1 = request created_at, $2 = second clean round created_at
+  local c1 c2
+  c1=$(clean_round "${TIP:0:10}" "$OLD_UTC"); c2=$(clean_round "${TIP:0:10}" "$2")
+  printf '%s' "$c1" | jq -c --arg rt "$1" \
+    --argjson c2 "$(printf '%s' "$c2" | jq '.[0][0]')" \
+    '.[0] += [{"user":{"login":"douglaz"},"created_at":$rt,"body":"@codex review"}, $c2]'
+}
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+clean_sandwich "$MID_UTC" "$NEW_UTC" > "$FIX/issues.json"
+check "a clean round answers the request before it" 0
+
+# ...but the clean-round anchor obeys the same gap rule as a review-object anchor: a
+# start event between the anchor and the request means a round may already have been in
+# flight, and the wrapper after the request could be that round's, not the request's.
+# Timeline: clean(OLD=0) < eyes(MID=1) < request(NEW=2) < clean(NEW2=3), strict everywhere.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+clean_sandwich "$NEW_UTC" "$NEW2_UTC" > "$FIX/issues.json"
+printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"eyes","created_at":"%s"}]]' "$MID_UTC" > "$FIX/reactions.json"
+check "an eyes in the anchor gap still blocks" 1
+
 # The filter must remove only the BOT's mentions. A human request posted after the clean
 # round is still an unanswered request and still blocks.
 human_request() {  # $1 = created_at

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate.test
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate.test
@@ -205,6 +205,27 @@ clean_round "${TIP:0:10}" "$OLD_UTC" > "$FIX/issues.json"
 printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"eyes","created_at":"%s"}]]' "$NOW_UTC" > "$FIX/reactions.json"
 check "an eyes after a clean round still blocks" 1
 
+# The REAL clean-round comment carries an About-Codex block that quotes the literal
+# trigger: `- Comment "@codex review".` Without an author filter on _mk_triggers, every
+# clean round therefore counted as a review request newer than the wrapper announcing it,
+# and a clean round could never clear its own gate — the bug that blocked three live merges.
+clean_round_boiler() {  # $1 = sha text to put in the marker, $2 = created_at
+  printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"created_at":"%s","body":"Codex Review: Didn'"'"'t find any major issues. :+1:\\n\\n**Reviewed commit:** `%s`\\n\\nAbout Codex in GitHub\\n- Comment \\"@codex review\\".\\n"}]]' "$2" "$1"
+}
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+clean_round_boiler "${TIP:0:10}" "$NOW_UTC" > "$FIX/issues.json"
+check "a clean round's own boilerplate is not a trigger" 0
+
+# The filter must remove only the BOT's mentions. A human request posted after the clean
+# round is still an unanswered request and still blocks.
+human_request() {  # $1 = created_at
+  printf '{"user":{"login":"douglaz"},"created_at":"%s","body":"@codex review"}' "$1"
+}
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+{ b=$(clean_round_boiler "${TIP:0:10}" "$OLD_UTC"); h=$(human_request "$NOW_UTC")
+  printf '%s' "$b" | jq -c --argjson h "$h" '.[0] += [$h]'; } > "$FIX/issues.json"
+check "a human request after the clean round still blocks" 1
+
 new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
 check "no wrapper for tip blocks" 1
 

--- a/skills/pr-with-codex-bot-review/scripts/bot-gate.test
+++ b/skills/pr-with-codex-bot-review/scripts/bot-gate.test
@@ -240,6 +240,18 @@ clean_sandwich "$NEW_UTC" "$NEW2_UTC" > "$FIX/issues.json"
 printf '[[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"eyes","created_at":"%s"}]]' "$MID_UTC" > "$FIX/reactions.json"
 check "an eyes in the anchor gap still blocks" 1
 
+# ...and only THIS tip's clean comments anchor. A normal push is invisible to the
+# start-event scan, so a prior-tip clean comment as anchor certifies a "quiet" gap the
+# push's auto round may be running in — the wrapper after the request would be that
+# round's, not the request's. Prior-tip clean comments anchor nothing.
+new_fix; echo '[[]]' > "$FIX/reviews.json"; threads 0 > "$FIX/threads.json"
+{ c1=$(clean_round "${OLDTIP:0:10}" "$OLD_UTC"); c2=$(clean_round "${TIP:0:10}" "$NEW_UTC")
+  printf '%s' "$c1" | jq -c --arg rt "$MID_UTC" \
+    --argjson c2 "$(printf '%s' "$c2" | jq '.[0][0]')" \
+    '.[0] += [{"user":{"login":"douglaz"},"created_at":$rt,"body":"@codex review"}, $c2]'
+} > "$FIX/issues.json"
+check "a prior-tip clean comment does not anchor" 1
+
 # The filter must remove only the BOT's mentions. A human request posted after the clean
 # round is still an unanswered request and still blocks.
 human_request() {  # $1 = created_at


### PR DESCRIPTION
Two structural bugs in `bot-gate`'s conjunct 3, both of the same shape: the gate's success path — a clean round — was invisible to part of the logic, making clearance unreachable on exactly the PRs that deserved it.

## Bug 1: a clean round can never clear its own gate

The codex bot's clean-round comment quotes the literal trigger string in its About-Codex boilerplate (`- Comment "@codex review".`). `_mk_triggers` scanned **all** issue comments with no author filter, so every clean round was counted as a fresh review request — by construction newer than the wrapper it announces. `RERUN_REQUESTED` latched true. Observed live: #25, #26, #27 each blocked by the announcement of their own clean review.

**Fix:** `_mk_triggers` excludes comments authored by `$BOT_LOGIN`. Both the loose (blocking) and strict (clearing) lists inherit it — the bot's own comments are neither requests nor clearing evidence.

## Bug 2: on an all-clean PR, no request can ever be provably answered

`_round_covered`'s anchor list (`WRAPPER_EPOCHS`) was fed only from **review objects**. A clean round posts no review object — only an issue comment. So a PR whose every round is clean had an empty anchor list, `_round_covered` returned 1 for every request forever, and the diagnostic's own documented escape ("`@codex review` once more and wait") posted a request its own clean round could then never answer. Observed live on this very PR: two clean rounds naming the tip, zero threads, blocked.

**Fix:** merge the clean-round comment channel into both coverage lists (`WRAPPER_EPOCHS`, tip-scoped via prefix match on the abbreviated sha), mirroring the channel-merge the verdict already does for `WRAPPER_TIP`/`WRAPPER_AT`.

## Tests

Four fixtures, each shown red against its own mutation:

- "a clean round's own boilerplate is not a trigger" (want 0) — red without the author filter (`got 1`)
- "a human request after the clean round still blocks" (want 1) — red against an over-broad filter (`select(false)` → `got 0`)
- "a clean round answers the request before it" (want 0) — red without the epoch merge (`got 1`)
- "an eyes in the anchor gap still blocks" (want 1) — red with the start-event gap scan disabled (`got 0`)

Suite: 123 passed, 0 failed (was 119). `drive-status.test` 70/70 unaffected.

These two bugs are why the four documentation PRs (#22/#25/#26/#27) needed fifteen review rounds to land: every clean round re-armed the gate against itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNyVSshCPFFwQFnTMqHBz5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated review boilerplate from being mistaken for a new review request.
  * Ensured genuine subsequent review requests continue to be detected correctly.
  * Improved review completion tracking, including clean review rounds and reviewed commit matching.
  * Added timestamp tracking to improve coverage of review activity.

* **Tests**
  * Added coverage for quoted automated review messages, follow-up human review requests, and ambiguous review-round scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->