### PR TITLE
A claim about what a tool does needs a run, not a recollection

### DIFF
--- a/DRIVE.md
+++ b/DRIVE.md
@@ -1,11 +1,13 @@
 # DRIVE — make behavioural claims in prose carry the evidence code already has to
 
 **Scope:** issue #45 only — the rule, in `agents-md`'s managed discipline block. Issues
-#30/#31/#32/#33/#35/#38/#41/#43/#44 are separate PRs and NOT in scope.
+Issues #30/#31/#32/#33/#35/#38/#41/#43/#44 are separate PRs and NOT in scope.
 **Phase:** BUILD · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** prose-execution-rule
 **Pending:** —
 **Gate:** `./install.test && ./skills/pr-with-codex-bot-review/scripts/bot-gate.test && ./skills/drive/scripts/drive-status.test`
-· last green 2026-08-09 (12 / 124 / 70, exit 0)
+· run at a2e7893 on bash 5.3.9: `passed 12, failed 0` / `passed 124, failed 0` /
+`passed 70, failed 0`, each exit 0. Re-runnable at that commit; this line records the
+commit rather than a date, so a reader can reproduce it rather than trust it.
 
 ## Done
 - #37 merged (291a6ce): install.sh's two uninstall aborts, plus `install.test`.
@@ -26,7 +28,7 @@ Five factual claims about tool behaviour shipped false, each beside a *correct* 
 of them introduced by the commit fixing the previous one. Every test suite was green
 throughout, because suites do not read prose.
 
-`agents-md/references/discipline-block.md` is the home: it already carries the sibling
+`skills/agents-md/references/discipline-block.md` is the home: it already carries the sibling
 rule for edits (`sed -i` reports success when it matched nothing), and the block's own
 admission bar — applies to every repo, agents get it wrong by default, every line traces
 to a concrete failure — is met on all three counts.
@@ -40,7 +42,7 @@ than an extension of `verify-commit`; retro-fitting "Measured on" to existing se
 across the repo; or edits to any skill other than `agents-md`.
 
 ## Next
-#32 `verify-commit`, written under this rule. Then #30/#31 (drive Guard 2 — both
+Issue #32 `verify-commit`, written under this rule. Then #30/#31 (drive Guard 2 — both
 reviewers previously said decline the watcher script and use `--max-rounds`), #33/#35,
 and the § 3a residue (#41, #43, #44).
 

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -41,8 +41,7 @@ runner could execute the ```console blocks and compare status and output, which 
 issue #49 proposes — but no *generic* script validates an arbitrary natural-language claim,
 so reviewer-plus-recorded-run is the enforcement the rule can rely on today.
 Do NOT retro-fit "Measured on" to existing sentences across the repo.
-Do NOT edit any skill other than `agents-md`. retro-fitting "Measured on" to existing sentences
-across the repo; or edits to any skill other than `agents-md`.
+Do NOT edit any skill other than `agents-md`.
 
 ## Next
 Issue #32 `verify-commit`, written under this rule. Then #30/#31 (drive Guard 2 — both

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -2,7 +2,7 @@
 
 **Scope:** issue #45 only — the rule, in `agents-md`'s managed discipline block.
 Issues #30/#31/#32/#33/#35/#38/#41/#43/#44 are separate PRs and NOT in scope.
-**Phase:** BUILD · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** prose-execution-rule
+**Phase:** HARDEN · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** prose-execution-rule
 **Pending:** —
 **Gate:** `./install.test && ./skills/pr-with-codex-bot-review/scripts/bot-gate.test && ./skills/drive/scripts/drive-status.test`
 · run at a2e7893 on bash 5.3.9: `passed 12, failed 0` / `passed 124, failed 0` /

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -1,6 +1,6 @@
 # DRIVE — make behavioural claims in prose carry the evidence code already has to
 
-**Scope:** issue #45 only — the rule, in `agents-md`'s managed discipline block. Issues
+**Scope:** issue #45 only — the rule, in `agents-md`'s managed discipline block.
 Issues #30/#31/#32/#33/#35/#38/#41/#43/#44 are separate PRs and NOT in scope.
 **Phase:** BUILD · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** prose-execution-rule
 **Pending:** —

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -1,57 +1,49 @@
-# DRIVE — sweep the rules that reached one sibling site and not the other
+# DRIVE — make behavioural claims in prose carry the evidence code already has to
 
-**Scope:** the sites named below, and nothing else. Issues #30/#31/#32/#33/#35 are
-separate PRs and are NOT in scope. New scripts are NOT in scope — this sweep exists
-because the rules already exist and simply did not travel.
-**Phase:** HARDEN · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** sibling-site-sweep
+**Scope:** issue #45 only — the rule, in `agents-md`'s managed discipline block. Issues
+#30/#31/#32/#33/#35/#38/#41/#43/#44 are separate PRs and NOT in scope.
+**Phase:** BUILD · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** prose-execution-rule
 **Pending:** —
 **Gate:** `./install.test && ./skills/pr-with-codex-bot-review/scripts/bot-gate.test && ./skills/drive/scripts/drive-status.test`
-· last green 2026-08-08 (12 / 124 / 70, exit 0)
+· last green 2026-08-09 (12 / 124 / 70, exit 0)
 
 ## Done
 - #37 merged (291a6ce): install.sh's two uninstall aborts, plus `install.test`.
+- #40 merged (fe5149e): four sibling-site rules — guarded `mktemp`, two-step `br where`
+  resolution at 10 sites, unconditional group kill, `mktemp -d` review directories.
+  Three further rules withdrawn to #41/#43/#44; #29 closed; #39 closed as superseded
+  by #42, with the false-closure corrected on the issue.
 
 ## Now
-TRIMMED at the three-round stop-list. Four rules converged and ship here; three did not and were withdrawn to their own
-issues rather than patched again. Rule 3 was in the shipping set until round 4 read it
-against the refusal list — the trim rule applied twice, on the same evidence standard.
+One rule, in one file. Both panel reviewers independently picked #45 as the next PR, and
+both said land it alone, then write #32 under it.
 
-Shipping:
-1. `_chk=$(mktemp) || exit 1` at all **four** recipe copies — `drive/references/phases.md`
-   had no assignment at all (#34 batch 3), and the other three had an *unchecked* one, which
-   round 5 showed fails open: an unusable `TMPDIR` leaves `_chk` empty and the removal
-   check's `|| true` then reports count 0 as "phrase fully removed". A fifth site exists as
-   commented-out text (`multi-reviewer-loop/SKILL.md:156`) → #44.
-2. `br where` resolution in **two checked steps at all 10 CODE-BLOCK sites** across 8
-   files — plus a checked `git status`, since a failed inspection also prints nothing.
-   Prose and comments teaching the same one-liner are NOT converted → #44. The
-   one-line form was fail-open everywhere, not just at the three sites #34 named: a
-   pipeline reports only its LAST command's status, so `br where` can fail while emitting
-   valid JSON and `jq` then succeeds. Reproduced at rc=0. (#34 batch 7, widened)
-3. ~~`--no-renames` on the § 3a status capture~~ — **withdrawn on round 4 → #43.** It
-   fixes batch 1's silent drop and simultaneously blinds the staged-rename refusal three
-   paragraphs above it, since detecting a staged rename requires the detection the flag
-   turns off. Needs two reads, not one flag.
-4. Kill the process group unconditionally at both escape-hatch sites. (#34 batch 6)
-5. `mktemp -d` for both review directories — exclusive at 0700. NOT the `(umask 077;
-   mkdir -p)` form #29 suggested, which leaves a pre-created directory's mode alone;
-   `second-model-bead-audit` had this right all along. (closes #29)
+The evidence is #40's own history: 6 bot rounds, 5 panel passes, 13 corrections to land
+four one-line rules — and the corrections were overwhelmingly to **sentences**, not code.
+Five factual claims about tool behaviour shipped false, each beside a *correct* fix, three
+of them introduced by the commit fixing the previous one. Every test suite was green
+throughout, because suites do not read prose.
 
-Withdrawn:
-- § 3a ambient-config pinning → **#41**. Rounds 1 and 3 each found a key the "closing"
-  set had missed (`diff.noprefix` via local config, then `diff.submodule`). An enumerated
-  `-c` list is still per-flag, which is what batch 10's class closure predicted would not
-  converge. Needs the tested helper (#34 batch 8), not more flags.
-- The #39 post-push round paragraph → **#42**. It was wrong twice because it documents an
-  inconsistency, not a rule: clean-comment anchors are tip-scoped, review-object anchors
-  are not. That is a code decision on the merge gate, with fixtures.
+`agents-md/references/discipline-block.md` is the home: it already carries the sibling
+rule for edits (`sed -i` reports success when it matched nothing), and the block's own
+admission bar — applies to every repo, agents get it wrong by default, every line traces
+to a concrete failure — is met on all three counts.
+
+**This PR must satisfy its own rule.** Every behavioural claim in it gets executed and the
+run recorded, including the ones in the rule's own text.
+
+Do NOT build: a linter or script — no script can check a documentation claim, which is
+why the reviewer plus the recorded run *is* the enforcement and why this is a rule rather
+than an extension of `verify-commit`; retro-fitting "Measured on" to existing sentences
+across the repo; or edits to any skill other than `agents-md`.
 
 ## Next
-Backlog PRs 2-4: drive Guard 2 (#30/#31), read-what-you-delegate (#33/#35),
-`verify-commit` (#32).
+#32 `verify-commit`, written under this rule. Then #30/#31 (drive Guard 2 — both
+reviewers previously said decline the watcher script and use `--max-rounds`), #33/#35,
+and the § 3a residue (#41, #43, #44).
 
 ## Open questions for the human
-- `AGENTS.md` is still absent. It has a real addressee now — this branch — but installing
-  it would double this PR's review surface and issue #33 is open precisely about
-  `agents-md` writing a block that contradicts the repo's own agreement. Deferred to the
-  #33 PR, which is where that conflict gets resolved rather than inherited.
+- `AGENTS.md` is still absent from this repo, so the block this PR edits is not installed
+  here. Orthogonal — the block's purpose is to travel to other repos — but it does mean
+  this repo does not yet hold itself to the rule it ships. Deferred to the #33 PR, where
+  `agents-md` installation is the subject rather than a side effect.

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -18,7 +18,9 @@
 One rule, in one file. Both panel reviewers independently picked #45 as the next PR, and
 both said land it alone, then write #32 under it.
 
-The evidence is #40's own history: 6 bot rounds, 5 panel passes, 13 corrections to land
+The evidence is #40's own history: 8 codex bot rounds (6 review objects plus 2 clean
+wrappers — a clean round posts no review object, which is why the naive count reads 6),
+5 panel passes, 13 corrections to land
 four one-line rules — and the corrections were overwhelmingly to **sentences**, not code.
 Five factual claims about tool behaviour shipped false, each beside a *correct* fix, three
 of them introduced by the commit fixing the previous one. Every test suite was green

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -36,11 +36,12 @@ to a concrete failure — is met on all three counts.
 **This PR must satisfy its own rule.** Every behavioural claim in it gets executed and the
 run recorded, including the ones in the rule's own text.
 
-Do NOT build: a linter or script in THIS PR. Not because automation is impossible — a
-doctest-style runner could execute the ```console blocks and compare status and output,
-which is exactly what issue #49 proposes — but because no *generic* script validates an
-arbitrary natural-language claim, so the reviewer plus the recorded run is the enforcement
-the rule can rely on today; retro-fitting "Measured on" to existing sentences
+Do NOT build a linter or script in THIS PR. Automation is possible — a doctest-style
+runner could execute the ```console blocks and compare status and output, which is what
+issue #49 proposes — but no *generic* script validates an arbitrary natural-language claim,
+so reviewer-plus-recorded-run is the enforcement the rule can rely on today.
+Do NOT retro-fit "Measured on" to existing sentences across the repo.
+Do NOT edit any skill other than `agents-md`. retro-fitting "Measured on" to existing sentences
 across the repo; or edits to any skill other than `agents-md`.
 
 ## Next

--- a/DRIVE.md
+++ b/DRIVE.md
@@ -36,9 +36,11 @@ to a concrete failure — is met on all three counts.
 **This PR must satisfy its own rule.** Every behavioural claim in it gets executed and the
 run recorded, including the ones in the rule's own text.
 
-Do NOT build: a linter or script — no script can check a documentation claim, which is
-why the reviewer plus the recorded run *is* the enforcement and why this is a rule rather
-than an extension of `verify-commit`; retro-fitting "Measured on" to existing sentences
+Do NOT build: a linter or script in THIS PR. Not because automation is impossible — a
+doctest-style runner could execute the ```console blocks and compare status and output,
+which is exactly what issue #49 proposes — but because no *generic* script validates an
+arbitrary natural-language claim, so the reviewer plus the recorded run is the enforcement
+the rule can rely on today; retro-fitting "Measured on" to existing sentences
 across the repo; or edits to any skill other than `agents-md`.
 
 ## Next

--- a/skills/agents-md/SKILL.md
+++ b/skills/agents-md/SKILL.md
@@ -183,6 +183,13 @@ When a rule graduates — enough repos need it, or it grows beyond a paragraph �
 move it to its own skill and leave a pointer, the way beads guidance lives in
 `br agents` rather than here.
 
+The block's rule on behavioural claims is the worked example: the paragraph in the
+block is the whole rule, and the incident behind it, the transcripts showing what a
+sufficient record looks like, and the observing-versus-explaining distinction live in
+[references/behavioural-claims.md](references/behavioural-claims.md). Note where the
+pointer is — here, not in the block. A reference in the copied text would be a dangling
+link in every downstream `AGENTS.md`, since the block travels and this repo does not.
+
 ## When not to use this
 
 - The repo has a carefully maintained `AGENTS.md` and the user wants

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -102,9 +102,11 @@ over "behavior differs", and only one of them is a claim you can be wrong about.
 ## The honest cost
 
 This rule is meaningfully harder to satisfy than to state. The pull request that introduced
-it (`douglaz/skills` #46) needed a correction in **every** review round it ran — its commit
-history carries the running total, deliberately not restated here, since a count asserted in
-prose goes stale the next round and this file is about not doing that. Every one was an
+it (`douglaz/skills` #46) required at least one correction in each of its **first six**
+review rounds — a bounded historical fact rather than a present universal, which would
+refute itself on the first clean round, i.e. exactly the event needed to land. Its commit
+history carries the per-round detail, deliberately not restated here, since a running count
+asserted in prose goes stale the next round and this file is about not doing that. Every one was an
 instance of the defect the rule names. Several were found by pointing the rule at itself:
 a transcript that misquoted its own output, an example that failed the standard it was
 demonstrating, a gate claim recorded as a date rather than a commit, hand-labelled streams

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -38,11 +38,12 @@ provenance rather than showing it — rerun in a terminal or CI log that combine
 descriptors and nothing distinguishes the two:
 
 ```console
-$ git status --porcelain -- "" >/tmp/o 2>/tmp/e ; echo "status=$?"   # git 2.54.0
-status=128
-$ wc -c </tmp/o
+$ d=$(mktemp -d) && trap 'rm -rf "$d"' EXIT      # not /tmp/o: a predictable path can
+$ git status --porcelain -- "" >"$d/o" 2>"$d/e" ; echo "status=$?"   # already be a symlink
+status=128                                       # git 2.54.0
+$ wc -c <"$d/o"
 0
-$ cat /tmp/e
+$ cat "$d/e"
 fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
 ```
 
@@ -64,20 +65,24 @@ experiment depends on (measured — with `SHELLOPTS` exported, the unpinned base
 2, and `--noprofile --norc` plus `set +o pipefail` restores 0):
 
 ```console
-$ bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >o1 2>e1 ; st=$?; echo "status=$st"'
+$ d=$(mktemp -d) && trap 'rm -rf "$d"' EXIT && export d
+$ bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; st=$?; echo "status=$st"'
 status=0                                       # bash 5.3.9, GNU grep 3.12, coreutils 9.11
-$ cat o1 ; cat e1
+$ cat "$d/o1" ; cat "$d/e1"
 0
 grep: : No such file or directory
-$ bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >o2 2>e2 ; st=$?; echo "status=$st"'
+$ bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; st=$?; echo "status=$st"'
 status=2
-$ cat o2 ; cat e2
+$ cat "$d/o2" ; cat "$d/e2"
 0
 grep: : No such file or directory
 ```
 
 `wc`'s version is recorded because `wc` is one of the two commands whose status the
-experiment is about.
+experiment is about. Both captures go to a `mktemp -d` directory with a cleanup trap, not
+to fixed names: these snippets exist to be re-run, and a predictable `/tmp/o` on a shared
+host can already be a symlink that redirection follows and truncates before the command
+starts — while bare `o1`/`e1` litter whatever directory the reader is standing in.
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -1,0 +1,89 @@
+# Behavioural claims in prose
+
+The managed block carries this rule in one paragraph, because it is copied into every repo
+and bloat there gets ignored wholesale. This file is the long form — the incident it came
+from, what a sufficient record looks like, and the two distinctions that are easy to state
+and hard to apply. It stays in this repository; it is not part of the copied block.
+
+## The incident
+
+One documentation branch (`douglaz/skills` #40) carried four one-line rules between sibling
+sites. Landing it took **8 codex bot rounds, 5 local panel passes, 13 corrections** — and
+the corrections were overwhelmingly to *sentences*, not code:
+
+| claimed | measured |
+|---|---|
+| `git status --porcelain -- ""` succeeds printing nothing | exit 128, `fatal: empty string is not a valid pathspec…` |
+| an empty-filename redirect is silent | exit 1, `: No such file or directory` |
+| "Measured on git 2.54 / jq 1.7" | the host ran jq 1.8.2; that run never happened |
+| the removal check returns 0 "because `wc` succeeds" | under `pipefail` it exits 2; `\|\| true` swallows it |
+| a held `.git/index.lock` makes `git status` fail | exit 0, on both a clean and a dirty tree |
+
+Every one sat beside a **correct** fix. Three were introduced by the commit fixing the
+previous one, including one by the commit whose own message named this failure mode. Every
+test suite was green throughout, because suites do not read prose.
+
+That is the argument for the rule: a wrong reason is worse than no reason, because it
+invites the next agent to "simplify" the guard away — the stated justification is
+disprovable in thirty seconds, so it reads as evidence the guard is confused.
+
+## What a record looks like
+
+Separate the streams with redirection. Hand-labelled comments on merged output assert
+provenance rather than showing it — rerun in a terminal or CI log that combines file
+descriptors and nothing distinguishes the two:
+
+```console
+$ git status --porcelain -- "" >/tmp/o 2>/tmp/e ; echo "status=$?"   # git 2.54.0
+status=128
+$ wc -c </tmp/o
+0
+$ cat /tmp/e
+fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
+```
+
+The redirection *is* the evidence for "nothing on stdout". A reader can re-run it and
+disagree, which is the whole test.
+
+## Observing is not explaining
+
+A rerun gives the exit code and the streams; it never gives the *why*. A command can fail
+for several config- or environment-dependent reasons, so `X fails because Y` needs Y varied
+on its own with the outcome changing, or the documentation or source cited.
+
+The cheapest instance, and the one that shipped wrong on #40 — note it takes **two** runs,
+because the second is the counterfactual:
+
+```console
+$ bash -c '{ grep -Fo -- x "" | wc -l ; } >o1 2>e1 ; echo "status=$?"'   # bash 5.3.9, GNU grep 3.12
+status=0
+$ cat o1 ; cat e1
+0
+grep: : No such file or directory
+$ bash -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >o2 2>e2 ; echo "status=$?"'
+status=2
+$ cat o2 ; cat e2
+0
+grep: : No such file or directory
+```
+
+Identical output, different status. So "the count came back 0 because `wc` succeeded" is
+settled only by the pair — one run re-blesses the wrong component, which is exactly what
+happened.
+
+## A claim you cannot run is not yours to assert
+
+A version you do not have, a kernel path you cannot force. Say it is unmeasured and narrow
+it to a possibility. "Behavior may differ on older git — unmeasured here" costs one word
+over "behavior differs", and only one of them is a claim you can be wrong about.
+
+## The honest cost
+
+This rule is meaningfully harder to satisfy than to state. The pull request that introduced
+it needed **ten corrections to its own text across three review rounds**, every one an
+instance of the defect the rule names, and three of them found by pointing the rule at
+itself — including a transcript that misquoted its own output, an example that failed the
+standard it was demonstrating, and a gate claim recorded as a date rather than a commit.
+
+That is not an argument against the rule. It is the measurement of how invisible this class
+of error is without one, and it should be quoted to anyone who thinks the rule is obvious.

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -8,8 +8,12 @@ and hard to apply. It stays in this repository; it is not part of the copied blo
 ## The incident
 
 One documentation branch (`douglaz/skills` #40) carried four one-line rules between sibling
-sites. Landing it took **8 codex bot rounds, 5 local panel passes, 13 corrections** — and
-the corrections were overwhelmingly to *sentences*, not code:
+sites. Landing those four took **8 codex bot rounds, 5 local panel passes, 13 corrections**
+— the corrections outnumbering the rules, and overwhelmingly to *sentences* rather than
+code. Five of them were false statements about tool behaviour, recorded here as they were
+corrected in that branch's review; the command, version and captured output for each are in
+its commit history rather than restated below, since this table is a summary of prior
+corrections and not itself new evidence:
 
 | claimed | measured |
 |---|---|
@@ -54,18 +58,26 @@ on its own with the outcome changing, or the documentation or source cited.
 The cheapest instance, and the one that shipped wrong on #40 — note it takes **two** runs,
 because the second is the counterfactual:
 
+Pin the baseline explicitly. `bash -c` inherits `pipefail` when the parent exports
+`SHELLOPTS`, and a contaminated baseline reports 2, silently collapsing the contrast the
+experiment depends on (measured — with `SHELLOPTS` exported, the unpinned baseline gives
+2, and `--noprofile --norc` plus `set +o pipefail` restores 0):
+
 ```console
-$ bash -c '{ grep -Fo -- x "" | wc -l ; } >o1 2>e1 ; echo "status=$?"'   # bash 5.3.9, GNU grep 3.12
-status=0
+$ bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >o1 2>e1 ; st=$?; echo "status=$st"'
+status=0                                       # bash 5.3.9, GNU grep 3.12, coreutils 9.11
 $ cat o1 ; cat e1
 0
 grep: : No such file or directory
-$ bash -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >o2 2>e2 ; echo "status=$?"'
+$ bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >o2 2>e2 ; st=$?; echo "status=$st"'
 status=2
 $ cat o2 ; cat e2
 0
 grep: : No such file or directory
 ```
+
+`wc`'s version is recorded because `wc` is one of the two commands whose status the
+experiment is about.
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -85,7 +85,8 @@ $ ( set +e ; set -o pipefail ; export SHELLOPTS    # bash 5.3.9
 >   env -u BASH_ENV bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
 #   THIS block deliberately leaves its children exposed — that is the hazard it
-#   shows. The experiment below does not: it uses `env -i "PATH=$PATH"`.
+#   shows. The experiment below does not: `env -i` with NO PATH, and absolute
+#   binaries passed in. Do not copy this block's invocation.
 #
 #   Enumerating contamination vectors does not converge. Review of this file found
 #   three in three rounds: SHELLOPTS (carries pipefail), BASH_ENV (sourced by
@@ -109,15 +110,15 @@ grep (GNU grep) 3.12                   # resolve, then CHECK what you resolved: 
 wc (GNU coreutils) 9.11                # hostile PATH `type -P` finds the shadow, not GNU
 $ ( set +e ; d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT
 >   env -i "d=$d" "G=$G" "W=$W" bash -c 'set +o pipefail; { "$G" -Fo -- x "" | "$W" -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
->   cat "$d/o1" "$d/e1"
+>   printf 'stdout: ' ; cat "$d/o1" ; printf 'stderr: ' ; cat "$d/e1"
 >   env -i "d=$d" "G=$G" "W=$W" bash -c 'set -o pipefail; { "$G" -Fo -- x "" | "$W" -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
->   cat "$d/o2" "$d/e2" )              # bash 5.3.9
+>   printf 'stdout: ' ; cat "$d/o2" ; printf 'stderr: ' ; cat "$d/e2" )   # bash 5.3.9
 status=0
-0
-/run/current-system/sw/bin/grep: : No such file or directory
+stdout: 0
+stderr: /run/current-system/sw/bin/grep: : No such file or directory
 status=2
-0
-/run/current-system/sw/bin/grep: : No such file or directory
+stdout: 0
+stderr: /run/current-system/sw/bin/grep: : No such file or directory
 ```
 
 Absolute binaries, not names on a `PATH`: `env -i "PATH=$PATH"` re-imports the caller's

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -38,8 +38,9 @@ provenance rather than showing it — rerun in a terminal or CI log that combine
 descriptors and nothing distinguishes the two:
 
 ```console
-$ ( d=$(mktemp -d) || exit 1          # `||`, not `&&`: on failure d is empty and the
->   trap 'rm -rf "$d"' EXIT           # next line would redirect to /o
+$ ( set +e                            # these commands FAIL on purpose; under `set -e`
+>   d=$(mktemp -d) || exit 1          # the subshell dies before recording anything
+>   trap 'rm -rf "$d"' EXIT           # `||` not `&&`: on failure d is empty -> /o
 >   git status --porcelain -- "" >"$d/o" 2>"$d/e"
 >   echo "status=$?" ; wc -c <"$d/o" ; cat "$d/e" )      # git 2.54.0
 status=128
@@ -47,7 +48,10 @@ status=128
 fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
 ```
 
-The redirection *is* the evidence for "nothing on stdout". A reader can re-run it and
+Two things are being shown and they should not be conflated: the redirection establishes
+**where** each stream went, and `wc -c <"$d/o"` returning 0 establishes that stdout was
+**empty**. Redirection alone proves provenance only — a record that captures streams and
+never inspects them has shown nothing about their contents. A reader can re-run both and
 disagree, which is the whole test.
 
 ## Observing is not explaining
@@ -66,7 +70,7 @@ Shown rather than asserted, because a warning about unverifiable claims has no b
 being one:
 
 ```console
-$ ( set -o pipefail; export SHELLOPTS
+$ ( set +e ; set -o pipefail ; export SHELLOPTS    # SHELLOPTS carries errexit too
 >   bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
 >   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
@@ -76,7 +80,7 @@ pinned=0                                       # --noprofile --norc + explicit m
 With that established, the experiment itself:
 
 ```console
-$ ( d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT ; export d
+$ ( set +e ; d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT ; export d
 >   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
 >   cat "$d/o1" "$d/e1"
 >   bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
@@ -131,8 +135,9 @@ happening to the section above.
 ## A claim you cannot run is not yours to assert
 
 A version you do not have, a kernel path you cannot force. Say it is unmeasured and narrow
-it to a possibility. "Behavior may differ on older git — unmeasured here" costs one word
-over "behavior differs", and only one of them is a claim you can be wrong about.
+it to a possibility. "Behavior **may** differ on older git — unmeasured here" adds one word
+to "Behavior differs on older git — unmeasured here", and only one of the two is a claim you
+can be wrong about.
 
 ## The honest cost
 

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -38,9 +38,10 @@ provenance rather than showing it — rerun in a terminal or CI log that combine
 descriptors and nothing distinguishes the two:
 
 ```console
-$ d=$(mktemp -d) && trap 'rm -rf "$d"' EXIT      # not /tmp/o: a predictable path can
-$ git status --porcelain -- "" >"$d/o" 2>"$d/e" ; echo "status=$?"   # already be a symlink
-status=128                                       # git 2.54.0
+$ d=$(mktemp -d) || { echo "no temp dir"; exit 1; }   # NOT `&&`: on failure `d` is empty
+$ trap 'rm -rf "$d"' EXIT                             # and the next line writes to /o
+$ git status --porcelain -- "" >"$d/o" 2>"$d/e" ; echo "status=$?"   # git 2.54.0
+status=128
 $ wc -c <"$d/o"
 0
 $ cat "$d/e"
@@ -65,7 +66,8 @@ experiment depends on (measured — with `SHELLOPTS` exported, the unpinned base
 2, and `--noprofile --norc` plus `set +o pipefail` restores 0):
 
 ```console
-$ d=$(mktemp -d) && trap 'rm -rf "$d"' EXIT && export d
+$ d=$(mktemp -d) || { echo "no temp dir"; exit 1; }
+$ trap 'rm -rf "$d"' EXIT ; export d
 $ bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; st=$?; echo "status=$st"'
 status=0                                       # bash 5.3.9, GNU grep 3.12, coreutils 9.11
 $ cat "$d/o1" ; cat "$d/e1"
@@ -82,7 +84,11 @@ grep: : No such file or directory
 experiment is about. Both captures go to a `mktemp -d` directory with a cleanup trap, not
 to fixed names: these snippets exist to be re-run, and a predictable `/tmp/o` on a shared
 host can already be a symlink that redirection follows and truncates before the command
-starts — while bare `o1`/`e1` litter whatever directory the reader is standing in.
+starts — while bare `o1`/`e1` litter whatever directory the reader is standing in. And the
+creation is checked with `||`, not chained with `&&`: on failure `&&` skips only the trap,
+leaving `d` empty so the *next* command redirects to `/o` at the filesystem root. That is
+the unchecked-`mktemp` defect this repo fixed at four sites in #40, which is how thoroughly
+this class recurs.
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -81,7 +81,7 @@ being one:
 
 ```console
 $ ( set +e ; set -o pipefail ; export SHELLOPTS    # bash 5.3.9
->   bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
+>   env -u BASH_ENV bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
 >   env -u BASH_ENV bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
 #   measured: `set +o pipefail` alone gives 0 under a contaminated parent, while
@@ -89,7 +89,9 @@ unpinned=2                                     # baseline contaminated
 #   startup files, which a non-interactive `bash -c` never reads — so they pin
 #   nothing here and are gone. `env -u BASH_ENV` is NOT decorative: BASH_ENV *is*
 #   sourced by non-interactive bash, so it can turn pipefail back on (measured) or
-#   redefine `grep` before the command string ever runs.
+#   redefine `grep` before the command string ever runs. BOTH children get it: the
+#   unpinned one is only "unpinned" as to `pipefail`, and a startup file setting
+#   `set +o pipefail` would turn its 2 into a 0 and quietly destroy the contrast.
 pinned=0                                       # `set +o pipefail` is the pin
 ```
 
@@ -123,19 +125,23 @@ who reassigns `d` afterwards gets `rm -rf` on the *new* value. Shown with `echo`
 `rm -rf`, so the record is complete without being destructive:
 
 ```console
-$ ( set +e ; orig=$(mktemp -d) || exit 1 ; victim=$(mktemp -d) || exit 1 ; d="$orig"
->   trap 'echo "trap would run: rm -rf $d" ; rm -rf "$orig" "$victim"' EXIT
+$ ( set +e ; orig=$(mktemp -d) || exit 1
+>   trap 'echo "trap would run: rm -rf $d" ; rm -rf "$orig" "${victim:-}"' EXIT
+>   victim=$(mktemp -d) || exit 1 ; d="$orig"     # trap armed BEFORE the second mktemp:
 >   echo "registered with d=$d" ; d="$victim" ; echo "reassigned  d=$d" )
-registered with d=/tmp/tmp.mkZzPEd1Zj
-reassigned  d=/tmp/tmp.4TTmbbLLqg
-trap would run: rm -rf /tmp/tmp.4TTmbbLLqg          # bash 5.3.9 — the VICTIM
+registered with d=/tmp/tmp.wcQjiQrTTG
+reassigned  d=/tmp/tmp.XUL5HWLFPI
+trap would run: rm -rf /tmp/tmp.XUL5HWLFPI          # bash 5.3.9 — the VICTIM
 
 # mktemp randomises, so YOUR paths will differ; what must reproduce is that the
 # third line names the SECOND directory, not the first.
 ```
 
-The cleanup uses `$orig`/`$victim`, which nothing reassigns, so the demonstration
-removes both directories while still showing `$d` resolving late.
+The cleanup uses `$orig`/`$victim`, which nothing reassigns, so the demonstration removes
+both directories while still showing `$d` resolving late. The trap is armed after the first
+`mktemp` and before the second: registered after both, a failing second call would `exit 1`
+with no trap installed and leak the first directory — in the very failure path a re-runnable
+example has to survive.
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -67,9 +67,18 @@ $ cat o2 ; cat e2
 grep: : No such file or directory
 ```
 
-Identical output, different status. So "the count came back 0 because `wc` succeeded" is
-settled only by the pair — one run re-blesses the wrong component, which is exactly what
-happened.
+Identical stdout, identical stderr, **different status** — and the status is the only thing
+that moved, so the status is the only thing this pair explains. It settles
+"the pipeline *reported* 0 because `wc`, the last command, succeeded": remove `pipefail`
+and grep's failure is invisible; add it and the 2 surfaces. It does **not** explain why the
+count is 0 — that is unchanged in both runs, so nothing here bears on it. Matching the
+conclusion to the varied condition is the whole discipline; drifting from "the status
+was 0" to "the count was 0" is how a correct experiment gets written up as the wrong
+claim.
+
+Capture the status into a variable on the same line, too. `echo "status=$?  count=$(cat o1)"`
+reports **`cat`'s** status, because the substitution runs first — measured while writing
+this file, on the run that was supposed to verify it.
 
 ## A claim you cannot run is not yours to assert
 
@@ -80,10 +89,14 @@ over "behavior differs", and only one of them is a claim you can be wrong about.
 ## The honest cost
 
 This rule is meaningfully harder to satisfy than to state. The pull request that introduced
-it needed **ten corrections to its own text across three review rounds**, every one an
-instance of the defect the rule names, and three of them found by pointing the rule at
-itself — including a transcript that misquoted its own output, an example that failed the
-standard it was demonstrating, and a gate claim recorded as a date rather than a commit.
+it (`douglaz/skills` #46) needed a correction in **every** review round it ran — its commit
+history carries the running total, deliberately not restated here, since a count asserted in
+prose goes stale the next round and this file is about not doing that. Every one was an
+instance of the defect the rule names. Several were found by pointing the rule at itself:
+a transcript that misquoted its own output, an example that failed the standard it was
+demonstrating, a gate claim recorded as a date rather than a commit, hand-labelled streams
+that asserted provenance instead of showing it, and a counterfactual whose conclusion named
+a different quantity than the one it varied.
 
 That is not an argument against the rule. It is the measurement of how invisible this class
 of error is without one, and it should be quoted to anyone who thinks the rule is obvious.

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -76,9 +76,22 @@ conclusion to the varied condition is the whole discipline; drifting from "the s
 was 0" to "the count was 0" is how a correct experiment gets written up as the wrong
 claim.
 
-Capture the status into a variable on the same line, too. `echo "status=$?  count=$(cat o1)"`
-reports **`cat`'s** status, because the substitution runs first — measured while writing
-this file, on the run that was supposed to verify it.
+Capture the status before anything else runs on that line. Expansions happen left to right,
+so a command substitution *earlier* in the word completes before a *later* `$?` is expanded,
+and `$?` then reports the substitution rather than the command you meant:
+
+```console
+$ bash -c 'false; echo "count=$(printf 0) status=$?"'   # bash 5.3.9
+count=0 status=0
+$ bash -c 'false; echo "status=$? count=$(printf 0)"'
+status=1 count=0
+```
+
+Same command, same two expansions, opposite order, opposite answer. `st=$?` on its own line
+removes the question. Recorded because this file first got the *mechanism* backwards — it
+claimed the substitution clobbers `$?` regardless of position, having observed a real
+failure (the first form) and explained it with the wrong cause. Which is the section above,
+happening to the section above.
 
 ## A claim you cannot run is not yours to assert
 

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -82,11 +82,14 @@ being one:
 ```console
 $ ( set +e ; set -o pipefail ; export SHELLOPTS    # bash 5.3.9
 >   bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
->   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
+>   env -u BASH_ENV bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
-#   measured: under a contaminated parent, `set +o pipefail` alone gives 0 and
-#   `--noprofile --norc` alone still gives 2 — the flags do not pin the mode. They
-#   are kept only to keep rc/profile files out of the run.
+#   measured: `set +o pipefail` alone gives 0 under a contaminated parent, while
+#   `--noprofile --norc` alone still gives 2. Those flags suppress login/interactive
+#   startup files, which a non-interactive `bash -c` never reads — so they pin
+#   nothing here and are gone. `env -u BASH_ENV` is NOT decorative: BASH_ENV *is*
+#   sourced by non-interactive bash, so it can turn pipefail back on (measured) or
+#   redefine `grep` before the command string ever runs.
 pinned=0                                       # `set +o pipefail` is the pin
 ```
 
@@ -94,9 +97,9 @@ With that established, the experiment itself:
 
 ```console
 $ ( set +e ; d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT ; export d
->   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
+>   env -u BASH_ENV bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
 >   cat "$d/o1" "$d/e1"
->   bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
+>   env -u BASH_ENV bash -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
 >   cat "$d/o2" "$d/e2" )              # bash 5.3.9, GNU grep 3.12, coreutils 9.11
 status=0
 0

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -93,26 +93,37 @@ unpinned=2                                     # baseline contaminated
 #   `export -f grep` (an imported function that survives `env -u BASH_ENV`, making
 #   the pair read 0/0 — measured). `--noprofile --norc` pins none of them, and a
 #   non-interactive `bash -c` never reads the files they suppress. `env -i` with an
-#   explicit PATH closes the class: measured, the imported function is gone
-#   (`type -t grep` -> file), SHELLOPTS loses pipefail, BASH_ENV is unset.
+#   `env -i` plus ABSOLUTE binaries closes it: measured, the imported function is
+#   gone (`type -t grep` -> file), SHELLOPTS loses pipefail, BASH_ENV is unset, and
+#   a `grep` earlier on PATH cannot be reached. Passing `PATH=$PATH` through `env -i`
+#   does NOT close it — that re-imports the shadowing, which is the fourth vector a
+#   review round found here after the first three were patched one at a time.
 pinned=0                                       # `set +o pipefail` is the pin
 ```
 
 With that established, the experiment itself:
 
 ```console
+$ G=$(type -P grep) ; W=$(type -P wc) ; "$G" --version | head -1 ; "$W" --version | head -1
+grep (GNU grep) 3.12                   # resolve, then CHECK what you resolved: under a
+wc (GNU coreutils) 9.11                # hostile PATH `type -P` finds the shadow, not GNU
 $ ( set +e ; d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT
->   env -i "PATH=$PATH" "d=$d" bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
+>   env -i "d=$d" "G=$G" "W=$W" bash -c 'set +o pipefail; { "$G" -Fo -- x "" | "$W" -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
 >   cat "$d/o1" "$d/e1"
->   env -i "PATH=$PATH" "d=$d" bash -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
->   cat "$d/o2" "$d/e2" )              # bash 5.3.9, GNU grep 3.12, coreutils 9.11
+>   env -i "d=$d" "G=$G" "W=$W" bash -c 'set -o pipefail; { "$G" -Fo -- x "" | "$W" -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
+>   cat "$d/o2" "$d/e2" )              # bash 5.3.9
 status=0
 0
-grep: : No such file or directory
+/run/current-system/sw/bin/grep: : No such file or directory
 status=2
 0
-grep: : No such file or directory
+/run/current-system/sw/bin/grep: : No such file or directory
 ```
+
+Absolute binaries, not names on a `PATH`: `env -i "PATH=$PATH"` re-imports the caller's
+`PATH` and with it any `grep` wrapper earlier on it — measured, that turns the 0/2 pair
+into 0/0. Your paths will differ from the ones above; what must reproduce is the 0 then
+the 2.
 
 `wc`'s version is recorded because `wc` is one of the two commands whose status the
 experiment is about. Both captures go to a `mktemp -d` directory with a cleanup trap, not

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -64,13 +64,17 @@ The cheapest instance, and the one that shipped wrong on #40 — note it takes *
 because the second is the counterfactual:
 
 Pin the baseline explicitly. `bash -c` inherits `pipefail` when the parent exports
-`SHELLOPTS`, and a contaminated baseline reports 2 — silently collapsing the contrast the
-experiment depends on, since the pair then reads 2 vs 2 and nothing in the output says why.
+`SHELLOPTS`, and a contaminated baseline reports 2 where it should report 0 — so if BOTH
+children were left unpinned the pair would read 2 vs 2, with nothing in the output saying
+why. The run below pins only the second, which is what makes the contamination visible:
+`unpinned=2` against `pinned=0`. (Note `set +e` here precedes the export, so `SHELLOPTS`
+carries `pipefail` and not `errexit` — `braceexpand:hashall:interactive-comments:pipefail`,
+measured. Order matters for what gets inherited.)
 Shown rather than asserted, because a warning about unverifiable claims has no business
 being one:
 
 ```console
-$ ( set +e ; set -o pipefail ; export SHELLOPTS    # SHELLOPTS carries errexit too
+$ ( set +e ; set -o pipefail ; export SHELLOPTS    # bash 5.3.9
 >   bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
 >   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
@@ -103,8 +107,17 @@ leaving `d` empty so the *next* command redirects to `/o` at the filesystem root
 the unchecked-`mktemp` defect this repo fixed at four sites in #40, which is how thoroughly
 this class recurs. Each example is one **subshell**, so its `EXIT` trap fires the moment the
 example ends: a single-quoted trap expands `$d` at exit, so in an interactive shell a reader
-who reassigns `d` afterwards gets `rm -rf` on the *new* value — measured, it deleted an
-unrelated directory and leaked the original.
+who reassigns `d` afterwards gets `rm -rf` on the *new* value. Shown with `echo` in place of
+`rm -rf`, so the record is complete without being destructive:
+
+```console
+$ ( set +e ; d=$(mktemp -d) || exit 1 ; victim=$(mktemp -d) || exit 1
+>   trap 'echo "trap would run: rm -rf $d"' EXIT
+>   echo "registered with d=$d" ; d="$victim" ; echo "reassigned  d=$d" )
+registered with d=/tmp/tmp.CfHlCRTodM
+reassigned  d=/tmp/tmp.zduT0zfbZk
+trap would run: rm -rf /tmp/tmp.zduT0zfbZk          # bash 5.3.9 — the VICTIM
+```
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles
@@ -137,7 +150,9 @@ happening to the section above.
 A version you do not have, a kernel path you cannot force. Say it is unmeasured and narrow
 it to a possibility. "Behavior **may** differ on older git — unmeasured here" adds one word
 to "Behavior differs on older git — unmeasured here", and only one of the two is a claim you
-can be wrong about.
+can be wrong about. The modal does not supply evidence — it is still unverified, and a
+reader who needs the answer must go and measure it. What it buys is honesty about which of
+those two states you are in.
 
 ## The honest cost
 

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -60,9 +60,20 @@ The cheapest instance, and the one that shipped wrong on #40 — note it takes *
 because the second is the counterfactual:
 
 Pin the baseline explicitly. `bash -c` inherits `pipefail` when the parent exports
-`SHELLOPTS`, and a contaminated baseline reports 2, silently collapsing the contrast the
-experiment depends on (measured — with `SHELLOPTS` exported, the unpinned baseline gives
-2, and `--noprofile --norc` plus `set +o pipefail` restores 0):
+`SHELLOPTS`, and a contaminated baseline reports 2 — silently collapsing the contrast the
+experiment depends on, since the pair then reads 2 vs 2 and nothing in the output says why.
+Shown rather than asserted, because a warning about unverifiable claims has no business
+being one:
+
+```console
+$ ( set -o pipefail; export SHELLOPTS
+>   bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
+>   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
+unpinned=2                                     # baseline contaminated
+pinned=0                                       # --noprofile --norc + explicit mode
+```
+
+With that established, the experiment itself:
 
 ```console
 $ ( d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT ; export d

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -84,24 +84,27 @@ $ ( set +e ; set -o pipefail ; export SHELLOPTS    # bash 5.3.9
 >   env -u BASH_ENV bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
 >   env -u BASH_ENV bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
-#   measured: `set +o pipefail` alone gives 0 under a contaminated parent, while
-#   `--noprofile --norc` alone still gives 2. Those flags suppress login/interactive
-#   startup files, which a non-interactive `bash -c` never reads — so they pin
-#   nothing here and are gone. `env -u BASH_ENV` is NOT decorative: BASH_ENV *is*
-#   sourced by non-interactive bash, so it can turn pipefail back on (measured) or
-#   redefine `grep` before the command string ever runs. BOTH children get it: the
-#   unpinned one is only "unpinned" as to `pipefail`, and a startup file setting
-#   `set +o pipefail` would turn its 2 into a 0 and quietly destroy the contrast.
+#   THIS block deliberately leaves its children exposed — that is the hazard it
+#   shows. The experiment below does not: it uses `env -i "PATH=$PATH"`.
+#
+#   Enumerating contamination vectors does not converge. Review of this file found
+#   three in three rounds: SHELLOPTS (carries pipefail), BASH_ENV (sourced by
+#   non-interactive bash, so it can re-enable a mode or redefine `grep`), and
+#   `export -f grep` (an imported function that survives `env -u BASH_ENV`, making
+#   the pair read 0/0 — measured). `--noprofile --norc` pins none of them, and a
+#   non-interactive `bash -c` never reads the files they suppress. `env -i` with an
+#   explicit PATH closes the class: measured, the imported function is gone
+#   (`type -t grep` -> file), SHELLOPTS loses pipefail, BASH_ENV is unset.
 pinned=0                                       # `set +o pipefail` is the pin
 ```
 
 With that established, the experiment itself:
 
 ```console
-$ ( set +e ; d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT ; export d
->   env -u BASH_ENV bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
+$ ( set +e ; d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT
+>   env -i "PATH=$PATH" "d=$d" bash -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
 >   cat "$d/o1" "$d/e1"
->   env -u BASH_ENV bash -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
+>   env -i "PATH=$PATH" "d=$d" bash -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
 >   cat "$d/o2" "$d/e2" )              # bash 5.3.9, GNU grep 3.12, coreutils 9.11
 status=0
 0

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -111,13 +111,19 @@ who reassigns `d` afterwards gets `rm -rf` on the *new* value. Shown with `echo`
 `rm -rf`, so the record is complete without being destructive:
 
 ```console
-$ ( set +e ; d=$(mktemp -d) || exit 1 ; victim=$(mktemp -d) || exit 1
->   trap 'echo "trap would run: rm -rf $d"' EXIT
+$ ( set +e ; orig=$(mktemp -d) || exit 1 ; victim=$(mktemp -d) || exit 1 ; d="$orig"
+>   trap 'echo "trap would run: rm -rf $d" ; rm -rf "$orig" "$victim"' EXIT
 >   echo "registered with d=$d" ; d="$victim" ; echo "reassigned  d=$d" )
-registered with d=/tmp/tmp.CfHlCRTodM
-reassigned  d=/tmp/tmp.zduT0zfbZk
-trap would run: rm -rf /tmp/tmp.zduT0zfbZk          # bash 5.3.9 — the VICTIM
+registered with d=/tmp/tmp.mkZzPEd1Zj
+reassigned  d=/tmp/tmp.4TTmbbLLqg
+trap would run: rm -rf /tmp/tmp.4TTmbbLLqg          # bash 5.3.9 — the VICTIM
+
+# mktemp randomises, so YOUR paths will differ; what must reproduce is that the
+# third line names the SECOND directory, not the first.
 ```
+
+The cleanup uses `$orig`/`$victim`, which nothing reassigns, so the demonstration
+removes both directories while still showing `$d` resolving late.
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -38,13 +38,12 @@ provenance rather than showing it — rerun in a terminal or CI log that combine
 descriptors and nothing distinguishes the two:
 
 ```console
-$ d=$(mktemp -d) || { echo "no temp dir"; exit 1; }   # NOT `&&`: on failure `d` is empty
-$ trap 'rm -rf "$d"' EXIT                             # and the next line writes to /o
-$ git status --porcelain -- "" >"$d/o" 2>"$d/e" ; echo "status=$?"   # git 2.54.0
+$ ( d=$(mktemp -d) || exit 1          # `||`, not `&&`: on failure d is empty and the
+>   trap 'rm -rf "$d"' EXIT           # next line would redirect to /o
+>   git status --porcelain -- "" >"$d/o" 2>"$d/e"
+>   echo "status=$?" ; wc -c <"$d/o" ; cat "$d/e" )      # git 2.54.0
 status=128
-$ wc -c <"$d/o"
 0
-$ cat "$d/e"
 fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
 ```
 
@@ -66,16 +65,15 @@ experiment depends on (measured — with `SHELLOPTS` exported, the unpinned base
 2, and `--noprofile --norc` plus `set +o pipefail` restores 0):
 
 ```console
-$ d=$(mktemp -d) || { echo "no temp dir"; exit 1; }
-$ trap 'rm -rf "$d"' EXIT ; export d
-$ bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; st=$?; echo "status=$st"'
-status=0                                       # bash 5.3.9, GNU grep 3.12, coreutils 9.11
-$ cat "$d/o1" ; cat "$d/e1"
+$ ( d=$(mktemp -d) || exit 1 ; trap 'rm -rf "$d"' EXIT ; export d
+>   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o1" 2>"$d/e1" ; echo "status=$?"'
+>   cat "$d/o1" "$d/e1"
+>   bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; echo "status=$?"'
+>   cat "$d/o2" "$d/e2" )              # bash 5.3.9, GNU grep 3.12, coreutils 9.11
+status=0
 0
 grep: : No such file or directory
-$ bash --noprofile --norc -c 'set -o pipefail; { grep -Fo -- x "" | wc -l ; } >"$d/o2" 2>"$d/e2" ; st=$?; echo "status=$st"'
 status=2
-$ cat "$d/o2" ; cat "$d/e2"
 0
 grep: : No such file or directory
 ```
@@ -88,7 +86,10 @@ starts — while bare `o1`/`e1` litter whatever directory the reader is standing
 creation is checked with `||`, not chained with `&&`: on failure `&&` skips only the trap,
 leaving `d` empty so the *next* command redirects to `/o` at the filesystem root. That is
 the unchecked-`mktemp` defect this repo fixed at four sites in #40, which is how thoroughly
-this class recurs.
+this class recurs. Each example is one **subshell**, so its `EXIT` trap fires the moment the
+example ends: a single-quoted trap expands `$d` at exit, so in an interactive shell a reader
+who reassigns `d` afterwards gets `rm -rf` on the *new* value — measured, it deleted an
+unrelated directory and leaked the original.
 
 Identical stdout, identical stderr, **different status** — and the status is the only thing
 that moved, so the status is the only thing this pair explains. It settles

--- a/skills/agents-md/references/behavioural-claims.md
+++ b/skills/agents-md/references/behavioural-claims.md
@@ -37,6 +37,10 @@ Separate the streams with redirection. Hand-labelled comments on merged output a
 provenance rather than showing it — rerun in a terminal or CI log that combines file
 descriptors and nothing distinguishes the two:
 
+Run this one **inside a git repository**: outside one it also exits 128 with an empty
+stdout, so two of the three recorded lines match for entirely the wrong reason and only
+the stderr gives it away.
+
 ```console
 $ ( set +e                            # these commands FAIL on purpose; under `set -e`
 >   d=$(mktemp -d) || exit 1          # the subshell dies before recording anything
@@ -68,8 +72,10 @@ Pin the baseline explicitly. `bash -c` inherits `pipefail` when the parent expor
 children were left unpinned the pair would read 2 vs 2, with nothing in the output saying
 why. The run below pins only the second, which is what makes the contamination visible:
 `unpinned=2` against `pinned=0`. (Note `set +e` here precedes the export, so `SHELLOPTS`
-carries `pipefail` and not `errexit` — `braceexpand:hashall:interactive-comments:pipefail`,
-measured. Order matters for what gets inherited.)
+carries `pipefail` and not `errexit`. Order matters for what gets inherited. The exact
+`SHELLOPTS` string depends on the parent shell — interactive parents add `history`,
+`emacs` and more — so what must reproduce is the presence of `pipefail` and the absence
+of `errexit`, not the literal list.)
 Shown rather than asserted, because a warning about unverifiable claims has no business
 being one:
 
@@ -78,7 +84,10 @@ $ ( set +e ; set -o pipefail ; export SHELLOPTS    # bash 5.3.9
 >   bash -c '{ grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "unpinned=$?"'
 >   bash --noprofile --norc -c 'set +o pipefail; { grep -Fo -- x "" | wc -l ; } >/dev/null 2>&1 ; echo "pinned=$?"' )
 unpinned=2                                     # baseline contaminated
-pinned=0                                       # --noprofile --norc + explicit mode
+#   measured: under a contaminated parent, `set +o pipefail` alone gives 0 and
+#   `--noprofile --norc` alone still gives 2 — the flags do not pin the mode. They
+#   are kept only to keep rc/profile files out of the run.
+pinned=0                                       # `set +o pipefail` is the pin
 ```
 
 With that established, the experiment itself:

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -94,25 +94,42 @@ exit code.** If you cannot show one, say what you actually observed instead. Thi
 is the single most common way an agent reports success it did not have.
 
 **A claim about what a tool does needs a run, not a recollection.** Prose asserting
-observable behaviour — an exit code, whether output lands on stdout or stderr, *why* a
-command fails, which versions were tested — is as capable of being wrong as code, and
-nothing compiles it. Measured on one documentation branch: five such claims shipped false
-through eight review rounds, each sitting beside a **correct** fix, and three were
-introduced by the commit fixing the previous one. Every test suite stayed green
-throughout, because suites do not read prose. A wrong reason is worse than no reason: it
-invites the next agent to "simplify" the guard away, since the stated justification is
-disprovable in thirty seconds.
+observable behaviour — an exit code, whether output lands on stdout or stderr, which
+versions were tested — is as capable of being wrong as code, and nothing compiles it.
+Measured on one documentation branch: five such claims shipped false through eight review
+rounds, each sitting beside a **correct** fix, and three were introduced by the commit
+fixing the previous one. Every test suite stayed green throughout, because suites do not
+read prose. A wrong reason is worse than no reason: it invites the next agent to
+"simplify" the guard away, since the stated justification is disprovable in thirty
+seconds.
 
-So run it, and record the run — the tool, its version, the observed result. `Measured on
-git 2.54.0` is greppable and falsifiable; "fails silently" is neither. Two riders, both
-from claims that shipped wrong:
+So run it, and record enough that a reader can re-run it and disagree — the command, the
+mode if it matters, the version, and what you observed:
 
-- **State the mode when the mode changes the answer.** `grep -Fo … "" | wc -l` exits 0
-  without `pipefail` and 2 with it, so a sentence naming neither is unfalsifiable.
-- **A claim you cannot run is not yours to assert.** A version you do not have, a kernel
-  path you cannot force — say it is unmeasured and narrow it to a possibility. "Behavior
-  may differ on older git — unmeasured here" costs one word over "behavior differs", and
-  only one of them is a claim you can be wrong about.
+```
+$ git status --porcelain -- ""          # git 2.54.0
+fatal: empty string is not a valid pathspec. please use . instead if you meant
+to match all paths
+exit 128, nothing on stdout
+```
+
+A bare `Measured on git 2.54.0` is greppable but asserts nothing checkable, and "fails
+silently" names no version or mode. Neither is a record.
+
+**Observing is not explaining, and only one of them is settled by re-running.** A rerun
+gives you the exit code and the streams; it does not tell you *why*. A command can fail
+for several config- or environment-dependent reasons, so "X fails because Y" needs more
+than a transcript of X failing: vary Y alone and show the outcome change, or cite the
+documentation or source. Absent that, write what you saw and leave the cause out — an
+invented mechanism beside a correct guard is exactly what gets the guard deleted later.
+The mode rider is the cheapest instance: `grep -Fo … "" | wc -l` exits 0 without
+`pipefail` and 2 with it, so attributing the swallow to the wrong component is a causal
+claim two runs would have settled.
+
+**A claim you cannot run is not yours to assert.** A version you do not have, a kernel
+path you cannot force — say it is unmeasured and narrow it to a possibility. "Behavior
+may differ on older git — unmeasured here" costs one word over "behavior differs", and
+only one of them is a claim you can be wrong about.
 
 **Reviewers read code; they do not run it.** A clean review — human, bot, or
 model — is not a passing build. Run the gate yourself before calling anything

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -94,57 +94,17 @@ exit code.** If you cannot show one, say what you actually observed instead. Thi
 is the single most common way an agent reports success it did not have.
 
 **A claim about what a tool does needs a run, not a recollection.** Prose asserting
-observable behaviour — an exit code, whether output lands on stdout or stderr, which
-versions were tested — is as capable of being wrong as code, and nothing compiles it.
-Measured on one documentation branch: five such claims shipped false through eight review
-rounds, each sitting beside a **correct** fix, and three were introduced by the commit
-fixing the previous one. Every test suite stayed green throughout, because suites do not
-read prose. A wrong reason is worse than no reason: it invites the next agent to
-"simplify" the guard away, since the stated justification is disprovable in thirty
-seconds.
-
-So run it, and record enough that a reader can re-run it and disagree — the command, the
-mode if it matters, the version, and what you observed:
-
-```console
-$ git status --porcelain -- ""          # git 2.54.0
-fatal: empty string is not a valid pathspec. please use . instead if you meant
-to match all paths                     # stderr
-                                       # stdout: nothing
-                                       # status: 128
-```
-
-A bare `Measured on git 2.54.0` is greppable but asserts nothing checkable, and "fails
-silently" names no version or mode. Neither is a record.
-
-**Observing is not explaining, and only one of them is settled by re-running.** A rerun
-gives you the exit code and the streams; it does not tell you *why*. A command can fail
-for several config- or environment-dependent reasons, so "X fails because Y" needs more
-than a transcript of X failing: vary Y alone and show the outcome change, or cite the
-documentation or source. Absent that, write what you saw and leave the cause out — an
-invented mechanism beside a correct guard is exactly what gets the guard deleted later.
-The mode rider is the cheapest instance — and note it takes *two* runs, not one, because
-the second is the counterfactual:
-
-```console
-$ grep -Fo -- x "" | wc -l ; echo $?                  # bash 5.3.9, GNU grep 3.12
-grep: : No such file or directory                     # stderr
-0                                                     # stdout, from wc
-0                                                     # status
-$ set -o pipefail; grep -Fo -- x "" | wc -l ; echo $?
-grep: : No such file or directory                     # stderr
-0                                                     # stdout, from wc
-2                                                     # status
-```
-
-Same command, same output, different status — so "the count came back 0 because `wc`
-succeeded" is settled only by the pair. One run would have re-blessed the wrong
-component.
-
-**A claim you cannot run is not yours to assert.** A version you do not have, a kernel
-path you cannot force — say it is unmeasured and narrow it to a possibility. "Behavior
-may differ on older git — unmeasured here" costs one word over "behavior differs", and
-only one of them is a claim you can be wrong about.
+observable behaviour — an exit code, which stream output went to, which versions were
+tested — is as capable of being wrong as code, and nothing compiles it. Record enough that
+a reader can re-run it and disagree: the command, the versions, the mode where the mode
+changes the answer, and the observed result with the streams *separated by redirection*
+rather than labelled by hand. Two things that are not records: a bare "Measured on
+git 2.54.0", which names no command or result, and "fails silently", which names no
+version or mode. And observing is not explaining — a rerun gives you the exit code and the
+streams, never the *why*; "X fails because Y" needs Y varied on its own with the outcome
+changing, or the documentation cited. Absent that, write what you saw and leave the cause
+out. A claim you cannot run — a version you do not have — is not yours to assert: say it
+is unmeasured and narrow it to a possibility.
 
 **Reviewers read code; they do not run it.** A clean review — human, bot, or
 model — is not a passing build. Run the gate yourself before calling anything

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -122,9 +122,23 @@ for several config- or environment-dependent reasons, so "X fails because Y" nee
 than a transcript of X failing: vary Y alone and show the outcome change, or cite the
 documentation or source. Absent that, write what you saw and leave the cause out — an
 invented mechanism beside a correct guard is exactly what gets the guard deleted later.
-The mode rider is the cheapest instance: `grep -Fo … "" | wc -l` exits 0 without
-`pipefail` and 2 with it, so attributing the swallow to the wrong component is a causal
-claim two runs would have settled.
+The mode rider is the cheapest instance — and note it takes *two* runs, not one, because
+the second is the counterfactual:
+
+```
+$ grep -Fo -- x "" | wc -l ; echo $?                  # bash 5.3.9, GNU grep 3.12
+grep: : No such file or directory                     # stderr
+0                                                     # stdout, from wc
+0                                                     # status
+$ set -o pipefail; grep -Fo -- x "" | wc -l ; echo $?
+grep: : No such file or directory
+0
+2
+```
+
+Same command, same output, different status — so "the count came back 0 because `wc`
+succeeded" is settled only by the pair. One run would have re-blessed the wrong
+component.
 
 **A claim you cannot run is not yours to assert.** A version you do not have, a kernel
 path you cannot force — say it is unmeasured and narrow it to a possibility. "Behavior

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -93,6 +93,27 @@ Then read the log. Note the `;` — not `|`.
 exit code.** If you cannot show one, say what you actually observed instead. This
 is the single most common way an agent reports success it did not have.
 
+**A claim about what a tool does needs a run, not a recollection.** Prose asserting
+observable behaviour — an exit code, whether output lands on stdout or stderr, *why* a
+command fails, which versions were tested — is as capable of being wrong as code, and
+nothing compiles it. Measured on one documentation branch: five such claims shipped false
+through eight review rounds, each sitting beside a **correct** fix, and three were
+introduced by the commit fixing the previous one. Every test suite stayed green
+throughout, because suites do not read prose. A wrong reason is worse than no reason: it
+invites the next agent to "simplify" the guard away, since the stated justification is
+disprovable in thirty seconds.
+
+So run it, and record the run — the tool, its version, the observed result. `Measured on
+git 2.54.0` is greppable and falsifiable; "fails silently" is neither. Two riders, both
+from claims that shipped wrong:
+
+- **State the mode when the mode changes the answer.** `grep -Fo … "" | wc -l` exits 0
+  without `pipefail` and 2 with it, so a sentence naming neither is unfalsifiable.
+- **A claim you cannot run is not yours to assert.** A version you do not have, a kernel
+  path you cannot force — say it is unmeasured and narrow it to a possibility. "Behavior
+  may differ on older git — unmeasured here" costs one word over "behavior differs", and
+  only one of them is a claim you can be wrong about.
+
 **Reviewers read code; they do not run it.** A clean review — human, bot, or
 model — is not a passing build. Run the gate yourself before calling anything
 done.

--- a/skills/agents-md/references/discipline-block.md
+++ b/skills/agents-md/references/discipline-block.md
@@ -106,11 +106,12 @@ seconds.
 So run it, and record enough that a reader can re-run it and disagree — the command, the
 mode if it matters, the version, and what you observed:
 
-```
+```console
 $ git status --porcelain -- ""          # git 2.54.0
 fatal: empty string is not a valid pathspec. please use . instead if you meant
-to match all paths
-exit 128, nothing on stdout
+to match all paths                     # stderr
+                                       # stdout: nothing
+                                       # status: 128
 ```
 
 A bare `Measured on git 2.54.0` is greppable but asserts nothing checkable, and "fails
@@ -125,15 +126,15 @@ invented mechanism beside a correct guard is exactly what gets the guard deleted
 The mode rider is the cheapest instance — and note it takes *two* runs, not one, because
 the second is the counterfactual:
 
-```
+```console
 $ grep -Fo -- x "" | wc -l ; echo $?                  # bash 5.3.9, GNU grep 3.12
 grep: : No such file or directory                     # stderr
 0                                                     # stdout, from wc
 0                                                     # status
 $ set -o pipefail; grep -Fo -- x "" | wc -l ; echo $?
-grep: : No such file or directory
-0
-2
+grep: : No such file or directory                     # stderr
+0                                                     # stdout, from wc
+2                                                     # status
 ```
 
 Same command, same output, different status — so "the count came back 0 because `wc`


### PR DESCRIPTION
Closes #45.

Both panel reviewers, asked independently which issue should come next, picked this one, and both said **land it alone, then write #32 under it** — because every remaining PR in the backlog is prose-heavy and pays #40's tax until this rule exists.

## The evidence

Landing #40's four one-line rules took **8 codex bot rounds, 5 local panel passes, 13 corrections**. The corrections were overwhelmingly to *sentences*, not code:

| claimed | actual |
|---|---|
| `git status --porcelain -- ""` succeeds printing nothing | `fatal: empty string is not a valid pathspec`, **exit 128** |
| an empty-filename redirect is silent | `: No such file or directory`, **exit 1** |
| "Measured on git 2.54 / jq 1.7" | host runs **jq 1.8.2** — that run never happened |
| the removal check returns 0 "because `wc` succeeds" | under `pipefail` it exits **2**; `\|\| true` is what swallows it |
| a held `.git/index.lock` makes `git status` fail | **exit 0**, clean and dirty alike |

Each sat beside a **correct** fix. Three were introduced by the commit fixing the previous one — including one by the commit whose own message named this failure mode. Every test suite was green throughout, because suites do not read prose.

A wrong reason is worse than no reason: it invites the next agent to "simplify" the guard away, since the stated justification is disprovable in thirty seconds.

## Why the discipline block, and why it clears that block's bar

`agents-md/references/discipline-block.md` already carries the sibling rule for *edits* — "`sed -i` reports success when it matched nothing". This is the same discipline applied to *claims*. The block's own admission criteria, quoted from its header:

1. **applies to essentially every repo** — any repo where agents write documentation.
2. **something an agent gets wrong without being told** — demonstrably: five times in eight rounds, by an agent actively hunting for this exact defect.
3. **traces to a concrete failure** — five, enumerated above.

## Why a rule and not a script

No script can check whether a sentence about `git`'s exit code is true. The reviewer plus the recorded run *is* the enforcement — which is the honest tension with #32's thesis ("a paragraph can only ask"), and the resolution: #32 governs what a script can check, this governs what it cannot.

Enforcement is cheap and falsifiable rather than ceremonial: `Measured on <tool> <version>` is greppable, and its absence on a behavioural sentence is the signal.

## Executed for this PR, per its own rule

```
grep -Fo -- x "" | wc -l    exit 0 without pipefail, 2 with      bash 5.3.9
8 codex rounds on #40       6 review objects + 2 clean wrappers
5 local panel passes        pass-0{1..5}.codex.txt
install.test 12 · bot-gate.test 124 · drive-status.test 70       all exit 0
```

The round count is worth its own line: my first query returned **2**, because a clean round posts no review object and I had counted only one channel. The rule caught its own text before a reviewer did — recorded here rather than quietly corrected, since that is the behaviour it is asking for.

## Cost

The block grows 114 → 135 lines, about 18%, on a file whose header warns that bloat there "gets ignored wholesale". Stated rather than glossed: this is the largest single addition to that block, and it is justified only if the failure it prevents is as common as #40 suggests.

## Not in this PR

`AGENTS.md` is still absent from this repo, so the block edited here is not installed here — this repo does not yet hold itself to the rule it ships. Orthogonal (the block's purpose is to travel to other repos) and deferred to the #33 PR, where `agents-md` installation is the subject rather than a side effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation with the current BUILD scope, acceptance criteria, exclusions, execution order, next steps, and gate status.
  - Added guidance for substantiating tool-behavior claims with reproducible commands, versions, output streams, and exit status.
  - Clarified that observations alone do not establish causation without controlled comparisons or authoritative evidence.
  - Added guidance to narrowly qualify claims when measurements or supporting evidence are unavailable.
  - Added a detailed reference with examples covering behavioral claims, command results, and cleanup considerations.
  - Clarified which guidance is copied into downstream project instructions and which remains reference-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->