### PR TITLE
install.sh: --uninstall stops after the first target and reports success

### DIFF
--- a/DRIVE.md
+++ b/DRIVE.md
@@ -1,0 +1,35 @@
+# DRIVE — fix install.sh's uninstall path and give it a test suite
+
+**Scope:** `install.sh` + `install.test` only. The backlog plan (issues #29–#35) is
+NOT in scope for this drive — it is queued behind it as separate PRs.
+**Phase:** HARDEN · **Bead:** n/a (direct-edit tier) · **Branch:** installer-uninstall-abort
+**Pending:** —
+**Gate:** `./install.test && ./skills/pr-with-codex-bot-review/scripts/bot-gate.test && ./skills/drive/scripts/drive-status.test`
+· last green 2026-08-08 (12 / 124 / 70, exit 0)
+
+## Done
+- BUILD: two `set -e` aborts on `--uninstall` fixed — a partial uninstall that fired only
+  when the removal succeeded, and a `read` EOF that made every non-interactive run report
+  failure. Both reproduced against the real installer before any edit.
+- BUILD: `install.test` added, the repo's third suite. Each defect gets its own fixture,
+  because either alone yields exit 1 and a combined test cannot say which fired.
+- Bot round 1 on `61792be` found a real defect **in the fix**: `|| answer=""` discards an
+  unterminated `y`. Fixed in `c3e3074` with its own fixture; thread resolved with evidence.
+- Bot round 2 on `c3e3074`: clean (`NO_PENDING_EVIDENCE`).
+
+## Now
+HARDEN: local codex + fable panel on `origin/master..HEAD`. Bot approval is not clearance
+— LAND is admitted by the local `cleared` marker, which this checkout does not have.
+
+## Next
+LAND #37 (squash, delete branch) → then backlog PR 1, the sibling-site sweep: the
+uninitialized `$_chk` in `drive/references/phases.md:43`, the three byte-identical
+fail-open `br where` paragraphs, `--no-renames` on the § 3a status capture, the group-kill
+probe, `umask 077` (#29), and the batch-10 ambient-git-config class.
+
+## Open questions for the human
+- `AGENTS.md` is absent. Phase 0 wants it installed once per repo, but adding it here
+  would make a PR about the installer also about repo-wide agent policy — and issue #33 is
+  open precisely about `agents-md` installing a block that contradicts the repo's own
+  agreement. Deferred to backlog PR 1, which is a real branch that will exist, not a
+  branch that never will. Stated rather than silently skipped.

--- a/install.sh
+++ b/install.sh
@@ -185,10 +185,13 @@ if $uninstall; then
   done
 
   if [[ -d "$install_dir" ]]; then
-    # `|| answer=""` because EOF makes `read` exit 1, and under `set -e` that aborts
-    # before the `exit 0` below — so a non-interactive uninstall reported failure for
-    # work that had fully succeeded. EOF is a declined prompt, which is the [y/N] default.
-    read -rp "Also remove cloned repo at $install_dir? [y/N] " answer || answer=""
+    # `|| true`, because EOF makes `read` exit 1 and under `set -e` that aborts before
+    # the `exit 0` below — a non-interactive uninstall reported failure for work that had
+    # fully succeeded. Not `|| answer=""`: on EOF `read` still assigns whatever it read
+    # first, so `printf y | ...` (no trailing newline) sets answer=y AND exits 1, and
+    # clearing it there discards a real affirmative. An input-less EOF leaves it empty on
+    # its own, which is the declined [y/N] default.
+    read -rp "Also remove cloned repo at $install_dir? [y/N] " answer || true
     if [[ "$answer" =~ ^[Yy]$ ]]; then
       rm -rf "$install_dir"
       echo "Removed: $install_dir"

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,14 @@ remove_symlinks_from_dir() {
     fi
   done
 
-  [[ $removed -eq 0 ]] && echo "No symlinks found in $dir pointing to $install_dir"
+  # An `if`, not `[[ ... ]] && echo`: that form returns 1 whenever it DID remove
+  # something, the function propagates that to its caller, and `set -e` then aborts the
+  # target loop mid-way — so `--target both` cleaned Claude, left Codex linked, skipped
+  # the clone prompt, and printed no error. The failure fired only when the removal
+  # succeeded, which is why it read as a clean uninstall.
+  if [[ $removed -eq 0 ]]; then
+    echo "No symlinks found in $dir pointing to $install_dir"
+  fi
 }
 
 # Drop installer-managed symlinks whose source is gone (skill renamed or removed
@@ -178,7 +185,10 @@ if $uninstall; then
   done
 
   if [[ -d "$install_dir" ]]; then
-    read -rp "Also remove cloned repo at $install_dir? [y/N] " answer
+    # `|| answer=""` because EOF makes `read` exit 1, and under `set -e` that aborts
+    # before the `exit 0` below — so a non-interactive uninstall reported failure for
+    # work that had fully succeeded. EOF is a declined prompt, which is the [y/N] default.
+    read -rp "Also remove cloned repo at $install_dir? [y/N] " answer || answer=""
     if [[ "$answer" =~ ^[Yy]$ ]]; then
       rm -rf "$install_dir"
       echo "Removed: $install_dir"

--- a/install.test
+++ b/install.test
@@ -116,6 +116,16 @@ run "$b" --target both --uninstall </dev/null >/dev/null
 if [[ ! -d "$b/clone" ]]; then fail "$t" "EOF was read as consent to delete"
 else pass "$t"; fi
 
+# The other half of that EOF handling, and the reason it is `|| true` rather than
+# `|| answer=""`: `read` assigns what it consumed BEFORE hitting EOF, so an unterminated
+# `y` sets answer=y and still exits 1. Clearing answer in the fallback silently declines a
+# prompt the caller answered. Raised by codex on PR #37 against exactly that first fix.
+t="an unterminated y is still consent"
+b=$(new_fixture "alpha"); link_skill "$b" alpha
+printf 'y' | run "$b" --target both --uninstall >/dev/null
+if [[ -d "$b/clone" ]]; then fail "$t" "a newline-less y was discarded as EOF"
+else pass "$t"; fi
+
 # ── install ─────────────────────────────────────────────────────────────────────────
 
 t="install links a named skill into both targets"

--- a/install.test
+++ b/install.test
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# install.test — fixture tests for the installer's uninstall and link paths.
+#
+# Written because `--uninstall` carried two independent `set -e` aborts that both
+# reported success:
+#
+#   1. `remove_symlinks_from_dir` ended on `[[ $removed -eq 0 ]] && echo ...`, so it
+#      returned 1 whenever it HAD removed something. `set -e` then killed the target
+#      loop: `--target both` unlinked Claude, left Codex linked, never reached the clone
+#      prompt, and printed no error. It fired only when the removal worked.
+#   2. `read -rp` at the clone prompt exits 1 on EOF, so every non-interactive uninstall
+#      exited 1 after fully succeeding.
+#
+# Both are this repo's recurring shape — a failure that looks like the happy path — and
+# the second masked the first's exit code, so the two get SEPARATE fixtures: each is red
+# against its own fix and green against the other's.
+#
+# Usage: ./install.test        (exits 0 if all pass)
+
+set -uo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+INSTALL="$HERE/install.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+
+pass() { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL %s\n         %s\n' "$1" "$2"; }
+
+# A self-contained clone plus two target roots, so no test can see another's state or
+# the real $HOME.
+# mktemp, not a counter: this runs inside `$( )`, so an `N=$((N+1))` here increments a
+# SUBSHELL's copy and every fixture comes back as the same path — the tests then inherit
+# each other's symlinks and pass on state they did not create.
+new_fixture() {  # $1 = space-separated skill names to create in the clone
+  local base s
+  base=$(mktemp -d "$WORK/fixture.XXXXXX")
+  mkdir -p "$base"/{clone/.git,home/.claude/skills,codexhome/skills,bin}
+  for s in $1; do
+    mkdir -p "$base/clone/skills/$s"
+    printf 'stub\n' > "$base/clone/skills/$s/SKILL.md"
+  done
+  # install.sh runs `git -C ... pull` (the clone dir has .git above) before linking.
+  # Stubbed so no test touches the network; git is used for nothing else in the script.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$base/bin/git"
+  chmod +x "$base/bin/git"
+  printf '%s' "$base"
+}
+
+link_skill() {  # $1 = base, $2 = skill — pre-link into both targets
+  ln -s "$1/clone/skills/$2" "$1/home/.claude/skills/$2"
+  ln -s "$1/clone/skills/$2" "$1/codexhome/skills/$2"
+}
+
+# -L as well as -e: a dangling symlink is invisible to -e, and "removed" must mean the
+# link is gone, not merely broken.
+gone() { [[ ! -e "$1" && ! -L "$1" ]]; }
+
+run() {  # $1 = base, rest = installer args
+  local base=$1; shift
+  HOME="$base/home" CODEX_HOME="$base/codexhome" PATH="$base/bin:$PATH" \
+    bash "$INSTALL" --dir "$base/clone" "$@" 2>&1
+}
+
+# ── uninstall ───────────────────────────────────────────────────────────────────────
+
+# Asserts filesystem state ONLY, never the exit code — that is what isolates it from the
+# read-EOF defect, which leaves this outcome correct while still exiting 1.
+t="uninstall --target both reaches the SECOND target"
+b=$(new_fixture "alpha"); link_skill "$b" alpha
+run "$b" --target both --uninstall </dev/null >/dev/null
+if ! gone "$b/home/.claude/skills/alpha"; then fail "$t" "claude symlink survived"
+elif ! gone "$b/codexhome/skills/alpha"; then fail "$t" "codex symlink survived — the loop aborted after target 1"
+else pass "$t"; fi
+
+# Nothing to remove, so the partial-uninstall defect cannot fire and a non-zero exit can
+# only come from the prompt's EOF.
+t="a non-interactive uninstall exits 0"
+b=$(new_fixture "alpha")
+run "$b" --target both --uninstall </dev/null >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc on a run with nothing to remove"
+else pass "$t"; fi
+
+t="the real case — links present, no tty — exits 0 with both targets clean"
+b=$(new_fixture "alpha"); link_skill "$b" alpha
+run "$b" --target both --uninstall </dev/null >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc"
+elif ! gone "$b/codexhome/skills/alpha"; then fail "$t" "codex symlink survived"
+else pass "$t"; fi
+
+t="uninstall leaves symlinks that point outside the install dir"
+b=$(new_fixture "alpha"); mkdir -p "$b/foreign/beta"
+ln -s "$b/foreign/beta" "$b/home/.claude/skills/beta"
+run "$b" --target claude --uninstall </dev/null >/dev/null
+if gone "$b/home/.claude/skills/beta"; then fail "$t" "removed a symlink it does not own"
+else pass "$t"; fi
+
+t="answering y removes the clone"
+b=$(new_fixture "alpha"); link_skill "$b" alpha
+printf 'y\n' | run "$b" --target both --uninstall >/dev/null
+if [[ -d "$b/clone" ]]; then fail "$t" "clone survived an explicit y"
+else pass "$t"; fi
+
+t="answering n keeps the clone"
+b=$(new_fixture "alpha"); link_skill "$b" alpha
+printf 'n\n' | run "$b" --target both --uninstall >/dev/null
+if [[ ! -d "$b/clone" ]]; then fail "$t" "clone removed against an explicit n"
+else pass "$t"; fi
+
+# Pins the semantics the fix chose: EOF is a DECLINED prompt, matching the [y/N] default.
+# Without this a future `|| answer=y` would satisfy every other case here and delete the
+# clone out from under a scripted uninstall.
+t="EOF at the prompt keeps the clone"
+b=$(new_fixture "alpha"); link_skill "$b" alpha
+run "$b" --target both --uninstall </dev/null >/dev/null
+if [[ ! -d "$b/clone" ]]; then fail "$t" "EOF was read as consent to delete"
+else pass "$t"; fi
+
+# ── install ─────────────────────────────────────────────────────────────────────────
+
+t="install links a named skill into both targets"
+b=$(new_fixture "alpha beta")
+run "$b" --target both alpha >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc"
+elif [[ ! -L "$b/home/.claude/skills/alpha" ]]; then fail "$t" "claude link missing"
+elif [[ ! -L "$b/codexhome/skills/alpha" ]]; then fail "$t" "codex link missing"
+elif [[ -L "$b/home/.claude/skills/beta" ]]; then fail "$t" "linked an unrequested skill"
+else pass "$t"; fi
+
+t="re-running an install is idempotent"
+b=$(new_fixture "alpha")
+run "$b" --target both alpha >/dev/null
+out=$(run "$b" --target both alpha); rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc on the second run"
+elif [[ "$out" != *"already linked"* ]]; then fail "$t" "did not report an existing link"
+else pass "$t"; fi
+
+t="a real directory at the target is skipped, not clobbered"
+b=$(new_fixture "alpha")
+mkdir -p "$b/home/.claude/skills/alpha"; printf 'mine\n' > "$b/home/.claude/skills/alpha/NOTES.md"
+run "$b" --target claude alpha >/dev/null; rc=$?
+if [[ ! -f "$b/home/.claude/skills/alpha/NOTES.md" ]]; then fail "$t" "destroyed a user directory"
+elif [[ $rc -eq 0 ]]; then fail "$t" "reported success while skipping"
+else pass "$t"; fi
+
+t="a missing skill name is a warning and a non-zero exit"
+b=$(new_fixture "alpha")
+out=$(run "$b" --target claude nosuch); rc=$?
+if [[ $rc -eq 0 ]]; then fail "$t" "exit 0 for a skill that does not exist"
+elif [[ "$out" != *"not found"* ]]; then fail "$t" "no warning naming the missing skill"
+else pass "$t"; fi
+
+printf '\npassed %d, failed %d\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Two independent `set -e` aborts on `--uninstall`, both of which looked like a clean run.

## 1. `--target both` uninstalls one target, silently

`remove_symlinks_from_dir` ended on:

```bash
[[ $removed -eq 0 ]] && echo "No symlinks found in $dir pointing to $install_dir"
```

When it **had** removed something that test is false, the `&&` list exits 1, the function returns 1, and `set -e` (line 2) kills the target loop. Reproduced against the real installer with a fixture holding a symlink in each target:

```
Removed symlink: .../home/.claude/skills/alpha
EXIT=1
AFTER:
  codexhome/skills:  alpha        <-- survived
  home/.claude/skills:  (empty)
```

Claude cleaned, Codex still linked, the clone prompt never reached, no error text. The perverse property: with **nothing** to remove, `removed` is 0, the test is true, the function returns 0 and both targets are processed correctly. **The abort fires only when the removal succeeds.**

## 2. Every non-interactive uninstall reports failure

`read -rp` exits 1 on EOF, and under `set -e` that aborts before the `exit 0`. Differential on one fixture: `</dev/null` → `EXIT=1`; `printf 'n\n' |` → `EXIT=0`. The uninstall had fully succeeded in both.

This also **masked** defect 1 — a caller checking the exit code saw the same bare `1` either way.

## The fix

An `if` (returns 0 on both branches), and `|| answer=""` so EOF reads as a declined prompt — the `[y/N]` default.

## Tests

Adds `install.test`, the repo's third suite, 11 cases.

The two defects get **separate** fixtures rather than one end-to-end case, because either alone yields exit 1 and a combined test cannot say which fired:

- the partial-uninstall fixture asserts **filesystem state only** and ignores the exit code, so defect 2 cannot redden it;
- the EOF fixture runs with **nothing to remove**, so defect 1 cannot fire.

Mutation-verified, one mutation at a time, on production behavior:

| mutation | red | green |
|---|---|---|
| restore `[[ ... ]] && echo` | `reaches the SECOND target` ("codex symlink survived — the loop aborted after target 1") | `a non-interactive uninstall exits 0` |
| drop `\|\| answer=""` | `a non-interactive uninstall exits 0` ("exit 1 on a run with nothing to remove") | `reaches the SECOND target` |
| `\|\| answer=y` | `EOF at the prompt keeps the clone` ("EOF was read as consent to delete") | all others |

Isolation holds in both directions.

Two notes on the process, since this repo counts them:

- A `sed`-based fourth mutation **silently matched nothing** (`|` delimiter colliding with `||`), and the suite came back 11/11 — a false green that would have read as "no coverage gap." Caught by reading the `sed` error and re-checking the line; redone in Python with an asserted occurrence count. That is the `sed -i` succeeding on zero matches hazard from the discipline block, hit live.
- The suite's first draft built fixtures with `N=$((N+1))` inside `$( )`, which increments a **subshell's** copy — every fixture resolved to the same path and tests inherited each other's symlinks. Two install cases failed for that reason; the first seven "passed" on shared state and proved nothing. Fixed with `mktemp -d`.

## Verification

```
install.test        passed 11, failed 0
bot-gate.test       passed 124, failed 0
drive-status.test   passed 70, failed 0
```

Found while checking `install.sh` for the backlog plan — its per-skill symlinking bears on where a shared script (#32) can live, since it clones the whole repo but links one directory at a time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved uninstall behavior in non-interactive environments by treating end-of-file input as a declined response.
  - Prevented successful symlink cleanup from being reported as a failure.
  - Preserved existing directories and protected unrelated content during uninstall operations.

- **Tests**
  - Added comprehensive coverage for installation, uninstallation, symlink handling, clone removal consent, idempotency, ownership protection, and missing skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->