### PR TITLE
Keep shared skills within Tau load limits

### DIFF
--- a/DRIVE.md
+++ b/DRIVE.md
@@ -1,65 +1,42 @@
-# DRIVE — the Claude reviewer slot is a role, not a model, and it fails over
+# DRIVE — keep shared skills fully loadable in Tau
 
-**Scope:** the reviewer-model fallback in every panel **this repo launches** —
-`multi-reviewer-loop`, `second-model-bead-audit`, `harden-until-clean`, and
-`pr-with-codex-bot-review`'s pre-push review. Explicitly NOT in scope: the reviewer
-commands `orchestrating-with-rb-lite` hands to **rb-lite** to dispatch (SKILL.md:111,
-plus :1296/:1298 under `## Customizing the panel`) — three unbounded `claude -p`
-reviewers with hardcoded models, which still hang on an exhausted one — this repo does not launch those processes and
-cannot bound them, so converting them is its own change. Filed as #51, not fixed here.
-Issues #30/#31/#32/#33/#35/#38/#41/#42/#43/#44/#47/#48/#49/#50 are separate PRs and
-NOT in scope.
-**Phase:** HARDEN · **Bead:** n/a (direct-edit tier, doc-only) · **Branch:** claude-reviewer-fallback
+**Scope:** keep each top-level `SKILL.md` inside Tau's 64 KiB source-prefix limit
+and each folded description inside its 1,024-byte limit. Move long procedural detail
+into exact-name companion skills without changing the workflow, then pin both limits
+in `install.test`.
+**Phase:** HARDEN · **Bead:** n/a (direct repository-maintenance change)
+· **Branch:** `fix/tau-skill-limits`
 **Pending:** —
 **Gate:** `./install.test && ./skills/pr-with-codex-bot-review/scripts/bot-gate.test && ./skills/drive/scripts/drive-status.test`
-· run at aeaceb3 on bash 5.3.9: `passed 12, failed 0` / `passed 124, failed 0` /
-`passed 70, failed 0`, each exit 0. Re-runnable at that commit — a SHA, not "on this
-branch", which names no reproducible point once the branch has six of them. Note what that does **not** cover: every file in
-this change is prose, and no suite reads prose. The evidence for this change is the
-recorded runs in the reference, not the suites.
+· run 2026-08-10 on the working tree based at `ffe024ff93a6e7a6a40c87f8e49ed3888f95cb24`
+with bash 5.3.15: `passed 25, failed 0` / `passed 124, failed 0` /
+`passed 70, failed 0`, each exit 0.
 
 ## Done
-- #37 merged (291a6ce): install.sh's two uninstall aborts, plus `install.test`.
-- #40 merged (fe5149e): four sibling-site rules across 8 files.
-- #46 merged (029bc8c): behavioural claims in prose need a run, not a recollection.
-- `install.sh` run against the live install: fast-forwarded `a4bb5e1..029bc8c`,
-  14 skills linked into `~/.claude/skills` and `~/.codex/skills`, exit 0.
+
+- Measured Tau 0.1.0's raw 65,536-byte skill-source prefix and 1,024-byte description
+  bounds against the implementation in `~/p/tau`.
+- Extracted the long procedures from `multi-reviewer-loop`,
+  `orchestrating-with-rb-lite`, and `pr-with-codex-bot-review` into required companion
+  skills while retaining the entry points and stable recovery anchors in their main
+  skills. Exact companion names work with Tau's source-opaque skill loader and avoid
+  selecting a different duplicate installation through process-local filesystem state.
+- Shortened oversized descriptions and added dependency-free compatibility checks.
+- Mutation-tested over-limit, missing-skill, unsupported-description, and broken-link
+  failures; separately verified ignored workspace directories are excluded from the
+  skill inventory.
+- Ran iterative independent Codex and Opus review and addressed the accepted findings.
 
 ## Now
-Fable is out of credits, so every panel in this repo currently has one working
-reviewer and does not know it. The measured failure is the reason this is a change
-rather than a config tweak: an unreachable model does **not** error, it hangs. Two
-separate runs, kept separate because they show different things — the *bounded* 90s
-probe exits 124 having written valid JSON with `is_error: true`, a null `.result`, and
-only the small side-model in `modelUsage`; an *unbounded* call in the same state was
-observed still running after eight minutes with both output files at zero bytes, and
-was killed by hand (no 124, no JSON — that is the whole point of the contrast). stderr
-was empty in both, so every "read stderr for the auth error" rule in these skills was
-unreachable for this case.
 
-So: a `$CLAUDE_MODEL` ladder (`fable` → `opus`; a user pin *replaces* the ladder rather
-than heading it, so a named model fails instead of being substituted), resolved once per
-run by a bounded 90s probe, keyed on exit code **and** `is_error` **and** a non-empty
-`.result`. An exhausted ladder is **not** a new state: it means the Claude reviewer is
-unavailable, which every one of these skills already handled — so it drops out of the
-panel and the existing `DEGRADED` rules take over unchanged.
-Artifacts and source tags rename from the model (`fable`) to the slot (`claude`),
-because after a fallback a file named `pass-01.fable.txt` is a false provenance claim —
-the exact defect #46 landed a rule against.
-
-Budget: 14 files. Round 4 = the CUT, not another fix round: panel rounds 1-3 produced 41 findings, 0 rejected, 0 cut, all rooted in one over-built path. Removing that path is the corrective.
-Do NOT build: a retry/backoff policy, a model-capability matrix, per-pass re-probing,
-or a shared shell library — these are five prose skills, not a program.
+Require one clean parallel reviewer confirmation plus the review loop's consistency
+pass on the amended tree.
 
 ## Next
-Issue #32 `verify-commit`. Then #30/#31 (drive Guard 2), #33/#35, and the § 3a
-residue (#41, #43, #44).
+
+Commit the reviewed tree, push `fix/tau-skill-limits`, and open the PR with the local
+gate and reviewer evidence.
 
 ## Open questions for the human
-- The ladder's second rung is `opus`, which is also the model that usually *drives*
-  these skills. `second-model-bead-audit` now **discloses** that overlap in the panel roster. It does
-  not downgrade the label for it: independence is judged against the graph's builder, so
-  on a Codex-built graph the Claude auditor stays `INDEPENDENT` whichever rung it landed
-  on. The mitigation shipped is therefore disclosure only — the deeper fix, a non-Claude
-  fallback rung so the second opinion is independent by construction, is a product
-  decision rather than a sweep.
+
+None.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,9 @@ otherwise be an already-running round's submission), no `eyes` reaction newer th
 wrapper, no base mutation lacking such a provably-fresh later review request (a retarget
 grows the diff without moving the head), and zero unresolved threads from either gated bot. It fails closed on any API error or missing tool **in the signals that feed those six** —
 a CodeRabbit query failure is reported and does not block, deliberately. Exit 0, 1 blocked,
-2 usage, 3 cannot determine, and "cannot determine" is never clearance.
+2 usage, 3 cannot determine, and 4 `BLOCKED_UNATTRIBUTED`. Exits 1 and 4 both refuse the
+merge; exit 4 means a round finished without evidence naming its tree, so waiting may not
+help. "Cannot determine" is never clearance.
 
 CodeRabbit's status is printed and ignored. It is a PR-level signal, not evidence about a
 tree: measured on this repo, CodeRabbit stamped `success`/"Review completed" on a commit
@@ -420,6 +422,27 @@ symlink, the installer now treats that as a conflict and exits non-zero after
 reporting the partial install. When the directory looks like a copied skill
 from this repo, rerun with `--migrate-existing` to rename it to
 `<skill>.backup.<timestamp>` and replace it with a symlink.
+
+Repository validation intentionally requires each frontmatter description to use one
+single-paragraph `description: >-` block. Tau accepts more YAML scalar forms, but this
+narrow authoring convention lets `install.test` enforce its 1,024-byte limit without a
+runtime YAML dependency.
+
+Some large workflows are split into exact-name companion skills so Tau can discover
+the continuation through its normal skill loader without exposing a source filesystem
+path. Their descriptions mark them as internal companions: load them only when the
+owning or an explicitly compatible sibling workflow names them, not as standalone
+workflow selectors. They remain model-loadable by exact name but are hidden from direct
+user invocation. A selective install
+automatically includes every required companion of the named skills. After updating the
+shared clone, the installer also repairs direct missing companions beside already-managed
+referring skills inside each selected target; it does not recursively add newly exposed
+standalone workflows or copy an existing skill from one target to another.
+
+One-time upgrade note: an installer process from before companion support cannot change
+the code already running in its shell after `git pull`. If that old process performed a
+selective update, run the same install command once more so the updated installer adds the
+new companion links. Current installers re-exec updated bytes automatically.
 
 Install specific skills:
 

--- a/docs/adr/0004-the-bot-gate-claims-absence-of-evidence-not-clearance.md
+++ b/docs/adr/0004-the-bot-gate-claims-absence-of-evidence-not-clearance.md
@@ -13,8 +13,9 @@ Accepted. Supersedes the settle-window and skipped-file clauses described in
 current tip is observable. That is not the same as deciding the bots have finished, and
 this ADR exists because the difference is the whole point: GitHub exposes no terminal
 signal, so exit 0 is `NO_PENDING_EVIDENCE`, never "the bots cleared this".
-It is a merge *prerequisite*, not merge authorization: § 8 of the skill runs the
-base-freshness ancestor test before merging, which this gate never looks at, and the skill
+It is a merge *prerequisite*, not merge authorization: the skill's
+[exact companion merge skill](../../skills/pr-with-codex-bot-review-merge/SKILL.md)
+runs the base-freshness ancestor test before merging, which this gate never looks at, and the skill
 explicitly forbids chaining `bot-gate && gh pr merge`.
 
 That prohibition postdates the problem below. The chain WAS the documented usage while

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,14 @@ DEFAULT_INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/douglaz-skills"
 CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
 DEFAULT_CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
 LEGACY_CODEX_SKILLS_DIR="$HOME/.agents/skills"
+ORIGINAL_ARGS=("$@")
+SCRIPT_PATH=""
+SCRIPT_CKSUM=""
+if [[ -f "$0" ]]; then
+  SCRIPT_PATH=$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")
+  SCRIPT_CKSUM=$(cksum < "$SCRIPT_PATH") \
+    || { echo "Cannot checksum running installer at $SCRIPT_PATH" >&2; exit 1; }
+fi
 
 usage() {
   cat <<EOF
@@ -18,7 +26,7 @@ Usage: $(basename "$0") [OPTIONS] [SKILL_NAME...]
 Install Claude Code and Codex skills from douglaz/skills.
 
 If no skill names are given, all skills are installed.
-If skill names are given, only those skills are installed.
+If skill names are given, those skills and their required companions are installed.
 
 Options:
   --dir DIR    Install to DIR instead of $DEFAULT_INSTALL_DIR
@@ -56,6 +64,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+explicit_skill_count=${#skills[@]}
+
 case "$target" in
   claude)
     target_dirs=("$CLAUDE_SKILLS_DIR")
@@ -83,12 +93,163 @@ esac
 
 # Discover available skills in the repo
 discover_skills() {
-  local base="$1"
+  local base="$1" d
   local found=()
   for d in "$base"/skills/*/; do
+    # Matches .gitignore: eval-creator `*-workspace` scaffolds are not skills.
+    [[ ${d%/} == *-workspace ]] && continue
     [[ -f "$d/SKILL.md" ]] && found+=("$(basename "$d")")
   done
   printf '%s\n' "${found[@]}"
+}
+
+# Exact-name companion skills hold mandatory continuations that no longer fit inside
+# their owners' model-visible Tau prefix. A selective install must keep those handoffs
+# loadable just as an all-skill install does. List only companions introduced by this
+# repository split; this is not a general dependency solver for workflow routing.
+companion_dependencies() {
+  case "$1" in
+    multi-reviewer-loop)
+      printf '%s\n' multi-reviewer-loop-delegating-edits
+      ;;
+    multi-reviewer-loop-delegating-edits)
+      printf '%s\n' multi-reviewer-loop
+      ;;
+    orchestrating-with-rb-lite|bead-polish-loop|plan-to-beads-transfer|second-model-bead-audit)
+      printf '%s\n' rb-lite-backlog-drain
+      ;;
+    rb-lite-backlog-drain)
+      printf '%s\n' orchestrating-with-rb-lite
+      ;;
+    pr-with-codex-bot-review)
+      printf '%s\n' pr-with-codex-bot-review-merge
+      ;;
+    pr-with-codex-bot-review-merge)
+      printf '%s\n' pr-with-codex-bot-review
+      ;;
+    drive)
+      printf '%s\n' rb-lite-backlog-drain pr-with-codex-bot-review-merge
+      ;;
+  esac
+}
+
+append_skill_once() {
+  local candidate="$1" existing
+
+  for existing in "${skills[@]}"; do
+    [[ "$existing" == "$candidate" ]] && return 0
+  done
+  skills+=("$candidate")
+}
+
+expand_companion_dependencies() {
+  local requested=("${skills[@]}")
+  local skill dependency index=0
+
+  # This function is called only for a non-empty explicit request. Seed the array before
+  # append_skill_once inspects it: Bash 4.0-4.3 treats "${empty[@]}" as unbound under
+  # `set -u`, even though newer Bash accepts it.
+  skills=("${requested[0]}")
+  index=1
+  while [[ $index -lt ${#requested[@]} ]]; do
+    append_skill_once "${requested[$index]}"
+    index=$((index + 1))
+  done
+
+  # Walk the finite graph to closure. Companion -> owner edges matter when a sibling
+  # consumer requests the companion directly; owner -> companion edges then complete
+  # the cycle without duplication.
+  index=0
+  while [[ $index -lt ${#skills[@]} ]]; do
+    skill=${skills[$index]}
+    while IFS= read -r dependency; do
+      [[ -n "$dependency" ]] || continue
+      append_skill_once "$dependency"
+    done < <(companion_dependencies "$skill")
+    index=$((index + 1))
+  done
+}
+
+skill_declares_exact_name() {
+  local skill_file="$1" expected="$2"
+
+  # Repository skills use one plain `name:` scalar in a closed YAML frontmatter block.
+  # Fail conservatively on malformed or duplicate declarations: Tau indexes the declared
+  # name, so a SKILL.md merely present at the expected path does not satisfy an exact-name
+  # handoff.
+  LC_ALL=C awk -v expected="$expected" '
+    NR == 1 {
+      if ($0 != "---") exit 1
+      next
+    }
+    $0 == "---" {
+      closed = 1
+      exit (names == 1 && matched == 1) ? 0 : 1
+    }
+    /^name:/ {
+      names++
+      if ($0 == "name: " expected) matched++
+    }
+    END {
+      if (!closed) exit 1
+    }
+  ' "$skill_file"
+}
+
+reconcile_target_companions() {
+  local target_dir="$1" link target_path skill dependency
+  local dependency_source dependency_target processed='|'
+  local managed_skills=("")
+
+  # A pull updates every already-linked owner in place. Repair only inside the target
+  # where that owner is already managed: unioning target inventories would silently make
+  # a Claude-only skill trigger-eligible in Codex (or vice versa).
+  # Snapshot the pre-reconciliation inventory. Following links created by this pass would
+  # turn companion -> owner back-references into an unsolicited transitive install of
+  # standalone workflow selectors. An explicit selective request still gets full closure
+  # through expand_companion_dependencies; upgrade repair is deliberately one hop.
+  for link in "$target_dir"/*; do
+    [[ -L "$link" ]] || continue
+    target_path=$(readlink "$link")
+    [[ "$target_path" == "$install_dir"/skills/* ]] || continue
+    skill=${target_path#"$install_dir"/skills/}
+    [[ $skill != */* && -f "$install_dir/skills/$skill/SKILL.md" ]] || continue
+    managed_skills+=("$skill")
+  done
+
+  for skill in "${managed_skills[@]}"; do
+    [[ -n "$skill" ]] || continue
+    while IFS= read -r dependency; do
+      [[ -n "$dependency" ]] || continue
+      # One target path can be required by several installed skills. Diagnose and count
+      # that path once; the action summary reports paths, not graph edges.
+      [[ $processed == *"|$dependency|"* ]] && continue
+      processed+="$dependency|"
+      dependency_source="$install_dir/skills/$dependency"
+      dependency_target="$target_dir/$dependency"
+      if [[ ! -f "$dependency_source/SKILL.md" ]] \
+         || ! skill_declares_exact_name "$dependency_source/SKILL.md" "$dependency"; then
+        echo "  $dependency [$target_dir]: WARNING - required companion source is missing or declares the wrong skill name"
+        ((missing_count += 1))
+        continue
+      fi
+      # Any live skill at the exact target name satisfies discovery. Reconciliation
+      # never migrates or overwrites an unrequested plain directory or external link.
+      if [[ -f "$dependency_target/SKILL.md" ]] \
+         && skill_declares_exact_name "$dependency_target/SKILL.md" "$dependency"; then
+        continue
+      fi
+      if [[ -e "$dependency_target" || -L "$dependency_target" ]]; then
+        echo "  $dependency [$target_dir]: WARNING - required companion path exists but is not a loadable skill"
+        ((skipped_count += 1))
+        continue
+      fi
+      ln -s "$dependency_source" "$dependency_target"
+      echo "  $dependency [$target_dir]: installed as companion of existing $skill"
+      ((installed_count += 1))
+      ((reconciled_count += 1))
+    done < <(companion_dependencies "$skill")
+  done
 }
 
 list_relative_paths() {
@@ -200,19 +361,48 @@ if $uninstall; then
   exit 0
 fi
 
-# Clone or update
-if [[ -d "$install_dir/.git" ]]; then
-  echo "Updating existing install at $install_dir ..."
-  git -C "$install_dir" pull --ff-only
+# Clone or update. The process re-execed just below inherits a one-shot skip: the first
+# process already completed this mutable network step, so repeating it could fail after a
+# successful update or advance the script again while the reexec guard suppresses a retry.
+if [[ ${DOUGLAZ_INSTALL_SKIP_UPDATE_ONCE:-0} == 1 ]]; then
+  echo "Using the clone already updated by the previous installer process ..."
+  unset DOUGLAZ_INSTALL_SKIP_UPDATE_ONCE
 else
-  echo "Cloning $REPO_URL to $install_dir ..."
-  mkdir -p "$(dirname "$install_dir")"
-  git clone "$REPO_URL" "$install_dir"
+  if [[ -d "$install_dir/.git" ]]; then
+    echo "Updating existing install at $install_dir ..."
+    git -C "$install_dir" pull --ff-only
+  else
+    echo "Cloning $REPO_URL to $install_dir ..."
+    mkdir -p "$(dirname "$install_dir")"
+    git clone "$REPO_URL" "$install_dir"
+  fi
+fi
+
+# A pipe (`curl ... | bash`) has no readable script path, and `git pull` can replace a
+# file while its Bash process keeps executing old bytes. Re-exec the clone's installer
+# after clone/update when the source was stdin or its checksum changed. Preserve argv,
+# guard the second run, and avoid expanding an empty array under Bash 4.0-4.3 + `set -u`.
+INSTALLED_SCRIPT=$(cd "$install_dir" && pwd -P)/install.sh
+if [[ ${DOUGLAZ_INSTALL_REEXECED:-0} != 1 && -f "$INSTALLED_SCRIPT" ]]; then
+  INSTALLED_CKSUM=$(cksum < "$INSTALLED_SCRIPT") \
+    || { echo "Cannot checksum updated installer at $INSTALLED_SCRIPT" >&2; exit 1; }
+  if [[ -z "$SCRIPT_CKSUM" || "$SCRIPT_CKSUM" != "$INSTALLED_CKSUM" ]]; then
+    echo "Installer source changed; re-executing the clone's version ..."
+    if [[ ${#ORIGINAL_ARGS[@]} -eq 0 ]]; then
+      DOUGLAZ_INSTALL_REEXECED=1 DOUGLAZ_INSTALL_SKIP_UPDATE_ONCE=1 \
+        exec bash "$INSTALLED_SCRIPT"
+    else
+      DOUGLAZ_INSTALL_REEXECED=1 DOUGLAZ_INSTALL_SKIP_UPDATE_ONCE=1 \
+        exec bash "$INSTALLED_SCRIPT" "${ORIGINAL_ARGS[@]}"
+    fi
+  fi
 fi
 
 # Determine which skills to install
 if [[ ${#skills[@]} -eq 0 ]]; then
   mapfile -t skills < <(discover_skills "$install_dir")
+else
+  expand_companion_dependencies
 fi
 
 if [[ ${#skills[@]} -eq 0 ]]; then
@@ -228,6 +418,7 @@ skipped_count=0
 missing_count=0
 migration_hint_count=0
 pruned_count=0
+reconciled_count=0
 backup_stamp=$(date -u +%Y%m%dT%H%M%SZ)
 
 # Ensure target directories exist
@@ -283,6 +474,7 @@ done
 
 for target_dir in "${target_dirs[@]}"; do
   prune_dangling_symlinks "$target_dir"
+  reconcile_target_companions "$target_dir"
 done
 
 echo
@@ -291,7 +483,12 @@ if [[ $skipped_count -eq 0 && $missing_count -eq 0 ]]; then
 else
   echo "Install completed with warnings."
 fi
-echo "Requested ${#skills[@]} skill(s) across ${#target_dirs[@]} target(s)."
+if [[ $explicit_skill_count -eq 0 ]]; then
+  echo "Selected ${#skills[@]} skill(s) across ${#target_dirs[@]} target(s)."
+else
+  echo "Requested $explicit_skill_count skill(s); selected ${#skills[@]} including required companions across ${#target_dirs[@]} target(s)."
+fi
+echo "Reconciled $reconciled_count missing companion(s) for existing managed skills."
 echo "Actions: installed=$installed_count updated=$updated_count migrated=$migrated_count already-linked=$already_linked_count skipped=$skipped_count missing=$missing_count pruned=$pruned_count"
 echo "Targets:"
 for target_dir in "${target_dirs[@]}"; do

--- a/install.test
+++ b/install.test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# install.test — fixture tests for the installer's uninstall and link paths.
+# install.test — installer fixtures and repository-level harness compatibility checks.
 #
 # Written because `--uninstall` carried two independent `set -e` aborts that both
 # reported success:
@@ -35,7 +35,7 @@ fail() { FAIL=$((FAIL+1)); printf '  FAIL %s\n         %s\n' "$1" "$2"; }
 new_fixture() {  # $1 = space-separated skill names to create in the clone
   local base s
   base=$(mktemp -d "$WORK/fixture.XXXXXX")
-  mkdir -p "$base"/{clone/.git,home/.claude/skills,codexhome/skills,bin}
+  mkdir -p "$base"/{clone/.git,clone/skills,home/.claude/skills,codexhome/skills,bin}
   for s in $1; do
     mkdir -p "$base/clone/skills/$s"
     printf 'stub\n' > "$base/clone/skills/$s/SKILL.md"
@@ -45,6 +45,26 @@ new_fixture() {  # $1 = space-separated skill names to create in the clone
   printf '#!/usr/bin/env bash\nexit 0\n' > "$base/bin/git"
   chmod +x "$base/bin/git"
   printf '%s' "$base"
+}
+
+new_repo_fixture() {
+  local base skill_dir
+  base=$(new_fixture "")
+  for skill_dir in "$HERE"/skills/*/; do
+    [[ -f "$skill_dir/SKILL.md" ]] || continue
+    ln -s "${skill_dir%/}" "$base/clone/skills/$(basename "$skill_dir")"
+  done
+  printf '%s' "$base"
+}
+
+repository_skill_files() {
+  local base="$1" skill_dir
+  for skill_dir in "$base"/skills/*/; do
+    skill_dir=${skill_dir%/}
+    # Matches .gitignore: eval-creator `*-workspace` scaffolds are not skills.
+    [[ $skill_dir == *-workspace ]] && continue
+    [[ -f "$skill_dir/SKILL.md" ]] && printf '%s\n' "$skill_dir/SKILL.md"
+  done
 }
 
 link_skill() {  # $1 = base, $2 = skill — pre-link into both targets
@@ -158,6 +178,333 @@ b=$(new_fixture "alpha")
 out=$(run "$b" --target claude nosuch); rc=$?
 if [[ $rc -eq 0 ]]; then fail "$t" "exit 0 for a skill that does not exist"
 elif [[ "$out" != *"not found"* ]]; then fail "$t" "no warning naming the missing skill"
+else pass "$t"; fi
+
+t="the documented stdin-piped installer can parse --help"
+out=$(bash -s -- --help < "$INSTALL" 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc: $out"
+elif [[ "$out" != *"Usage:"* ]]; then fail "$t" "usage text missing"
+else pass "$t"; fi
+
+t="the stdin-piped installer re-execs and skips a second pull"
+b=$(new_fixture "alpha")
+cp "$INSTALL" "$b/clone/install.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'n=0' '[[ -f "$GIT_COUNT_FILE" ]] && read -r n < "$GIT_COUNT_FILE"' 'n=$((n + 1))' 'printf "%s\n" "$n" > "$GIT_COUNT_FILE"' > "$b/bin/git"
+chmod +x "$b/bin/git"
+GIT_COUNT_FILE="$b/git-count" HOME="$b/home" CODEX_HOME="$b/codexhome" \
+  PATH="$b/bin:$PATH" bash -s -- --dir "$b/clone" --target claude alpha \
+  < "$INSTALL" >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc"
+elif [[ ! -L "$b/home/.claude/skills/alpha" ]]; then fail "$t" "alpha link missing"
+elif [[ $(< "$b/git-count") != 1 ]]; then fail "$t" "git ran more than once"
+else pass "$t"; fi
+
+t="a pulled installer re-execs its updated bytes with the original arguments"
+b=$(new_fixture "alpha")
+cp "$INSTALL" "$b/clone/install.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "$*" > "$HOME/reexec-observed"' > "$b/clone/install.sh.updated"
+printf '%s\n' '#!/usr/bin/env bash' 'cp "$SELF_UPDATE_SOURCE" "$SELF_UPDATE_TARGET.next" && mv "$SELF_UPDATE_TARGET.next" "$SELF_UPDATE_TARGET"' > "$b/bin/git"
+chmod +x "$b/bin/git"
+SELF_UPDATE_SOURCE="$b/clone/install.sh.updated" SELF_UPDATE_TARGET="$b/clone/install.sh" \
+  HOME="$b/home" CODEX_HOME="$b/codexhome" PATH="$b/bin:$PATH" \
+  bash "$b/clone/install.sh" --dir "$b/clone" --target claude alpha >/dev/null; rc=$?
+observed=$(< "$b/home/reexec-observed")
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc"
+elif [[ "$observed" != "--dir $b/clone --target claude alpha" ]]; then
+  fail "$t" "updated installer observed wrong argv: $observed"
+else pass "$t"; fi
+
+t="a pulled installer re-execs safely with empty arguments"
+b=$(new_fixture "alpha")
+mkdir -p "$b/data"
+mv "$b/clone" "$b/data/douglaz-skills"
+cp "$INSTALL" "$b/data/douglaz-skills/install.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "$#" > "$HOME/reexec-argc"' > "$b/data/douglaz-skills/install.sh.updated"
+printf '%s\n' '#!/usr/bin/env bash' 'cp "$SELF_UPDATE_SOURCE" "$SELF_UPDATE_TARGET.next" && mv "$SELF_UPDATE_TARGET.next" "$SELF_UPDATE_TARGET"' > "$b/bin/git"
+chmod +x "$b/bin/git"
+SELF_UPDATE_SOURCE="$b/data/douglaz-skills/install.sh.updated" \
+  SELF_UPDATE_TARGET="$b/data/douglaz-skills/install.sh" XDG_DATA_HOME="$b/data" \
+  HOME="$b/home" CODEX_HOME="$b/codexhome" PATH="$b/bin:$PATH" \
+  bash "$b/data/douglaz-skills/install.sh" >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "exit $rc"
+elif [[ ! -f "$b/home/reexec-argc" ]]; then fail "$t" "updated installer did not run"
+elif [[ $(< "$b/home/reexec-argc") != 0 ]]; then fail "$t" "updated installer received arguments"
+else pass "$t"; fi
+
+t="selective installs include required companions without unrelated skills"
+dependency_failures=""
+while IFS='|' read -r consumer companion; do
+  b=$(new_repo_fixture)
+  run "$b" --target both "$consumer" >/dev/null; rc=$?
+  if [[ $rc -ne 0 ]]; then
+    dependency_failures+="$consumer exited $rc; "
+  elif [[ ! -L "$b/home/.claude/skills/$companion" ]]; then
+    dependency_failures+="$consumer omitted Claude $companion; "
+  elif [[ ! -L "$b/codexhome/skills/$companion" ]]; then
+    dependency_failures+="$consumer omitted Codex $companion; "
+  elif [[ -L "$b/home/.claude/skills/voice-dna" || -L "$b/codexhome/skills/voice-dna" ]]; then
+    dependency_failures+="$consumer installed unrelated voice-dna; "
+  fi
+done <<'DEPENDENCIES'
+multi-reviewer-loop|multi-reviewer-loop-delegating-edits
+multi-reviewer-loop-delegating-edits|multi-reviewer-loop
+orchestrating-with-rb-lite|rb-lite-backlog-drain
+rb-lite-backlog-drain|orchestrating-with-rb-lite
+pr-with-codex-bot-review|pr-with-codex-bot-review-merge
+pr-with-codex-bot-review-merge|pr-with-codex-bot-review
+drive|rb-lite-backlog-drain
+drive|orchestrating-with-rb-lite
+drive|pr-with-codex-bot-review-merge
+drive|pr-with-codex-bot-review
+bead-polish-loop|rb-lite-backlog-drain
+bead-polish-loop|orchestrating-with-rb-lite
+plan-to-beads-transfer|rb-lite-backlog-drain
+plan-to-beads-transfer|orchestrating-with-rb-lite
+second-model-bead-audit|rb-lite-backlog-drain
+second-model-bead-audit|orchestrating-with-rb-lite
+DEPENDENCIES
+if [[ -n "$dependency_failures" ]]; then fail "$t" "$dependency_failures"
+else pass "$t"; fi
+
+t="selective upgrades repair companions per target without cross-target migration"
+upgrade_failures=""
+while IFS='|' read -r owner companion; do
+  b=$(new_repo_fixture)
+  ln -s "$b/clone/skills/$owner" "$b/home/.claude/skills/$owner"
+  mkdir -p "$b/codexhome/skills/$owner"
+  printf 'mine\n' > "$b/codexhome/skills/$owner/SKILL.md"
+  run "$b" --target both --migrate-existing voice-dna >/dev/null; rc=$?
+  if [[ $rc -ne 0 ]]; then
+    upgrade_failures+="$owner upgrade exited $rc; "
+  elif [[ ! -L "$b/home/.claude/skills/$companion" ]]; then
+    upgrade_failures+="$owner omitted Claude $companion; "
+  elif [[ -e "$b/codexhome/skills/$companion" || -L "$b/codexhome/skills/$companion" ]]; then
+    upgrade_failures+="$owner leaked $companion into Codex; "
+  elif [[ -L "$b/codexhome/skills/$owner" || $(< "$b/codexhome/skills/$owner/SKILL.md") != mine ]]; then
+    upgrade_failures+="$owner migrated the unrequested Codex directory; "
+  fi
+done <<'UPGRADES'
+multi-reviewer-loop|multi-reviewer-loop-delegating-edits
+orchestrating-with-rb-lite|rb-lite-backlog-drain
+pr-with-codex-bot-review|pr-with-codex-bot-review-merge
+UPGRADES
+if [[ -n "$upgrade_failures" ]]; then fail "$t" "$upgrade_failures"
+else pass "$t"; fi
+
+t="upgrade repair is one hop and shared failure paths count once"
+b=$(new_repo_fixture)
+ln -s "$b/clone/skills/drive" "$b/home/.claude/skills/drive"
+run "$b" --target claude voice-dna >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "asymmetric repair exited $rc"
+elif [[ ! -L "$b/home/.claude/skills/rb-lite-backlog-drain" \
+     || ! -L "$b/home/.claude/skills/pr-with-codex-bot-review-merge" ]]; then
+  fail "$t" "drive's direct companions were not repaired"
+elif [[ -e "$b/home/.claude/skills/orchestrating-with-rb-lite" \
+     || -e "$b/home/.claude/skills/pr-with-codex-bot-review" ]]; then
+  fail "$t" "repair expanded through newly installed companion links"
+else
+  for owner in bead-polish-loop plan-to-beads-transfer second-model-bead-audit; do
+    ln -s "$b/clone/skills/$owner" "$b/codexhome/skills/$owner"
+  done
+  printf 'blocked\n' > "$b/codexhome/skills/rb-lite-backlog-drain"
+  out=$(run "$b" --target codex voice-dna 2>&1); rc=$?
+  warning_count=$(grep -Fc 'required companion path exists but is not a loadable skill' <<< "$out")
+  if [[ $rc -eq 0 ]]; then fail "$t" "blocked companion returned success"
+  elif [[ $warning_count -ne 1 ]]; then fail "$t" "blocked path warned $warning_count times"
+  elif [[ "$out" != *"skipped=1"* ]]; then fail "$t" "blocked path was not counted once"
+  else
+    b=$(new_repo_fixture)
+    for owner in bead-polish-loop plan-to-beads-transfer second-model-bead-audit; do
+      ln -s "$b/clone/skills/$owner" "$b/codexhome/skills/$owner"
+    done
+    mv "$b/clone/skills/rb-lite-backlog-drain" \
+      "$b/clone/skills/rb-lite-backlog-drain.missing"
+    out=$(run "$b" --target codex voice-dna 2>&1); rc=$?
+    warning_count=$(grep -Fc 'required companion source is missing' <<< "$out")
+    if [[ $rc -eq 0 ]]; then fail "$t" "missing companion returned success"
+    elif [[ $warning_count -ne 1 ]]; then fail "$t" "missing source warned $warning_count times"
+    elif [[ "$out" != *"missing=1"* ]]; then fail "$t" "missing source was not counted once"
+    else pass "$t"; fi
+  fi
+fi
+
+t="upgrade repair replaces dangling companions and rejects wrong declared names"
+b=$(new_repo_fixture)
+ln -s "$b/clone/skills/orchestrating-with-rb-lite" \
+  "$b/home/.claude/skills/orchestrating-with-rb-lite"
+ln -s "$b/clone/skills/rb-lite-backlog-drain-OLD" \
+  "$b/home/.claude/skills/rb-lite-backlog-drain"
+out=$(run "$b" --target claude voice-dna 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "dangling-link repair exited $rc: $out"
+elif [[ ! -L "$b/home/.claude/skills/rb-lite-backlog-drain" ]]; then
+  fail "$t" "dangling companion was not replaced"
+elif [[ $(readlink "$b/home/.claude/skills/rb-lite-backlog-drain") \
+     != "$b/clone/skills/rb-lite-backlog-drain" ]]; then
+  fail "$t" "dangling companion points at the wrong source"
+else
+  b=$(new_repo_fixture)
+  ln -s "$b/clone/skills/orchestrating-with-rb-lite" \
+    "$b/home/.claude/skills/orchestrating-with-rb-lite"
+  mkdir -p "$b/home/.claude/skills/rb-lite-backlog-drain"
+  printf '%s\n' '---' 'name: wrong-skill' 'description: wrong' '---' > \
+    "$b/home/.claude/skills/rb-lite-backlog-drain/SKILL.md"
+  out=$(run "$b" --target claude voice-dna 2>&1); rc=$?
+  if [[ $rc -eq 0 ]]; then fail "$t" "wrong-name companion returned success"
+  elif [[ "$out" != *"required companion path exists but is not a loadable skill"* ]]; then
+    fail "$t" "wrong-name companion emitted no warning"
+  elif [[ "$out" != *"skipped=1"* ]]; then fail "$t" "wrong-name path was not counted"
+  else pass "$t"; fi
+fi
+
+t="ignored workspace directories stay out of installer and validation inventories"
+b=$(new_fixture "alpha eval-workspace")
+inventory=$(repository_skill_files "$b/clone")
+run "$b" --target both >/dev/null; rc=$?
+if [[ $rc -ne 0 ]]; then fail "$t" "all-skill install exited $rc"
+elif [[ "$inventory" != "$b/clone/skills/alpha/SKILL.md" ]]; then
+  fail "$t" "validation inventory was not exactly alpha: $inventory"
+elif [[ ! -L "$b/home/.claude/skills/alpha" || ! -L "$b/codexhome/skills/alpha" ]]; then
+  fail "$t" "ordinary alpha skill was not installed"
+elif [[ -L "$b/home/.claude/skills/eval-workspace" || -L "$b/codexhome/skills/eval-workspace" ]]; then
+  fail "$t" "ignored eval-workspace was installed"
+else pass "$t"; fi
+
+# ── harness compatibility ────────────────────────────────────────────────────────
+
+# Evidence measured 2026-08-10 with Tau 0.1.0 (e341951, model-visible `skill` tool):
+# `rg -n 'MAX_SKILL_CONTENT_BYTES|read_skill_source_prefix' crates/tau-harness-tools/src/lib.rs`
+# reported `MAX_SKILL_CONTENT_BYTES: usize = 64 * 1024` and showed the loader passing
+# that bound directly to the raw source-prefix reader (no line-number rendering). In a
+# PTY-combined stream, invoking the old 97,161-byte skill through Tau's model-visible
+# `skill` tool warned that it was truncated to 65,536 bytes. Every current source is at
+# or below the bound checked here.
+# A skill can therefore install and parse while its load-bearing tail is never shown.
+# The same Tau revision defines `MAX_DESCRIPTION_LENGTH: usize = 1024` in
+# `crates/tau-skills/src/lib.rs`; the folded-description check below implements the
+# repository's current `description: >-` convention without adding a YAML dependency.
+folded_description_bytes() {
+  LC_ALL=C awk '
+    NR == 1 { if ($0 != "---") exit; next }
+    $0 == "---" { exit }
+    $0 == "description: >-" { in_description=1; next }
+    in_description && /^[[:space:]]*$/ { invalid=1; exit }
+    in_description && /^  / {
+      line=$0; sub(/^  /, "", line)
+      if (seen) total++
+      total += length(line); seen=1; next
+    }
+    in_description { exit }
+    END { if (in_description && !invalid && seen) print total }
+  ' "$1"
+}
+
+mapfile -t skill_files < <(repository_skill_files "$HERE")
+t="skills repository contains discoverable skills"
+if [[ ${#skill_files[@]} -eq 0 ]]; then fail "$t" "no skills/*/SKILL.md files found"
+else
+  pass "$t"
+  body_failures=""; description_failures=""
+  for skill_file in "${skill_files[@]}"; do
+    if ! bytes=$(LC_ALL=C wc -c < "$skill_file"); then
+      body_failures+="${skill_file#"$HERE/"} (could not measure); "
+      continue
+    fi
+    if [[ $bytes -gt 65536 ]]; then
+      body_failures+="${skill_file#"$HERE/"} ($bytes bytes); "
+    fi
+    description_bytes=$(folded_description_bytes "$skill_file")
+    if [[ ! $description_bytes =~ ^[0-9]+$ ]]; then
+      description_failures+="${skill_file#"$HERE/"} (unsupported description form); "
+    elif [[ $description_bytes -gt 1024 ]]; then
+      description_failures+="${skill_file#"$HERE/"} ($description_bytes bytes); "
+    fi
+  done
+
+  t="every SKILL.md fits Tau's 64 KiB skill-source prefix"
+  if [[ -n "$body_failures" ]]; then fail "$t" "$body_failures"
+  else pass "$t"; fi
+
+  t="every single-paragraph folded skill description fits Tau's 1,024-byte bound"
+  if [[ -n "$description_failures" ]]; then fail "$t" "$description_failures"
+  else pass "$t"; fi
+fi
+
+# These are the companion procedures most likely to be loaded under pressure. Pin their
+# exact model-invocable names, stable anchors, and every critical handoff rather than
+# attempting to validate all Markdown links with a second parser.
+t="critical companion-skill handoffs remain loadable"
+link_failures=""
+backlog_ref="$HERE/skills/rb-lite-backlog-drain/SKILL.md"
+for required_ref in \
+  skills/multi-reviewer-loop-delegating-edits/SKILL.md \
+  skills/pr-with-codex-bot-review-merge/SKILL.md; do
+  if [[ ! -f "$HERE/$required_ref" ]]; then
+    link_failures+="$required_ref missing; "
+  fi
+done
+for anchor in 7 8 11 12; do
+  if ! grep -Fq -- "<a id=\"backlog-step-$anchor\"></a>" "$backlog_ref"; then
+    link_failures+="backlog-step-$anchor anchor missing; "
+  fi
+done
+while IFS='|' read -r consumer target; do
+  if [[ $target == "##"* || $target == "name: "* ]]; then
+    grep -Fxq -- "$target" "$HERE/$consumer" || link_failures+="$consumer lacks $target; "
+  elif ! grep -Fq -- "$target" "$HERE/$consumer"; then
+    link_failures+="$consumer lacks $target; "
+  fi
+done <<'LINKS'
+skills/rb-lite-backlog-drain/SKILL.md|name: rb-lite-backlog-drain
+skills/rb-lite-backlog-drain/SKILL.md|user-invocable: false
+skills/multi-reviewer-loop-delegating-edits/SKILL.md|name: multi-reviewer-loop-delegating-edits
+skills/multi-reviewer-loop-delegating-edits/SKILL.md|user-invocable: false
+skills/pr-with-codex-bot-review-merge/SKILL.md|name: pr-with-codex-bot-review-merge
+skills/pr-with-codex-bot-review-merge/SKILL.md|user-invocable: false
+skills/orchestrating-with-rb-lite/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/orchestrating-with-rb-lite/SKILL.md|[`rb-lite-backlog-drain`](../rb-lite-backlog-drain/SKILL.md)
+skills/orchestrating-with-rb-lite/references/harden-until-clean.md|../../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/multi-reviewer-loop/SKILL.md|../multi-reviewer-loop-delegating-edits/SKILL.md
+skills/pr-with-codex-bot-review/SKILL.md|../pr-with-codex-bot-review-merge/SKILL.md
+skills/rb-lite-backlog-drain/SKILL.md|../orchestrating-with-rb-lite/SKILL.md#backlog-task-template
+skills/rb-lite-backlog-drain/SKILL.md|../orchestrating-with-rb-lite/SKILL.md#exit-codes-and-json-schema
+skills/rb-lite-backlog-drain/SKILL.md|../orchestrating-with-rb-lite/SKILL.md#verify-the-landed-diff
+skills/rb-lite-backlog-drain/SKILL.md|../orchestrating-with-rb-lite/SKILL.md#tool-dependencies
+skills/multi-reviewer-loop-delegating-edits/SKILL.md|../multi-reviewer-loop/SKILL.md#1-preflight
+skills/pr-with-codex-bot-review-merge/SKILL.md|../pr-with-codex-bot-review/SKILL.md#8a-the-merge-report-must-quote-the-gate
+skills/pr-with-codex-bot-review-merge/SKILL.md|GATE_JSON=$("$BOT_GATE" <N> --json) || GATE_RC=$?
+skills/pr-with-codex-bot-review-merge/SKILL.md|unset REVIEWED_TIP
+skills/pr-with-codex-bot-review-merge/SKILL.md|merge-gate-<N>.json
+skills/pr-with-codex-bot-review-merge/SKILL.md|pr-with-codex-bot-review § 8b
+skills/pr-with-codex-bot-review-merge/SKILL.md|# DEGRADED REENTRY A: stop here after repository and BOT_GATE resolution.
+skills/pr-with-codex-bot-review-merge/SKILL.md|# DEGRADED REENTRY B: resume here after completing main-skill § 8b.
+skills/pr-with-codex-bot-review/SKILL.md|LIVE_GATE_JSON=$("$BOT_GATE" <N> --json) || LIVE_GATE_RC=$?
+skills/pr-with-codex-bot-review/SKILL.md|"$LIVE_GATE_TIP" = "$AUTHORIZED_TIP"
+skills/pr-with-codex-bot-review/SKILL.md|_LIVE_TREE=$(git status --porcelain)
+skills/pr-with-codex-bot-review/SKILL.md|orchestrating-with-rb-lite` § **Tool dependencies**
+skills/pr-with-codex-bot-review/SKILL.md|orchestrating-with-rb-lite` § **Customizing the panel**
+skills/orchestrating-with-rb-lite/SKILL.md|## Backlog task template
+skills/orchestrating-with-rb-lite/SKILL.md|## Exit codes and JSON schema
+skills/orchestrating-with-rb-lite/SKILL.md|## Verify the landed diff
+skills/orchestrating-with-rb-lite/SKILL.md|## Tool dependencies
+skills/orchestrating-with-rb-lite/SKILL.md|## Customizing the panel
+skills/multi-reviewer-loop/SKILL.md|### 1. Preflight
+skills/pr-with-codex-bot-review/SKILL.md|### 8a. The merge report must quote the gate
+skills/pr-with-codex-bot-review/SKILL.md|### 8b. When the forge itself is degraded
+skills/drive/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/drive/references/phases.md|../../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/bead-polish-loop/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/plan-to-beads-transfer/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/second-model-bead-audit/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/second-model-bead-audit/references/reviewer-panel.md|../../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/multi-reviewer-loop/SKILL.md|Companion unavailable: do not delegate
+skills/pr-with-codex-bot-review/SKILL.md|Companion unavailable: stop
+skills/orchestrating-with-rb-lite/SKILL.md|Companion unavailable: stop
+skills/drive/SKILL.md|Companion unavailable: stop
+skills/bead-polish-loop/SKILL.md|Companion unavailable: stop
+skills/plan-to-beads-transfer/SKILL.md|Companion unavailable: stop
+skills/second-model-bead-audit/SKILL.md|Companion unavailable: stop
+LINKS
+if [[ -n "$link_failures" ]]; then fail "$t" "$link_failures"
 else pass "$t"; fi
 
 printf '\npassed %d, failed %d\n' "$PASS" "$FAIL"

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -73,8 +73,11 @@ _st=$(git status --porcelain -- "$BEADS_JSONL") \
 printf '%s' "$_st"
 ```
 
-If it is not empty, resolve it first — recovery
-case (a) in [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11. After the first flush the choice
+If it is not empty, resolve it first — recovery case (a) in
+exact companion skill [`rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
+**Companion unavailable: stop, rerun the same installer command once, reload it, and do
+not improvise this procedure.**
+After the first flush the choice
 is gone.
 
 ## Session shape
@@ -191,7 +194,7 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    re-serialization with every id on both sides is normal, ids on only one side or a
    `description` you did not touch is the tell. Recovery — and why `br sync --import-only`
    cannot do it — is in
-   [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11, with one
+   [exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11), with one
    caveat: its replay step assumes a SINGLE mutation, the drain's case. A polish round
    batches several rewrites, so enumerate the complete intended delta (the step 4 replay manifest, NOT
    the step 6 round summary — the summary records decisions, not commands, ids or order) before restoring — and restore from the side you established holds the good bodies, not

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -1,22 +1,16 @@
 ---
 name: drive
 description: >-
-  Use this whenever the user hands over a GOAL instead of a single action and expects
-  you to keep working until it is reached. Make sure to use it even when the user never
-  says the word "drive" — a request that spans more than one phase of the software
-  lifecycle is a drive, and running the phases ad hoc instead is the mistake this skill
-  exists to prevent. Trigger phrases: "drive this", "drive the project", "take X from
-  spec to merged", "from idea to merged", "handle it end to end", "run the whole
-  pipeline", "work on X until it's done", "keep going until the beads/backlog are
-  drained", "don't stop and ask me between steps", "I'll check back later", plus any
-  request that names a feature, epic or milestone rather than a file, or that states a
-  finish condition rather than an action. Also use it to answer "where are we / what's
-  next" on a project, and to resume a half-finished project in a fresh session. It
-  sequences the specialist lifecycle skills — spec, then beads, then build, then tests,
-  then the reviewer panel, then the PR and merge, then the next bead — and enforces the
-  evidence gate between each, so prefer it over invoking any single one of those skills
-  directly whenever the work spans more than one of those phases. Skip it only for a
-  single bounded action, a one-off edit, a question, or debugging and ops work.
+  Drive a software goal across lifecycle phases until its finish condition is met.
+  Use when work spans spec, beads, build, tests, reviewer convergence, PR/merge, or
+  multiple backlog items—even if the user never says "drive". Trigger on "drive
+  this", "end to end", "from idea/spec to merged", "run the whole pipeline",
+  "until it's done", "drain the backlog", "don't stop and ask me between steps",
+  "I'll check back later", feature/epic/milestone goals, project status, or resuming
+  half-finished work. It routes to specialist skills and enforces
+  evidence at every transition. Skip for a single bounded action, one-off edit,
+  question, or debugging/ops task. Prefer Drive over invoking phase skills directly
+  whenever the work crosses phases.
 argument-hint: "[goal or bead id] [--phase shape|graph|build|prove|harden|land]"
 compatibility: >-
   Inherits the prerequisites of whichever phases a project actually reaches:
@@ -298,7 +292,10 @@ A phase closes on evidence or it does not close.
   `.beads.jsonl` and `<name>.beads.jsonl` are supported too, and a hardcoded path diffs
   nothing on those — a false all-clear in the direction that loses text. Detail and
   recovery:
-  [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11.
+  load exact companion skill `rb-lite-backlog-drain` and follow
+  [step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
+  **Companion unavailable: stop, rerun the same installer command once, reload it, and do
+  not improvise this procedure.**
 
 
 The rules above are what closes a *phase*. The fuller set on not lying about *edits* —

--- a/skills/drive/evals/trigger-evals.json
+++ b/skills/drive/evals/trigger-evals.json
@@ -8,7 +8,8 @@
     "Keep a positive control in the set (N1 below). It fires first-tool on multi-reviewer-loop, so if N1 stops working the environment is broken, not the description."
   ],
   "fixture": "git repo with docs/specs/<slug>.md, a Cargo.toml, and 2 ready beads -- drive-status reports BUILD.",
-  "last_measured": "2026-08-01, claude-opus-5, 3 runs per positive",
+  "last_measured": "2026-08-10, claude-opus-5; 3 runs for evals 1, 2, and 7; 1 run for controls 11 and 18",
+  "measurement_note": "Measured in disposable copies of the documented fixture with drive-status reporting BUILD. A trigger counts when Skill(<name>) appears anywhere in the stream-json tool sequence.",
   "evals": [
     {
       "id": 1,
@@ -20,7 +21,7 @@
       "id": 2,
       "query": "where are we on the rustnroll multiplayer work and what's next?",
       "should_trigger": true,
-      "measured": "3/3"
+      "measured": "2/3"
     },
     {
       "id": 3,
@@ -46,8 +47,8 @@
       "id": 7,
       "query": "review and fix this branch until both reviewers are clean, then open the PR and squash merge it",
       "should_trigger": true,
-      "measured": "0/2",
-      "known_limitation": "Triggers nothing -- not drive, not multi-reviewer-loop -- because it names outcomes rather than tools. Deliberately NOT fixed: the gap spans two skills' descriptions and tuning both against one query would risk the cells that currently measure clean. Superseded by the invocation contract above: explicit invocation covers this case."
+      "measured": "3/3",
+      "history": "Measured 0/2 before the 2026-08-10 description rewrite. Do not tune either description against one query; explicit invocation remains the required path."
     },
     {
       "id": 8,
@@ -124,5 +125,5 @@
       "should_trigger": false
     }
   ],
-  "invocation_contract": "Explicit invocation (`/drive ...`) is the expected path and the one that must work. Auto-triggering from a bare goal is a bonus, not a requirement -- do NOT spend rounds tuning the description to raise it, and do not treat a should_trigger miss as a defect. Decision made 2026-08-02 after measuring; the numbers below are a baseline to detect regressions in, not a target to optimise."
+  "invocation_contract": "Explicit invocation (`/drive ...`) is the expected path and the one that must work. Auto-triggering from a bare goal is a bonus, not a requirement -- do NOT spend rounds tuning the description to raise it, and do not treat a should_trigger miss as a defect. Decision made 2026-08-02 after measuring; a future manual run may establish a new baseline, but it is not an optimization target."
 }

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -518,8 +518,9 @@ Read its "Files skipped from review" list and re-trigger unless the skip was exp
 creates a new commit; that equality is unsatisfiable by construction.
 
 Pin the head in the merge itself, using **the tip `bot-gate` checked** rather than a fresh
-`git rev-parse HEAD` — see `pr-with-codex-bot-review` § 8, which captures it from the
-gate's JSON. A re-read pins whatever is current, so an amend landing after the gate gets
+`git rev-parse HEAD` — see the
+[exact companion skill `pr-with-codex-bot-review-merge`](../../pr-with-codex-bot-review-merge/SKILL.md),
+which captures it from the gate's JSON. A re-read pins whatever is current, so an amend landing after the gate gets
 pinned to itself and is accepted
 (`-R` because a bare PR number resolves against the current repo, which on a fork is yours)
 (the **full** OID; the wrapper's SHA may be abbreviated, which would refuse every merge).
@@ -712,7 +713,9 @@ clone boundary, so a snippet that assumes one silently rejects every PR (`$id !=
 misses the closure it exists to find.
 
 Keyed on the **`bead-closure:` marker plus the bead id**, not on the id alone: every work
-PR body carries the bead id too (rb-lite's step 8 requires it), so an id-only filter
+PR body carries the bead id too
+([exact companion skill `rb-lite-backlog-drain`, step 8](../../rb-lite-backlog-drain/SKILL.md#backlog-step-8)
+requires it), so an id-only filter
 returns the merged work PR for any bead whose work landed — on a fresh clone that reads
 as closure history for a closure that was never opened, and the resume guard clears
 itself on the wrong PR. Not a branch-naming convention either — nothing here mandates
@@ -726,7 +729,9 @@ the metadata PR being opened leaves exactly that state: work on the base, bead s
 in the JSONL, no marker anywhere for the first query to find. Reading empty as
 "unfinished" there re-enters BUILD and duplicates merged work. The second query in the
 block is what tells those apart: it asks the same snapshot whether the bead's WORK
-already merged (every work PR body carries the bead id — rb-lite's step 8 requires it).
+already merged (every work PR body carries the bead id —
+[exact companion skill `rb-lite-backlog-drain`, step 8](../../rb-lite-backlog-drain/SKILL.md#backlog-step-8)
+requires it).
 
 Read any hit before acting on it. **Take the repository from the hit's `url`, never from
 the number alone** — these results merge the parent's PRs with the fork's, and #42 exists
@@ -794,7 +799,7 @@ Ids on only one side, or a `description` this phase did not write, is the tell. 
 hand-edit that file (a hand
 edit does not advance `updated_at`, which is what makes the cache stale and undetectable);
 write bead text with `br update -d/--notes`. Recovery is in
-[orchestrating-with-rb-lite](../../orchestrating-with-rb-lite/SKILL.md) step 11.
+[exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
 
 A flush
 over a graph that was already committed and unchanged legitimately reports nothing, so a

--- a/skills/drive/scripts/drive-status
+++ b/skills/drive/scripts/drive-status
@@ -103,7 +103,8 @@ if $_GITHUB_REMOTE && command -v gh >/dev/null 2>&1 && [[ -n "$BRANCH" ]]; then
   # Probe, do not prefer. A fork can host its own PRs, so forcing `.parent` misses them —
   # or finds an unrelated parent PR with the same number and validates clearance against
   # its base. Pick the candidate whose PR head is this checkout's HEAD; that is the only
-  # question with one answer. bot-gate and § 8 resolve the same way.
+  # question with one answer. bot-gate and exact companion skill
+  # `pr-with-codex-bot-review-merge` resolve the same way.
   # A failed self lookup degrades the head-label selector below into a bare branch name,
   # which finds nothing on exactly the fork clones it exists for — absence by broken
   # query. Mark the probe unknown rather than let that read as "no PR".
@@ -143,7 +144,8 @@ if $_GITHUB_REMOTE && command -v gh >/dev/null 2>&1 && [[ -n "$BRANCH" ]]; then
   # break that tie, and breaking on the parent picked one of two PRs by iteration order.
   # A head match is still the tiebreak when it singles ONE out (local HEAD ahead of a stale
   # PR head is routine mid-HARDEN); two open PRs that a head cannot separate are refused,
-  # the same double-match rule bot-gate and § 8 enforce for number-keyed lookups.
+  # the same double-match rule bot-gate and exact companion skill
+  # `pr-with-codex-bot-review-merge` enforce for number-keyed lookups.
   _UP=""; _FOUND=""; _OPEN_N=0; _HEADMATCH_N=0; _HEADMATCH_REPO=""
   for _c in ${_CANDS[@]+"${_CANDS[@]}"}; do
     _sel="$BRANCH"

--- a/skills/multi-reviewer-loop-delegating-edits/SKILL.md
+++ b/skills/multi-reviewer-loop-delegating-edits/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: multi-reviewer-loop-delegating-edits
+description: >-
+  Internal companion procedure for safely delegating edits from
+  multi-reviewer-loop. Load this exact skill only when multi-reviewer-loop directs
+  you here; it is not a standalone review workflow.
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Delegating reviewer-loop edits
+
+Use this only after the orchestrator has verified and adjudicated the findings.
+It defines how a fresh implementer may edit without damaging pre-existing work.
+
+## Contents
+
+- Why a fresh editor helps
+- The adjudicator/implementer responsibility split
+- Scope, tool, verification, and concept-sweep requirements
+- Four captures: tracked staged/unstaged patches, porcelain status, untracked bytes,
+  and explicit path existence
+- States that cannot safely be delegated
+- The five-step rollback sequence
+- Why `git stash create` is not an equivalent snapshot
+
+**The agent that wrote the text is the worst available editor of it.** After a few
+passes you stop reading what is on the page and start reading what you meant. Measured
+on one long documentation loop: the orchestrator fixing its own artifact introduced
+roughly one to two *new* defects per fixing pass across eleven passes — the same claim
+corrected in one file and left standing in its twin (ten times), replacements spliced
+into the middle of a sentence without re-reading (breaking a list and duplicating a
+clause), and absolutes that outran the code. Handed the same kind of findings, a fresh
+implementer applied five of them with zero self-inflicted defects and proactively swept
+eight sibling occurrences the orchestrator had not been asked about.
+
+Treat that as one trial, not a law — by then the artifact was already much cleaner and
+the findings were unusually well specified. The mechanism is probably **freshness plus a
+written finding list**, not the particular model: delegating forces you to state each
+finding precisely enough for someone else to act on, which by itself kills the vague ones.
+
+**The split that works:**
+
+- **You adjudicate.** Verify each finding against source first. Never hand over a finding
+  you have not checked — you would be outsourcing the judgment, not the typing.
+- **The implementer edits**, in a fresh context. A fresh context is also an *ignorant*
+  one: everything it must not do has to be in the prompt, because none of it is in the
+  air. Carry all of:
+  - **The scope, named.** The exact paths it may touch and the tools it may use. An
+    implementer told only "fix these findings" will range further than you meant, and
+    you cannot review what you did not bound.
+  - **Verify before fixing.** Findings are hypotheses; one may be wrong. Say so, or a
+    fresh agent will treat your list as a work order.
+  - **Sweep by concept, not by phrase.** After each fix, search the whole artifact for
+    the same claim stated differently.
+  - **Read back every passage you splice into** — the whole sentence and its
+    neighbours, not the replaced span.
+  - **Use the harness edit tool, not `sed -i` or `str.replace`**, which report success
+    on zero matches. If an edit must be scripted, assert the target exists before
+    replacing, then grep the file for both the new text and the *absence* of the old.
+    This is the repo's standing edit contract (`agents-md`), and it does not travel to
+    a fresh context on its own.
+  - **Add no *unrequested* mechanism** — not "nothing new". A verified finding may
+    genuinely require a lock, a validation, or a transaction; what is forbidden is
+    anything beyond the finding. Scope conflicts come back to you to adjudicate, not
+    resolved by the implementer.
+  - Plus your environment guards.
+- **Tool-managed state is delegable too — through the tool, never the file.** A ticket
+  tracker or database whose on-disk form is a single JSONL line per record is corrupted by
+  hand-editing, so the instinct is to keep those findings yourself. Measured: that instinct
+  cost more than it saved. The orchestrator's own shell command-substituted the backticks
+  in a double-quoted update and silently blanked three field names in a record. Delegating
+  the same work with one rule — *use the CLI, never edit the file* — landed clean and the
+  database still parsed. Name the tool, forbid the file, and require a read-back.
+- **Snapshot first — and non-destructively.** The implementer has write access, and
+  [the already-loaded owning skill's § 1.7](../multi-reviewer-loop/SKILL.md#1-preflight) explicitly permits a dirty tree, so plain
+  `git` is *not* your undo: `git checkout
+  .`, `git stash` and `git reset --hard` each discard the user's pre-existing work along
+  with the delegated edit, which [the owning skill's § 1.7](../multi-reviewer-loop/SKILL.md#1-preflight) forbids.
+
+  Capture **four** things before granting access, and require the capture *commands* to
+  succeed — never their output to be non-empty, since on a clean tree an empty patch is
+  the correct answer:
+
+  - `git diff --cached --binary --no-textconv --no-ext-diff -- <the delegated paths>` and
+    `git diff --binary --no-textconv --no-ext-diff -- <the delegated paths>`, as **two**
+    patches. `--no-ext-diff` because a configured `diff.external` helper is not disabled by
+    `--no-textconv`: measured on git 2.43, a helper emitting `bogus` gave an exit-0 capture
+    of non-patch output that could restore nothing. And `-- :(literal)<path>` for each delegated path at
+    *capture* time — the `:(literal)` magic matters, because a bare pathspec still globs
+    and delegated `a[1].txt` alongside an unrelated dirty `a1.txt` captures both, which
+    then aborts the replay on the hunk step 2 left applied. With literal magic the replay
+    needs no filtering: `git apply --include` takes a **pattern**, and both a
+    bare directory and a literal `a[1].txt` silently match no hunks while exiting 0 — after
+    step 2 has already reverted those paths, which turns a rollback into a loss that reports
+    success. One combined `git diff HEAD` flattens the layers, so an `MM` path
+    comes back ` M` and a later commit carries hunks the user left out. Both flags matter:
+    without `--binary` a modified binary records only "Binary files differ" and will not
+    apply; `--no-textconv` because the conversion is not what is on disk.
+  - `git status --porcelain -z`, NUL-delimited. Porcelain quotes paths that need it, so a
+    `cut`-based parse hands back a literal `"caf\303\251.py"` that does not exist. This
+    is also what restores **intent-to-add** entries (` A `) afterwards:
+    [the owning skill's § 1.6](../multi-reviewer-loop/SKILL.md#1-preflight) `git add
+    -N` runs only before the first pass, so a file demoted to `??` during a rollback drops
+    out of every later `codex review --base`.
+  - a **byte copy of every pre-existing untracked path in scope** — no patch contains
+    them. Clear each destination before copying and again before restoring: `cp -pR` into
+    an existing directory nests rather than replaces, and exits 0 either way.
+  - an **explicit existence list**: which delegated paths exist right now. Porcelain says
+    nothing about a clean tracked file, so status-absence is *not* an existence test —
+    treating it as one deletes exactly the files that were fine.
+
+  **Refuse the paths this cannot represent.** The recoverable byte state has three parts:
+  a staged diff, an unstaged diff, and a byte copy. Porcelain status and the existence
+  list are metadata used to restore those parts. Any state that does not round-trip
+  through the three byte representations is out of scope for delegation —
+  take the path out and say so. Known cases: unmerged paths; either
+  endpoint of a **staged rename**, which are one unit (reverting the destination leaves the
+  source staged as deleted and the replay then fails); contents inside a dirty submodule;
+  anything with a byte-transforming `.gitattributes` entry (`git check-attr --all` —
+  `filter`, `text`, `eol`, `working-tree-encoding`); text files under `core.autocrlf`, in **either**
+  `true` or `input` — both convert, with no attribute for `check-attr` to report.
+  Measured: under `true` a mixed CRLF/LF file replayed as all-CRLF from a patch that
+  applied cleanly; under `input` a CRLF worktree against an LF index gave an empty patch
+  for a file `git status` called modified, and the rollback then rewrote it to LF;
+  and files marked `assume-unchanged`,
+  where all three captures *succeed while recording nothing* and the revert then replaces
+  the bytes with `HEAD`. That list is the cases known to hit the rule, not the boundary.
+
+  **To roll back**, undo only the delegated paths and rebuild them from the capture, in
+  this order — anything else reaches for the destructive commands forbidden above:
+
+  1. **delete the delegated paths the implementer created** — those absent from the
+     *existence list*, never those merely absent from porcelain status. A clean tracked
+     file has no status entry, so the status test would delete a file that was fine
+  2. revert **only** the remaining delegated paths; leave every other path untouched
+  3. re-apply the **staged** patch with `git apply --index`, then the **unstaged** one.
+     No `--include` is needed or wanted — the patches were already restricted by pathspec
+     at capture time, which is the only way to scope them without pattern semantics. Not
+     `--cached`: it updates the index
+     "without touching the working tree", so the worktree stays at `HEAD` and the unstaged
+     patch fails against it — measured, `error: patch failed`, after the original was
+     already reverted. Path-restricted capture is also what keeps the replay from touching
+     unrelated hunks that step 2 deliberately left applied — replaying those would abort
+     the whole patch with `patch does not apply` before any delegated path is restored.
+     **Skip an empty patch file** (or pass `--allow-empty`): an
+     unstaged-only edit leaves the staged layer empty and `git apply` exits 128 on it —
+     after the revert, so the layer holding the user's work is never applied
+  4. restore each untracked backup, clearing its destination first
+  5. re-run `git add -N` for every path the status snapshot recorded as `" A "` — a leading
+     space, then `A`; `"A "` is an ordinary staged addition and must not be re-added
+
+  **`git stash create` cannot replace any of this.** It fails outright on the tree
+  [the owning skill's § 1.6](../multi-reviewer-loop/SKILL.md#1-preflight) builds:
+
+  ```console
+  $ git stash create
+  error: Entry 'café.py' not uptodate. Cannot merge.
+  ```
+
+  `git add -N` makes stash refuse outright. And it would not be a drop-in even without
+  that: `stash create` takes no `-u`, so an untracked-only tree yields **no stash object at
+  all** (measured), and a conflicted index is rejected rather than saved. It handles the
+  *tracked-content* cases well — binaries, textconv, index layers — which is the useful
+  half of the comparison, not the whole of it. Anyone proposing the swap should reproduce
+  the error above first.
+
+This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
+hands over *only the edit* for findings you have already verified.

--- a/skills/multi-reviewer-loop/SKILL.md
+++ b/skills/multi-reviewer-loop/SKILL.md
@@ -1,20 +1,16 @@
 ---
 name: multi-reviewer-loop
 description: >-
-  Runs an iterative multi-reviewer review/fix/re-review loop on the current
-  branch: detects a review base, runs a two-reviewer panel (`codex review` plus a
-  Claude reviewer at high effort) in parallel each pass, merges and dedupes their
-  findings, treats findings as credible until disproven, fixes accepted items,
-  validates the changed code, and repeats until both reviewers are clean on the
-  current diff. A final consistency pass then checks that the changed files still
-  agree with each other and with the docs describing them; a clean diff alone does
-  not finish the loop. Stops early at the pass limit. Use when the user asks to "review loop",
-  "multi-reviewer loop", "codex review loop", "review and fix", "review until
-  clean", "get a second reviewer on this", "let's get this PR clean", "fix what
-  the reviewers found", or right before opening a PR or shipping. Also suggest
-  proactively after substantial implementation work or when a single review pass
-  surfaced issues. Does not commit, open a PR, or reject findings without
-  concrete evidence.
+  Iteratively review, fix, validate, and re-review the current branch with
+  `codex review` and a high-effort Claude reviewer in parallel. Reconcile their
+  findings as hypotheses, repeat until both are clean, then run a cross-file and
+  documentation consistency pass; diff-clean alone is not complete. Use for
+  "review loop", "multi-reviewer loop", "codex review loop", "review and fix",
+  "review until clean", "codex plus opus", "codex plus fable", "get a second
+  reviewer", "get this PR clean", or before shipping substantial work. Stops at
+  the pass limit, never commits or opens a PR, and requires evidence to reject
+  findings. Suggest it proactively after substantial implementation or when a
+  first review finds issues.
 argument-hint: "[max-passes] [--reviewers codex|claude|codex,claude] [focus instructions]"
 allowed-tools:
   - Bash
@@ -23,6 +19,7 @@ allowed-tools:
   - Edit
   - Glob
   - Grep
+  - Skill
   - AskUserQuestion
 ---
 
@@ -223,7 +220,7 @@ a reviewer.
      fi
      BR=$(git branch --show-current)
      HEAD_OID=$(git rev-parse HEAD)
-     _GH_ERR=$(mktemp); trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it || { echo "mktemp failed"; exit 1; }
+     _GH_ERR=$(mktemp) || { echo "mktemp failed"; exit 1; }; trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it
      UP="$SELF"; SEL="$BR"; PRNUM=""; _M=0; _HM=0
      for _c in ${PARENT:+"$PARENT"} "$SELF"; do
        # Skips a degenerate candidate: a PARENT that duplicates SELF, and — load-bearing —
@@ -803,145 +800,14 @@ Otherwise:
 
 ### 3a. Delegating the edit
 
-**The agent that wrote the text is the worst available editor of it.** After a few
-passes you stop reading what is on the page and start reading what you meant. Measured
-on one long documentation loop: the orchestrator fixing its own artifact introduced
-roughly one to two *new* defects per fixing pass across eleven passes — the same claim
-corrected in one file and left standing in its twin (ten times), replacements spliced
-into the middle of a sentence without re-reading (breaking a list and duplicating a
-clause), and absolutes that outran the code. Handed the same kind of findings, a fresh
-implementer applied five of them with zero self-inflicted defects and proactively swept
-eight sibling occurrences the orchestrator had not been asked about.
-
-Treat that as one trial, not a law — by then the artifact was already much cleaner and
-the findings were unusually well specified. The mechanism is probably **freshness plus a
-written finding list**, not the particular model: delegating forces you to state each
-finding precisely enough for someone else to act on, which by itself kills the vague ones.
-
-**The split that works:**
-
-- **You adjudicate.** Verify each finding against source first. Never hand over a finding
-  you have not checked — you would be outsourcing the judgment, not the typing.
-- **The implementer edits**, in a fresh context. A fresh context is also an *ignorant*
-  one: everything it must not do has to be in the prompt, because none of it is in the
-  air. Carry all of:
-  - **The scope, named.** The exact paths it may touch and the tools it may use. An
-    implementer told only "fix these findings" will range further than you meant, and
-    you cannot review what you did not bound.
-  - **Verify before fixing.** Findings are hypotheses; one may be wrong. Say so, or a
-    fresh agent will treat your list as a work order.
-  - **Sweep by concept, not by phrase.** After each fix, search the whole artifact for
-    the same claim stated differently.
-  - **Read back every passage you splice into** — the whole sentence and its
-    neighbours, not the replaced span.
-  - **Use the harness edit tool, not `sed -i` or `str.replace`**, which report success
-    on zero matches. If an edit must be scripted, assert the target exists before
-    replacing, then grep the file for both the new text and the *absence* of the old.
-    This is the repo's standing edit contract (`agents-md`), and it does not travel to
-    a fresh context on its own.
-  - **Add no *unrequested* mechanism** — not "nothing new". A verified finding may
-    genuinely require a lock, a validation, or a transaction; what is forbidden is
-    anything beyond the finding. Scope conflicts come back to you to adjudicate, not
-    resolved by the implementer.
-  - Plus your environment guards.
-- **Tool-managed state is delegable too — through the tool, never the file.** A ticket
-  tracker or database whose on-disk form is a single JSONL line per record is corrupted by
-  hand-editing, so the instinct is to keep those findings yourself. Measured: that instinct
-  cost more than it saved. The orchestrator's own shell command-substituted the backticks
-  in a double-quoted update and silently blanked three field names in a record. Delegating
-  the same work with one rule — *use the CLI, never edit the file* — landed clean and the
-  database still parsed. Name the tool, forbid the file, and require a read-back.
-- **Snapshot first — and non-destructively.** The implementer has write access, and
-  § 1.7 explicitly permits a dirty tree, so plain `git` is *not* your undo: `git checkout
-  .`, `git stash` and `git reset --hard` each discard the user's pre-existing work along
-  with the delegated edit, which § 1.7 forbids.
-
-  Capture **three** things before granting access, and require the capture *commands* to
-  succeed — never their output to be non-empty, since on a clean tree an empty patch is
-  the correct answer:
-
-  - `git diff --cached --binary --no-textconv --no-ext-diff -- <the delegated paths>` and
-    `git diff --binary --no-textconv --no-ext-diff -- <the delegated paths>`, as **two**
-    patches. `--no-ext-diff` because a configured `diff.external` helper is not disabled by
-    `--no-textconv`: measured on git 2.43, a helper emitting `bogus` gave an exit-0 capture
-    of non-patch output that could restore nothing. And `-- :(literal)<path>` for each delegated path at
-    *capture* time — the `:(literal)` magic matters, because a bare pathspec still globs
-    and delegated `a[1].txt` alongside an unrelated dirty `a1.txt` captures both, which
-    then aborts the replay on the hunk step 2 left applied. With literal magic the replay
-    needs no filtering: `git apply --include` takes a **pattern**, and both a
-    bare directory and a literal `a[1].txt` silently match no hunks while exiting 0 — after
-    step 2 has already reverted those paths, which turns a rollback into a loss that reports
-    success. One combined `git diff HEAD` flattens the layers, so an `MM` path
-    comes back ` M` and a later commit carries hunks the user left out. Both flags matter:
-    without `--binary` a modified binary records only "Binary files differ" and will not
-    apply; `--no-textconv` because the conversion is not what is on disk.
-  - `git status --porcelain -z`, NUL-delimited. Porcelain quotes paths that need it, so a
-    `cut`-based parse hands back a literal `"caf\303\251.py"` that does not exist. This
-    is also what restores **intent-to-add** entries (` A `) afterwards: § 1.6's `git add
-    -N` runs only before the first pass, so a file demoted to `??` during a rollback drops
-    out of every later `codex review --base`.
-  - a **byte copy of every pre-existing untracked path in scope** — no patch contains
-    them. Clear each destination before copying and again before restoring: `cp -pR` into
-    an existing directory nests rather than replaces, and exits 0 either way.
-  - an **explicit existence list**: which delegated paths exist right now. Porcelain says
-    nothing about a clean tracked file, so status-absence is *not* an existence test —
-    treating it as one deletes exactly the files that were fine.
-
-  **Refuse the paths this cannot represent.** The capture is a staged diff, an unstaged
-  diff and a byte copy; any state that does not round-trip through those three is out of
-  scope for delegation — take the path out and say so. Known cases: unmerged paths; either
-  endpoint of a **staged rename**, which are one unit (reverting the destination leaves the
-  source staged as deleted and the replay then fails); contents inside a dirty submodule;
-  anything with a byte-transforming `.gitattributes` entry (`git check-attr --all` —
-  `filter`, `text`, `eol`, `working-tree-encoding`); text files under `core.autocrlf`, in **either**
-  `true` or `input` — both convert, with no attribute for `check-attr` to report.
-  Measured: under `true` a mixed CRLF/LF file replayed as all-CRLF from a patch that
-  applied cleanly; under `input` a CRLF worktree against an LF index gave an empty patch
-  for a file `git status` called modified, and the rollback then rewrote it to LF;
-  and files marked `assume-unchanged`,
-  where all three captures *succeed while recording nothing* and the revert then replaces
-  the bytes with `HEAD`. That list is the cases known to hit the rule, not the boundary.
-
-  **To roll back**, undo only the delegated paths and rebuild them from the capture, in
-  this order — anything else reaches for the destructive commands forbidden above:
-
-  1. **delete the delegated paths the implementer created** — those absent from the
-     *existence list*, never those merely absent from porcelain status. A clean tracked
-     file has no status entry, so the status test would delete a file that was fine
-  2. revert **only** the remaining delegated paths; leave every other path untouched
-  3. re-apply the **staged** patch with `git apply --index`, then the **unstaged** one.
-     No `--include` is needed or wanted — the patches were already restricted by pathspec
-     at capture time, which is the only way to scope them without pattern semantics. Not
-     `--cached`: it updates the index
-     "without touching the working tree", so the worktree stays at `HEAD` and the unstaged
-     patch fails against it — measured, `error: patch failed`, after the original was
-     already reverted. Path-restricted capture is also what keeps the replay from touching
-     unrelated hunks that step 2 deliberately left applied — replaying those would abort
-     the whole patch with `patch does not apply` before any delegated path is restored.
-     **Skip an empty patch file** (or pass `--allow-empty`): an
-     unstaged-only edit leaves the staged layer empty and `git apply` exits 128 on it —
-     after the revert, so the layer holding the user's work is never applied
-  4. restore each untracked backup, clearing its destination first
-  5. re-run `git add -N` for every path the status snapshot recorded as `" A "` — a leading
-     space, then `A`; `"A "` is an ordinary staged addition and must not be re-added
-
-  **`git stash create` cannot replace any of this.** It fails outright on the tree § 1.6
-  builds:
-
-  ```console
-  $ git stash create
-  error: Entry 'café.py' not uptodate. Cannot merge.
-  ```
-
-  `git add -N` makes stash refuse outright. And it would not be a drop-in even without
-  that: `stash create` takes no `-u`, so an untracked-only tree yields **no stash object at
-  all** (measured), and a conflicted index is rejected rather than saved. It handles the
-  *tracked-content* cases well — binaries, textconv, index layers — which is the useful
-  half of the comparison, not the whole of it. Anyone proposing the swap should reproduce
-  the error above first.
-
-This is not `rb-lite`. That loop hands over the whole task and reviews the result; this
-hands over *only the edit* for findings you have already verified.
+When using a fresh implementer to apply already-adjudicated findings, load exact
+companion skill
+[`multi-reviewer-loop-delegating-edits`](../multi-reviewer-loop-delegating-edits/SKILL.md)
+first. It owns the scope contract, non-destructive snapshot, refusal cases, and
+exact rollback sequence. This is optional delegation; adjudication remains with
+the orchestrator.
+**Companion unavailable: do not delegate. Apply the adjudicated fixes in the
+orchestrator and continue the loop; do not improvise this delegation procedure.**
 
 ### 4. Stop conditions
 

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -1,25 +1,15 @@
 ---
 name: orchestrating-with-rb-lite
 description: >-
-  Uses `rb-lite` to drive lightweight implement → review loops in the current
-  git repo. Covers one self-contained task on a branch, a serialized `br`
-  backlog drain where each ready bead becomes one branch, one rb-lite run, one
-  work PR, one squash merge, and one bead closure, and a harden-until-clean drive
-  that reviews a whole branch with a codex + Claude reviewer panel, mints beads
-  from the findings, drains them, and re-reviews until clean. Use when the user
-  says "rb-lite", "use rb-lite", "run the rb-lite loop", "iterate on this with
-  rb-lite", "implement this with codex + claude until clean", "review-and-fix
-  loop on this branch", "drain the bead backlog with rb-lite", "solve beads
-  one by one with rb-lite", "harden this branch", "review and solve until
-  clean", "review findings into beads", or asks for an iterative codex+claude
-  review/fix cycle. Prefer `rb-lite` when you want "code → review → fix →
-  repeat → JSON summary" without a durable project orchestrator. When the
-  deliverable IS a test or verification gate — a smoke, integration/regression/
-  property test, or a live end-to-end gate that must actually run green rather
-  than merely be reviewed — use `testing-with-rb-lite` instead (it authors the
-  test with rb-lite and then independently RUNS it, since the panel only reads
-  the test's source). Do NOT use for cross-project orchestration, open-ended
-  planning, or tiny one-shot edits.
+  Drive `rb-lite` implement-review-fix loops in the current git repo. Use for one
+  self-contained branch task, a serialized `br` backlog drain (one bead, branch,
+  rb-lite run, PR, merge, and closure at a time), or a harden-until-clean branch
+  drive that turns codex + Claude findings into beads and drains them. Trigger on
+  "rb-lite", "codex + claude until clean", "review-and-fix loop", "drain the bead
+  backlog", "solve beads one by one", "harden this branch", or "review findings
+  into beads". Use `testing-with-rb-lite` instead when the deliverable is a test or
+  live verification gate that must be independently executed. Do not use for
+  cross-project orchestration, open-ended planning, or tiny one-shot edits.
 compatibility: Requires `rb-lite` on `PATH` or `nix run --refresh github:douglaz/rb-lite -- ...` (use `--refresh` at least once per session so Nix does not reuse an hour-stale cached revision). rb-lite itself has no default implementer, so pass `--implementer` with one preset or a comma-separated cycle, or use `--implement-cmd`; this skill defaults to `--implementer claude,codex` unless the user pins another choice. `codex` and `claude` must be installed and authenticated; the default Claude reviewer needs `jq`, and normal timeout-enabled runs need a compatible `timeout`, either from the host shell for source installs or from the Nix wrapper for Nix installs. This skill's reviewer panel is codex + claude only, set by writing `.rb-lite-reviewers` before the run; rb-lite's built-in default additionally runs Gemini through `npx`, which this skill does not use. Backlog-drain mode also requires `br` (>= 0.1.45), `gh`, and the repo's normal local verification tools; harden-until-clean mode additionally needs `codex` and `claude` for the outer review panel.
 ---
 
@@ -184,11 +174,15 @@ supplies those to the rb-lite process. For source/path installs, check the host 
 If you skip the file, you get rb-lite's built-in three-reviewer default, unpinned Gemini
 included. That is a choice, not a default this skill endorses — make it deliberately.
 
+**Companion unavailable: stop, rerun the same installer command once, reload it, and do
+not improvise this procedure.** This applies to every exact companion handoff below.
+
 Backlog-drain mode additionally needs `br` for bead selection/state, `gh`
 for PR creation/checks/merge, and **`jq` in the HOST shell**. That last one is not
 covered by the Nix-wrapper exemption above: the wrapper supplies `jq` to rb-lite, not
-to you, and step 11's collateral-damage check and its whole recovery resolve the graph's
-real path through `br where --json | jq`. Without host `jq` a drain can run `br update`
+to you. Load exact companion skill `rb-lite-backlog-drain` for
+[step 11's collateral-damage check and recovery](../rb-lite-backlog-drain/SKILL.md#backlog-step-11),
+which resolve the graph's real path through `br where --json | jq`. Without host `jq` a drain can run `br update`
 and flush — silently reverting unrelated bead bodies — and only then fail at the command
 that would have located the damage. Check it before the first bead, not after. Require **`br` ≥ 0.1.45**: older builds corrupt
 their DB after branch resets, so `br update`/`br close` start returning
@@ -268,7 +262,8 @@ ready bead if the queue is not empty, and the exact reason the loop stopped.
   diff) — the panel's `clean` is one input, not the gate. See "Verify the landed
   diff."
 - In backlog-drain mode, one bead equals one branch and one **work** PR. Do not batch
-  unrelated beads into one rb-lite run. The final closure/metadata PR (step 11) is not a
+  unrelated beads into one rb-lite run. The final closure/metadata PR
+  ([exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11)) is not a
   second work PR and is not covered by this rule — it carries bookkeeping only.
 - Pre-existing backlog beads are immutable input. If a bead is ambiguous or
   its acceptance criteria are weak, ask the user before launching rb-lite.
@@ -405,8 +400,8 @@ ready bead if the queue is not empty, and the exact reason the loop stopped.
     "Verify the landed diff" below.
 
     **A mutation that stays green stops this workflow too**, exactly as it stops the
-    backlog drain. Standalone use reaches step 11 straight from here with the diff
-    already committed at (a), so without a stop the uncovered behavior ships and the
+    backlog drain. Standalone use continues to **11. Report concisely** immediately
+    below with the diff already committed at (a), so without a stop the uncovered behavior ships and the
     run reports success. Repair the test, observe both runs, and re-review the repair
     — or report the run as incomplete and name the unpinned behavior.
 
@@ -483,8 +478,9 @@ dogfooding made concrete:
   behavior may PERFORM the harmful operation before any assertion notices — the
   mutation is not a dry run. Use a disposable environment, pick a non-destructive
   mutation, or say plainly that the check could not be done safely. Never run a
-  deliberately broken build against live state; this applies here and in the
-  backlog drain's step 7, not only where the deliverable is a test. A behavior mutation can
+  deliberately broken build against live state; this applies here and in
+  [exact companion skill `rb-lite-backlog-drain`, step 7](../rb-lite-backlog-drain/SKILL.md#backlog-step-7), not only where
+  the deliverable is a test. A behavior mutation can
   trip an initialization error, a panic, or an unrelated assertion long before
   the intended check runs, and taking that as proof of coverage certifies a
   behavior nothing tests. If nothing fails, the loop wrote code the panel
@@ -499,500 +495,10 @@ dogfooding made concrete:
 
 ## Backlog-drain workflow
 
-Use this mode when the user wants to clear an existing `br` backlog with
-rb-lite. The beads are the input; do not invent a fresh work list. Codex is
-operating the queue and PR workflow, while rb-lite handles the inner
-implement → review loop for each bead.
-
-1. **Pick.** Run `br ready --limit 10`. Take the top P0 first; if none,
-   the lowest-numbered P1; only descend to P2 if the user says so or the
-   P1 list is empty / oversized.
-
-2. **Read.** Run `br show <id>` (and `br show <id> --json` if structured
-   fields help). If the acceptance criteria are vague, pause and ask the
-   user before writing the task.
-
-3. **Sync base and branch.** Confirm there is no unrelated dirty work, fetch
-   the selected base, and start the bead from that clean base. Use one branch
-   per bead, e.g. `feat/<bead-id>-<short-slug>`. Let rb-lite create/switch the
-   branch with `--branch` unless the branch already exists and the user
-   explicitly wants to resume it. Do not pile multiple beads onto one branch.
-
-4. **Task file.** Write a focused task file, usually under
-   `.rb-lite/tasks/bead-<id>.md`, using the template below. Keep it outside
-   the committed source diff unless the repo intentionally tracks task
-   files.
-
-5. **Run rb-lite.**
-
-   ```bash
-   rb-lite run \
-     --implementer claude,codex \
-     --task-file .rb-lite/tasks/bead-<id>.md \
-     --base origin/main \
-     --branch feat/<bead-id>-<short-slug> \
-     --run-dir /tmp/rb-lite-<bead-id>-run
-   ```
-
-   If using the nix fallback, prefix the same `run ...` arguments with
-   `nix run --refresh github:douglaz/rb-lite --`.
-
-6. **Read the JSON summary.** Exit `0` with status `clean` means the panel
-   had no P0/P1/P2 findings. For exit `10`, `11`, `12`, `13`, or `70`, use
-   the rb-lite diagnosis table below and inspect the run artifacts before
-   deciding whether to rerun, fix manually, or file a dogfood bead.
-
-7. **Run local gates.** Use the repo's own verification contract. In the
-   Rust/Nix repos this skill was built for, the default gate set is:
-
-   ```bash
-   nix develop -c cargo fmt --check
-   nix develop -c cargo clippy --locked -- -D warnings
-   nix develop -c cargo test --locked --features test-stub
-   nix build
-   ```
-
-   Treat real failures as part of the bead. Treat pre-existing flakiness as
-   a separate bead; don't hand-tune the branch to hide a flaky CI failure.
-
-   **These gates were already green before the bead, so passing them proves
-   nothing about it.** For **each** load-bearing behavior the bead introduces —
-   a new invariant, an ordering, a clock or lock choice — invert it in the
-   working tree, one at a time, and confirm the assertion that pins *that*
-   behavior goes red; then revert. Read the failure rather than just observing
-   one: a mutation that trips an initialization error or an unrelated assertion
-   proves nothing, and a mutation that changes no test outcome means the drain
-   shipped a behavior nothing covers.
-
-   **Protect the accepted diff before you invert anything.** rb-lite leaves its
-   changes UNCOMMITTED until step 8, so the obvious way to undo a mutation —
-   `git restore <file>` / `git checkout -- <file>` — discards rb-lite's accepted
-   implementation in that file along with your inversion. The gates ran before the
-   mutation and nothing re-runs after the revert, so step 8 would commit and push
-   a tree missing part of the work. Commit or stash the accepted diff first, or
-   mutate in a scratch copy — not "revert and re-run green". When the accepted fix and a
-   regression test sit in the same file, the file-level restore removes both and the suite
-   then passes *because* the test that would expose the loss is gone. Verify by diffing the
-   restored tree against the preserved diff, not by trusting a green run.
-
-   **A mutation that stays green STOPS the drain — it is not a note to carry into
-   step 8.** Diagnosing an uncovered behavior and then committing anyway ships
-   exactly what the check was added to catch, and step 8 pushes immediately, so
-   there is no later point that is cheaper. Add or repair the test that pins the
-   behavior, observe its red run against the inverted code AND its green run
-   against the correct code, and only then continue.
-
-   **That repair was never reviewed.** rb-lite returned its verdict on the tree
-   before you touched it, and step 9's SHA guard assumes local `HEAD` is the tree
-   the panel read — which it no longer is. Red/green proves the test detects the
-   behavior; it says nothing about the test's cleanup, isolation, or fixtures.
-   Neither obvious continuation is allowed here, which is the real problem: a second
-   rb-lite run breaks the one-bead/one-run invariant, and carrying it forward reaches
-   step 9's SHA guard, which asserts local `HEAD` is the tree rb-lite reviewed. So take
-   the third path — **stop the drain and track the repair as its own work**, on its own
-   branch with its own review. If the repair is small enough to belong to this bead, a
-   separate reviewer pass over the amended tree is the only in-band option; say which you
-   chose. Do not let it ride out on a clean verdict that predates it, and do not pretend
-   a second rb-lite run is permitted. If you cannot pin it — the
-   behavior is not reachable from a test, or the fix is out of the bead's scope —
-   say so and stop; that is a finding about the bead, not a formality to wave
-   through. Full rationale in "Verify the landed diff".
-
-8. **Commit, push, PR.** Add only intentional source/docs/config changes and
-   any bead-state sync files the repo expects. Do not commit `.rb-lite/` run
-   artifacts. Commit with a real message, push, and create a PR with a body
-   that includes the bead id, rb-lite status/rounds, and local test plan.
-
-9. **CI.** Capture the head *before* waiting, then wait for green:
-
-    ```bash
-    # Persisted to a file, not just a shell variable. Steps 9 and 10 usually run as
-    # separate tool calls, so a variable set here is gone by the merge — and the guard
-    # there would then abort a correct drain with "local HEAD moved". Under the git dir,
-    # so it is per-checkout and never committed (ADR 0001).
-    # Probe both repositories: a fork can host its own PR, and a colliding number in the
-    # parent can otherwise make the drain watch checks for somebody else's tree.
-    # Guarded: a failed parent lookup is not "not a fork" — it silently drops the one
-    # candidate whose same-number PR the ambiguity refusal below exists to catch.
-    SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
-      || { echo "cannot resolve this repository"; exit 1; }
-    PARENT=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
-      || { echo "cannot resolve the parent repository — a PR there would be invisible"; exit 1; }
-    LOCAL_HEAD=$(git rev-parse HEAD)
-    # Both repos matching is ambiguous, not a tiebreak: the same branch can be opened as a
-    # PR against the parent AND the fork, and picking the parent silently can watch and
-    # merge a PR the drain never gated. Refuse; pin the intended repo in every -R instead.
-    # And a FAILED query is not a miss: "no such PR" is read out of gh's own error text,
-    # because a transient failure treated as absence erases one candidate — and with it
-    # the refusal — leaving the drain watching whichever PR the outage left visible.
-    # PullRequest-level not-found only: both candidates are repos the API just named, so
-    # a Repository-level "could not resolve" or an HTTP 404 is lost access, not absence.
-    _GH_ERR=$(mktemp); trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it || { echo "mktemp failed"; exit 1; }
-    R=""; _M=0
-    for _r in ${PARENT:+"$PARENT"} "$SELF"; do
-      if ! _h=$(gh pr view <pr> -R "$_r" --json headRefOid -q .headRefOid 2>"$_GH_ERR"); then
-        grep -qiE 'could not resolve to a pullrequest|no pull requests found' "$_GH_ERR" \
-          || { echo "cannot query PR <pr> in $_r — absence not established"; exit 1; }
-        _h=""
-      fi
-      if [ "$_h" = "$LOCAL_HEAD" ]; then _M=$((_M+1)); [ -n "$R" ] || R="$_r"; fi
-    done
-    [ "$_M" -le 1 ] || { echo "PR <pr> matches this head in BOTH $PARENT and $SELF — ambiguous"; exit 1; }
-    [ -n "$R" ] || { echo "cannot find PR <pr> for local HEAD"; exit 1; }
-    MERGING_SHA=$(gh pr view <pr> -R "$R" --json headRefOid -q .headRefOid)
-    [ -n "$MERGING_SHA" ] || { echo "cannot resolve the PR head"; exit 1; }
-    printf '%s\n' "$MERGING_SHA" > "$(git rev-parse --git-path rb-lite-merging-sha)"
-    # Bind it to the commit that was actually reviewed. The remote head is only the right
-    # thing to merge if it IS your local HEAD — the tree rb-lite ran on and step 7's gates
-    # passed on. If the branch moved since step 8, green CI would otherwise merge code no
-    # panel and no gate ever saw.
-    [ "$MERGING_SHA" = "$(git rev-parse HEAD)" ] \
-      || { echo "PR head $MERGING_SHA is not the reviewed local HEAD — re-run the panel"; exit 1; }
-    gh pr checks <pr> -R "$R" --watch
-    ```
-
-   Capture first, because the SHA is what makes the pin mean anything. Reading it
-   *after* the checks pass adopts whatever is there then — so a force-push landing
-   between green CI and the merge gets pinned to itself and sails through the very
-   guard meant to catch it. Pinning the pre-CI SHA makes GitHub reject the merge
-   instead; rerun the checks against the new head and try again.
-
-   On known-flaky CI, rerun failed jobs via `gh run rerun <id> --failed`; do not
-   keep changing product code just to dodge a flake.
-
-10. **Merge and reset.** Squash-merge the PR, delete the branch, then reset local state
-    to *where the merge landed* — not to `origin`, which on a fork is your own copy — and rerun the
-    authoritative build gate before taking the next bead:
-
-    ```bash
-    # Read the step-9 pin before resolving the host. Matching the PR against that SHA keeps
-    # a same-number PR in the parent from winning when the real PR is owned by the fork.
-    MERGING_SHA=$(cat "$(git rev-parse --git-path rb-lite-merging-sha)" 2>/dev/null || echo "")
-    [ -n "$MERGING_SHA" ] || { echo "no pinned SHA — re-run step 9"; exit 1; }
-    SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
-      || { echo "cannot resolve this repository"; exit 1; }
-    PARENT=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
-      || { echo "cannot resolve the parent repository — a PR there would be invisible"; exit 1; }
-    # Same ambiguity rule as step 9: both repos carrying PR <pr> at the pinned SHA means
-    # two distinct PRs, and merging the parent's silently can land the one nobody gated.
-    # Same absence rule too: only gh's own "no such PR" counts as a miss — a transient
-    # failure treated as one hides the second match and merges the survivor. And only the
-    # PullRequest-level text: a Repository-level "could not resolve" or an HTTP 404 on a
-    # repo the API just named is lost access, not absence.
-    _GH_ERR=$(mktemp); trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it || { echo "mktemp failed"; exit 1; }
-    R=""; _M=0
-    for _r in ${PARENT:+"$PARENT"} "$SELF"; do
-      if ! _h=$(gh pr view <pr> -R "$_r" --json headRefOid -q .headRefOid 2>"$_GH_ERR"); then
-        grep -qiE 'could not resolve to a pullrequest|no pull requests found' "$_GH_ERR" \
-          || { echo "cannot query PR <pr> in $_r — absence not established; do NOT merge"; exit 1; }
-        _h=""
-      fi
-      if [ "$_h" = "$MERGING_SHA" ]; then _M=$((_M+1)); [ -n "$R" ] || R="$_r"; fi
-    done
-    [ "$_M" -le 1 ] || { echo "PR <pr> matches the pinned SHA in BOTH $PARENT and $SELF — ambiguous"; exit 1; }
-    [ -n "$R" ] || { echo "cannot find PR <pr> for the pinned SHA"; exit 1; }
-    PR_REFS=$(gh pr view <pr> -R "$R" --json baseRefName,headRefName) \
-      || { echo "cannot resolve the PR branches"; exit 1; }
-    BASE=$(printf %s "$PR_REFS" | jq -r '.baseRefName // ""')
-    HEAD_BRANCH=$(printf %s "$PR_REFS" | jq -r '.headRefName // ""')
-    [ -n "$BASE" ] && [ -n "$HEAD_BRANCH" ] \
-      || { echo "cannot resolve the PR branches"; exit 1; }
-    # Check the merge's exit status. `--delete-branch` makes gh switch branches as a side
-    # effect, so a FAILED merge still leaves you somewhere plausible-looking — and step 11
-    # then closes the bead for a merge that never happened, which is the exact state this
-    # skill's reviewed-closure path exists to prevent.
-    # The base moves while a bead is built and reviewed, and --match-head-commit pins only
-    # the HEAD — a squash replays onto the CURRENT base, so a behind branch lands a
-    # composition nobody reviewed while every SHA still matches. Fetch the live base and
-    # test ancestry before merging, the same way pr-with-codex-bot-review § 8 does.
-    # gh's own clone URL: `owner/repo` alone points at public github.com, which on GitHub
-    # Enterprise either fails or resolves an unrelated public repo of the same name.
-    R_URL=$(gh repo view "$R" --json url -q .url 2>/dev/null) \
-  || { echo "cannot resolve the clone URL for $R — do NOT merge"; exit 1; }
-    git fetch "$R_URL.git" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
-      || { echo "cannot fetch the merge target — base unknown, do NOT merge"; echo "  (on a private repo cloned over SSH this is usually missing git credentials for https, not a missing base)"; exit 1; }
-    # Against $MERGING_SHA, not HEAD: that is the commit --match-head-commit pins and the
-    # one GitHub will squash. A local rebase during CI that was never pushed would make
-    # HEAD pass this test while the pinned remote SHA is still behind the base.
-    [ "$MERGING_SHA" = "$(git rev-parse HEAD)" ] \
-      || { echo "local HEAD moved since step 9 — re-run the panel and the checks"; exit 1; }
-    git merge-base --is-ancestor "refs/remotes/upstream/$BASE" "$MERGING_SHA" \
-      || { echo "REBASE FIRST — $BASE advanced since the review"; exit 1; }
-    # LAST, immediately before the merge, for the reason pr-with-codex-bot-review § 8 gives
-    # at the same spot: ancestry answers "did $BASE advance", never "is $BASE still the
-    # target". A retarget points the PR at a different branch, leaving every check above
-    # validating the old one while gh squashes onto the new one — and the head never moves,
-    # so --match-head-commit stays satisfied. Read here, not earlier: each check between
-    # this read and the merge widens the window. It cannot reach zero (GitHub has no base
-    # pin), but it is one API call wide.
-    BASE_NOW=$(gh pr view <pr> -R "$R" --json baseRefName -q .baseRefName) \
-      || { echo "cannot re-read the merge target — do NOT merge"; exit 1; }
-    [ -n "$BASE_NOW" ] && [ "$BASE_NOW" = "$BASE" ] \
-      || { echo "the PR was retargeted ($BASE -> ${BASE_NOW:-unknown}) — the panel reviewed against $BASE; re-run the panel"; exit 1; }
-    gh pr merge <pr> -R "$R" --squash --delete-branch --match-head-commit "$MERGING_SHA" \
-      || { echo "merge did not land — do NOT close the bead"; exit 1; }
-
-    # `gh pr merge` returning 0 means the PR was accepted for merging — which, in a repo with a
-    # required merge queue, means ENQUEUED, not landed. Fetching now would read the still-old
-    # base and any caller that closes a tracker item here would close it for a merge that has
-    # not happened. Wait for the state to actually reach MERGED.
-    _n=0
-    while [ "$_n" -lt 60 ]; do
-      _n=$((_n+1))
-      _ST=$(gh pr view <pr> -R "$R" --json state -q .state 2>/dev/null || echo "")
-      [ "$_ST" = "MERGED" ] && break
-      [ "$_ST" = "CLOSED" ] && { echo "PR was closed without merging"; exit 1; }
-      sleep 10
-    done
-    [ "$_ST" = "MERGED" ] || { echo "PR still not merged (state=$_ST) — do NOT proceed"; exit 1; }
-
-    # Reset from where the merge LANDED. On a fork clone `origin` is your fork and does
-    # not contain the upstream squash commit, so resetting to origin/$BASE silently starts
-    # the next bead from a tree missing the one just merged — its PR then replays or
-    # conflicts with it.
-    # gh's own clone URL: `owner/repo` alone points at public github.com, which on GitHub
-    # Enterprise either fails or resolves an unrelated public repo of the same name.
-    R_URL=$(gh repo view "$R" --json url -q .url 2>/dev/null) \
-  || { echo "cannot resolve the clone URL for $R — do NOT merge"; exit 1; }
-    git fetch "$R_URL.git" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
-      || { echo "cannot fetch the merge target"; echo "  (on a private repo cloned over SSH this is usually missing git credentials for https, not a missing base)"; exit 1; }
-    # `checkout -B` moves the branch ref unconditionally, and a clean worktree does not
-    # protect committed work: any local commit on $BASE that upstream lacks becomes
-    # unreachable. A same-name fork PR is different: local $BASE is the feature head, and
-    # the squash commit cannot contain it. Allow only the verified, pinned PR head itself;
-    # a later local commit still refuses the reset.
-    if git show-ref --verify --quiet "refs/heads/$BASE" \
-       && ! git merge-base --is-ancestor "$BASE" "refs/remotes/upstream/$BASE"; then
-      if [ "$HEAD_BRANCH" != "$BASE" ] \
-         || [ "$(git rev-parse "refs/heads/$BASE")" != "$MERGING_SHA" ]; then
-        echo "local $BASE has commits upstream does not — refusing to reset; rebase or push them first"
-        exit 1
-      fi
-    fi
-    # Refuse a dirty worktree HERE, immediately before the reset: the merge-queue wait
-    # above can run ten minutes, and `checkout -B` silently CARRIES any nonconflicting
-    # tracked modification onto the fresh base — the build below then passes and the next
-    # bead inherits work that was never on this branch. FULL status, untracked included:
-    # checkout does not move an untracked file, but it does not remove it either, so a
-    # file created during the wait sits in the "fresh" base worktree where the build and
-    # the next bead's branch inherit it — unreviewed, and invisible to `-uno`.
-    _WT=$(git status --porcelain) || { echo "cannot read the worktree — not resetting"; exit 1; }
-    [ -z "$_WT" ] || { echo "worktree changed while waiting for the merge — resolve that before resetting to $BASE"; exit 1; }
-    git checkout -B "$BASE" "refs/remotes/upstream/$BASE" \
-      || { echo "cannot reset to the merge target"; exit 1; }
-    nix build
-    ```
-
-    Substitute `master` only when the repo actually uses `master`.
-
-11. **Close the bead, through a reviewed path.** Run `br update <bead-id> -s closed`
-    after the merged code is present on the base branch. That write lands in the
-    tracked `.beads/*.jsonl`, so do **not** commit it straight to the default branch —
-    it would reach the branch unreviewed. Carry the closure commit into the next bead's
-    branch, where it rides that PR; when the queue is empty and there is no next branch,
-    open one small metadata PR for it **and land it** — carry it through review and merge
-    like any other. Opening it is not enough: until it merges, the closure never reaches
-    the default branch and a fresh clone still shows the bead open, which is the failure
-    this reviewed path exists to prevent. The drain is not done until that PR is merged. Do not leave it uncommitted either, or the next
-    run starts from a dirty base and silently carries the previous closure into its diff.
-
-    **Give the PR body a machine-readable marker line, one per bead it closes:**
-
-    ```text
-    bead-closure: <bead-id>
-    ```
-
-    Step 8 puts the bead id in every ordinary work PR body too, so the id alone cannot
-    distinguish "the work merged" from "the closure merged" — and step 12's resume
-    discovery depends on telling them apart. The marker is what it filters on.
-
-    Verify it landed with a checked *explicit* sync: it propagates a real exit code, which
-    the automatic flush after `br update` does not — that one swallows its error. The
-    mutation is already in the shared DB, so the sync either writes it out or fails loudly:
-
-    ```bash
-    # DIVERGENCE CHECK FIRST — `br update` auto-flushes, so an unstaged hand-edit in the
-    # JSONL is destroyed by this very command, and neither the index nor HEAD holds it.
-        _bw=$(br where --json) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
-        BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
-    # Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so a FAILED
-    # inspection reads as a clean tree and lets the write through — the guard failing open at
-    # exactly the moment it matters. Compare against HEAD, not the index: a damaged JSONL that
-    # is staged leaves a worktree-vs-index diff empty while HEAD holds the good bodies.
-    _st=$(git status --porcelain -- "$BEADS_JSONL") \
-      || { echo "cannot read the worktree — do NOT write"; exit 1; }
-    [ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
-      echo "JSONL differs from HEAD — read that diff and resolve it BEFORE writing"; exit 1; }
-    br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
-    br sync --flush-only || { echo "not persisted"; exit 1; }
-    ```
-
-    **Check for divergence BEFORE the first `br` write.** `br update` auto-flushes, so a
-    hand-edit sitting unstaged in the JSONL is destroyed by the very first mutation — and
-    since neither the index nor `HEAD` holds it, every later diff shows only your intended
-    change, which makes the loss *undetectable*, not merely unrecoverable. Resolve the real
-    path (`br where --json | jq -er .jsonl_path`; `.beads/issues.jsonl` is only the default
-    layout, and a hardcoded path diffs nothing on a `.beads.jsonl` repo — a false
-    all-clear) and run `git status --porcelain` on it before any `br` command.
-
-    **That sync proves the closure reached the file. It says nothing about what else the
-    same write overwrote.** Every `br` write flushes the whole gitignored cache over the
-    tracked JSONL, so a write to **one** bead rewrites **all** of them, and any body the
-    cache holds a stale copy of is reverted. Observed on `br 0.2.19`: closing a single bead
-    silently reverted ~40 KB of specification text across three *other* beads and deleted a
-    fourth. Exit 0, success message, nothing failed. This step is the last write of every
-    bead, which is how the drain routes you into it every time.
-
-    Hand-editing the JSONL is what makes the cache stale — a hand edit does not advance
-    `updated_at`, so cache and file hold different bodies under identical timestamps and
-    nothing can tell them apart. **Write bead text through `br update -d/--notes`, never
-    the file.** The task template's ".beads/ is orchestration state" line is a *reviewing*
-    scope rule, not an editing licence. And the advertised guard does not help: `br sync
-    --help`'s "Stale DB Guard" is an **id**-level check, so same-id-different-body — the
-    case that loses text — is unguarded by design.
-
-    So field-diff the resolved path before committing any `br` write. A full-file
-    re-serialization with every id on both sides is normal; ids on only one side, or a
-    `description` you did not touch, is the tell.
-
-    **Recovery depends on which side holds the good text, and guessing cements the loss.**
-
-    - **(a) cache stale, file still good** — rebuild the cache from the file.
-      `br sync --import-only` alone cannot do it: it compares `updated_at`, so equal
-      timestamps with different bodies report `Skipped: N (up-to-date)` forever. The stale
-      DB has to go first.
-    - **(b) the flush already ran and the diff shows damage** — the working copy *is* the
-      damaged artifact. Restore it from the good side, **rebuild the cache**, and only then
-      replay: replaying first lets the still-stale cache auto-flush over what you just
-      restored. Read `git diff --cached` and `git diff` and decide explicitly which of
-      the index or `HEAD` holds the good bodies; a staged copy only proves a choice exists,
-      and an earlier flush may have been staged before anyone noticed.
-
-    Four things the recipe must do in both cases, each learned by getting it wrong: back up
-    the cache and **check the copy succeeded**; **verify the DB and its `-wal`/`-shm`
-    siblings are actually gone** (`rm -f` is silent on a permissions failure, and a
-    surviving cache makes the import skip equal-timestamp records and report success);
-    **check the import and the replay before any flush** (the stale DB is already deleted,
-    so a failed import leaves an empty one and the flush writes *that* over what you just
-    restored); and **rebuild the cache BEFORE replaying anything** — restore, delete and
-    re-import the DB, and only then replay. Restoring the file and replaying straight away
-    lets the first `br` command auto-flush the *still-stale* cache over what you just
-    restored, destroying the recovery with the recovery. And **replay the complete intended
-    delta**, not one command: the drain's case is a single closure, but
-    `plan-to-beads-transfer` and `bead-polish-loop` batch, so restoring from git there
-    discards their legitimate work unless the whole manifest is replayed.
-
-    **A round summary is not a replay manifest.** It records what you decided, not the
-    generated ids, the exact field values, or the order they were written in — and recovery
-    discards the working JSONL before you can go back and read them off it. So batching
-    callers must write the manifest *before* the first mutation: one line per intended `br`
-    command, complete enough to re-run verbatim. A coverage matrix or a round summary
-    reconstructed afterwards is a description of the work, not a copy of it.
-
-    Git is the whole recovery, which is why the field-diff must happen **before** you stage
-    anything: an uncommitted hand-edit that a flush overwrote is simply gone. That is the
-    sharpest reason never to write bead text through the file.
-
-    This is **not** the pre-0.1.45 corruption bug in "Tool dependencies": no
-    `ISSUE_NOT_FOUND`, no branch reset, and every command reported success.
-
-    Closing on the feature branch before the merge is **not** a safe shortcut, however
-    transactional it looks — the beads DB is shared across branches with no git
-    awareness, and import is last-write-wins, so the closure leaks. See
-    `docs/adr/0003-bead-closure-stays-post-merge.md` for the code evidence.
-
-12. **Loop.** Return to `br ready --limit 10` — but **on a resumed drain, look for an
-    in-flight closure PR before selecting work.** A closure lives on its metadata branch
-    until it merges, so a fresh clone of the default branch sees the old JSONL with the
-    bead still open and will happily rebuild and re-merge work that is already done. The
-    queue cannot tell you this; only the forge can:
-
-    ```bash
-    SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
-      || { echo "cannot resolve this repository — closure-PR discovery is incomplete"; exit 1; }
-    PARENT=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
-      || { echo "cannot resolve the parent repository — closure-PR discovery is incomplete"; exit 1; }
-    CLOSURE_PRS=()
-    for UP in ${PARENT:+"$PARENT"} "$SELF"; do
-      # `url` is not decoration: this loop MERGES parent and fork results, and a bare
-      # `number` is ambiguous across them — #42 exists in both. Acting on a parent hit with
-      # the fork's `-R` opens an unrelated same-numbered PR. The url carries the repository.
-      _PRS=$(gh pr list -R "$UP" --state all --limit 1000 --json number,state,headRefName,title,body,url) \
-        || { echo "cannot query closure PRs in $UP — do not resume work from partial results"; exit 1; }
-      CLOSURE_PRS+=("$_PRS")
-      # 1000 is a CAP, not "all of them". With more newer PRs than that, the older closure
-      # or work PR this recovery exists to find falls outside the snapshot, both filters
-      # come back empty, and the drain rebuilds work that already merged. A saturated page
-      # is the only case where anything can hide, so pay for the search only then.
-      if [ "$(printf '%s' "$_PRS" | jq 'length')" -ge 1000 ]; then
-        _MORE=$(gh pr list -R "$UP" --state all --limit 1000 --search "$BEAD_ID in:body" \
-                  --json number,state,headRefName,title,body,url) \
-          || { echo "closure search in $UP failed — do not resume from partial results"; exit 1; }
-        CLOSURE_PRS+=("$_MORE")
-      fi
-    done
-    printf '%s\n' "${CLOSURE_PRS[@]}" \
-      | jq -s --arg id "$BEAD_ID" 'add | unique_by(.url) | .[] | select($id != "" and ((.body // "") | ascii_downcase
-        | test("(^|\\r|\\n)[[:space:]]*bead-closure:[[:space:]]*" + ($id|ascii_downcase|gsub("\\.";"\\.")) + "[[:space:]]*(\\r|\\n|$)")))'
-    # SAME shell, same snapshot: the bead's work PRs, MERGED **or still OPEN**. Consulted
-    # whenever the marker query above is empty — see below. MERGED-only hid the third
-    # resume state: a work PR opened but not yet landed carries the bead id and no
-    # `bead-closure:` marker, so neither query saw it and the drain re-entered step 6 to
-    # rebuild work that was already open for review. Run separately this would re-fetch,
-    # and a fetch that failed here while the marker query succeeded would silently read as
-    # "nothing merged", the exact collapse this query exists to close.
-    printf '%s\n' "${CLOSURE_PRS[@]}" \
-      | jq -s --arg id "$BEAD_ID" 'add | unique_by(.url) | .[] | select(.state=="MERGED" or .state=="OPEN")
-          | select($id != "" and ((.body // "") | ascii_downcase
-            | test("(^|[^a-z0-9._-])" + ($id|ascii_downcase|gsub("\\.";"\\.")) + "([^a-z0-9._-]|$)")))'
-    ```
-
-    `BEAD_ID` is the bead you are about to take — loop this query over each open bead from
-    `br ready`/`br list` rather than assuming a variable survived the clone. Empty, the
-    filter rejects everything and the closure PR this exists to find is missed.
-
-    Keyed on the **`bead-closure:` marker plus the bead id**, not on the id alone: step 8
-    puts the id in every ordinary work PR body, so an id-only filter returns the merged
-    work PR for any bead whose work landed — which on a fresh clone looks exactly like
-    closure history when no closure was ever opened, and defeats the guard. Not a
-    branch-naming convention either — nothing mandates one. The raised `--limit` matters
-    because `gh pr list` returns 30 by default — an older closure PR hides behind newer
-    work PRs, which is the resume case this exists for.
-
-    **An empty result from the marker query answers only "no closure PR was opened" — it
-    is NOT evidence that nothing merged.** A drain that stops between step 10's merge and
-    step 11's closure PR leaves exactly that state: the work merged, the bead still open
-    in the JSONL, and no marker anywhere for the first query to find. Reading empty as
-    "unfinished" there rebuilds and re-merges code already on the base. The second query
-    in the block is what tells those apart: it asks the same snapshot whether the bead's
-    WORK already merged.
-
-    Read any hit before acting on it. **Take the repository from the hit's `url`, never
-    from the number alone** — these results merge the parent's PRs with the fork's, and
-    #42 exists in both; a parent hit acted on with the fork's `-R` lands you on an
-    unrelated PR. Then **read its `state` — it names where to resume**. `MERGED`: a merged PR carrying the id is almost certainly the work PR, and
-    the bead open in the default branch's JSONL beside it is precisely the interrupted
-    state; do **not** rebuild the bead, its code is on the base — resume at step 11, close
-    the bead and land the closure PR. `OPEN`: the work PR is up and has not landed, so
-    resume *that* PR's review-and-merge flow at step 9 rather than rebuilding — a rebuild
-    here races an open review and lands the bead twice.
-
-    Only when *both* queries are empty does "not started" stand, which is a narrower claim
-    than the "not started *or* not merged" this once read as — that phrasing quietly
-    folded the OPEN work PR into the same answer. On a drain older than these markers and
-    id-carrying bodies, even that needs the hits read by hand, because neither convention
-    was in force when its PRs were written.
-
-    An OPEN one: land it before taking another bead. A CLOSED-but-unmerged one is worse — the
-    work PR already merged, the closure never did, and `--state open` cannot see it: reopen
-    or replace it rather than rebuilding the bead. `drive`'s resume checklist does
-    the same discovery for the same reason (`skills/drive/references/phases.md` § LAND).
-
-    Stop when the queue is empty **and** any
-    final metadata PR from step 11 has merged — an open closure PR means the drain is
-    still in flight, however empty the queue looks. Also stop when
-    the user says stop, a bead needs human product/security judgment, or a
-    P0/P1 dogfood bead interrupts the queue.
+Load exact companion skill
+[`rb-lite-backlog-drain`](../rb-lite-backlog-drain/SKILL.md) before starting this
+mode. It owns the complete 12-step pick → branch → rb-lite → gate → PR →
+merge → bead-close → resume procedure; the general rules in this file still apply.
 
 ## Harden-until-clean drive
 
@@ -1085,7 +591,8 @@ phrases like "X happens when Y", not only test function names.>
   `.beads/` as orchestration/state directories, not product code to review.
   That is a *reviewing* scope rule, not an editing licence — nobody, implementer
   or operator, hand-edits `.beads/issues.jsonl`; bead text is written with
-  `br update -d/--notes` or it gets silently reverted by the next flush (step 11).
+  `br update -d/--notes` or it gets silently reverted by the next flush
+  ([exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11)).
   This does NOT forbid ordinary git usage: **`git add` any new SOURCE file you
   create** so it appears in the reviewed diff (`git diff <base>` omits untracked
   files — an unstaged new module reads to reviewers as "missing, won't compile").

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -286,13 +286,14 @@ _st=$(git status --porcelain -- "$BEADS_JSONL") \
 printf '%s' "$_st"
 ```
 
-If it is not empty, resolve it first — recovery
-case (a) in [orchestrating-with-rb-lite](../SKILL.md) step 11. After the first flush the choice
+If it is not empty, resolve it first — recovery case (a) in
+[exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11). After the first flush the choice
 is gone.
 
 **Start a replay manifest before minting.** Section 3 runs one `br create` per finding,
-each auto-flushing, and the damage check comes after all of them. If it fires, step 11's
-recovery deletes the cache and requires every intended mutation replayed — so record the
+each auto-flushing, and the damage check comes after all of them. If it fires,
+[exact companion skill `rb-lite-backlog-drain`, step 11 recovery](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11) deletes the cache
+and requires every intended mutation replayed — so record the
 `br` commands with their generated ids and field values as you go. Without it, restoring
 the good JSONL discards the whole iteration's legitimate bead additions.
 
@@ -369,15 +370,16 @@ field-level changes: a full re-serialization with every id on both sides is
 normal; ids on only one side, or a `description` this iteration did not write, is
 the tell. Never hand-edit the JSONL — that is what makes the cache stale, since a
 hand edit does not advance `updated_at`. Recovery is in
-[SKILL.md](../SKILL.md) step 11.
+[exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
 
 If the iteration ran degraded, say which reviewer was missing in that commit
 message. Months later it explains why iteration N looks thin.
 
 ## 4. Drain the beads
 
-Hand off to the **Backlog-drain workflow** in the main skill and follow it
-exactly: one bead, one branch, one rb-lite run, local gates, one **work** PR, one
+Hand off to exact companion skill
+[`rb-lite-backlog-drain`](../../rb-lite-backlog-drain/SKILL.md) and follow it exactly:
+one bead, one branch, one rb-lite run, local gates, one **work** PR, one
 squash merge, one `br close`. (Closing the last bead in a scope needs its own small
 metadata PR — that is bookkeeping, not a second work PR, and the rule still holds.) Nothing about draining changes here.
 
@@ -388,11 +390,13 @@ Two rules from the drain workflow matter more in this mode than usual:
 - **Evidence-first closure.** The closure has to say which merge satisfied the bead:
   put the merge SHA and PR number in the **closure commit message**. `br close` also
   takes `--reason`, but the drain path closes with `br update <id> -s closed` for the
-  flush behaviour the main skill explains — so the commit message is where this
-  evidence reliably lands. A bead closed without the merged fix just reappears in the
-  next review, and you will not know why.
+  flush behaviour that
+  [exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11)
+  explains — so the commit message is where this evidence reliably lands. A bead closed
+  without the merged fix just reappears in the next review, and you will not know why.
   The `bead-closure: <bead-id>` marker is a SEPARATE obligation and does not move here:
-  step 12's recovery query reads each PR's `.body` and nothing else, so a marker left
+  [exact companion skill `rb-lite-backlog-drain`, step 12 recovery](../../rb-lite-backlog-drain/SKILL.md#backlog-step-12) reads each
+  PR's `.body` and nothing else, so a marker left
   only in the commit message is invisible to a fresh clone — which is the state that
   rebuilds merged work. Evidence in the commit message, marker in the PR body, both.
 

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -65,8 +65,11 @@ _st=$(git status --porcelain -- "$BEADS_JSONL") \
 printf '%s' "$_st"
 ```
 
-If it is not empty, resolve it first — recovery
-case (a) in [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11. After the first flush the choice
+If it is not empty, resolve it first — recovery case (a) in
+[exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
+**Companion unavailable: stop, rerun the same installer command once, reload it, and do
+not improvise this procedure.**
+After the first flush the choice
 is gone.
 
 ## Translation readiness test
@@ -150,7 +153,7 @@ order.
     hardcoded path diffs nothing on the others) — ids on only one side, or a
     `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
     cannot do it, is in
-    [orchestrating-with-rb-lite](../orchestrating-with-rb-lite/SKILL.md) step 11 — but note
+    [exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11) — but note
     its replay step assumes a SINGLE mutation, the drain's case. A transfer has a whole
     graph in flight, so enumerate the complete intended delta (the replay manifest you started before step 4 —
     NOT the coverage matrix, which maps plan elements to beads and preserves no ids, field

--- a/skills/pr-with-codex-bot-review-merge/SKILL.md
+++ b/skills/pr-with-codex-bot-review-merge/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: pr-with-codex-bot-review-merge
+description: >-
+  Internal companion procedure for the final squash-merge and safe cleanup phase
+  of pr-with-codex-bot-review. Load this exact skill only when the owning skill
+  directs you here; it is not a standalone PR workflow.
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Skill
+---
+
+# Squash-merge and clean up
+
+The required merge and local-reset sequence after § 7 has admitted a PR.
+Run it as written; it deliberately re-checks mutable forge and worktree state.
+
+## Contents
+
+- Verify a clean worktree and identify the one PR matching the reviewed head
+- Re-run `bot-gate` and retain the reviewed tip and JSON evidence
+- Fetch and verify the base, then detect a late PR retarget
+- Squash-merge with the reviewed full OID and wait for `MERGED`
+- Preserve merge evidence, fetch the landed base, and refuse unsafe resets
+- Reset the local base and run its authoritative build
+
+```bash
+# Two checks, because a FAILED `git status` also prints nothing: a corrupt index would
+# read as a clean tree, in the merging direction.
+_ST=$(git status --porcelain) || { echo "cannot read the worktree — do NOT merge"; exit 1; }
+[ -z "$_ST" ] || { echo "tree dirty — do NOT merge"; exit 1; }
+# Resolve by matching HEAD, not by preferring the parent. A fork can host its own PRs, and
+# both repos can carry PR number N — so parent-first targets a missing or unrelated PR and
+# the real one can never be landed. `bot-gate` resolves the same way for the same reason.
+# BOTH matching is ambiguous, not a tiebreak: the same branch can be opened as a PR against
+# the parent AND the fork, and the two PRs were gated separately — silently merging the
+# parent's can land a PR whose reviews nobody checked. Refuse and make the caller say
+# which repo.
+# Guarded, because a failed lookup is not an answer: an unguarded SELF empties the loop's
+# only sure candidate, and a failed parent lookup silently reads as "not a fork" — dropping
+# the very candidate whose second PR the ambiguity refusal below exists to catch.
+SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
+  || { echo "cannot resolve this repository — do NOT merge"; exit 1; }
+UP=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
+  || { echo "cannot resolve the fork parent — a PR there would be invisible; do NOT merge"; exit 1; }
+# "No such PR" and "the query failed" share an exit code, so absence is read out of gh's
+# own error text; any other failure may be hiding the second match. bot-gate makes the
+# same split, but this loop picks the repo the MERGE targets, so it cannot lean on that.
+# PullRequest-level not-found only: both candidates are repos the API just named, so a
+# Repository-level "could not resolve" or an HTTP 404 is lost access, not absence.
+_GH_ERR=$(mktemp) || { echo "mktemp failed"; exit 1; }; trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it
+R=""; _M=0
+for _c in ${UP:+"$UP"} "$SELF"; do
+  if ! _h=$(gh pr view <N> -R "$_c" --json headRefOid -q .headRefOid 2>"$_GH_ERR"); then
+    grep -qiE 'could not resolve to a pullrequest|no pull requests found' "$_GH_ERR" \
+      || { echo "cannot query PR <N> in $_c — absence not established; do NOT merge"; exit 1; }
+    _h=""
+  fi
+  if [ "$_h" = "$(git rev-parse HEAD)" ]; then
+    _M=$((_M+1)); [ -n "$R" ] || R="$_c"
+  fi
+done
+[ "$_M" -le 1 ] || { echo "PR <N> matches this head in BOTH $UP and $SELF — ambiguous; re-run with the intended repo pinned in every -R"; exit 1; }
+[ -n "$R" ] || { echo "no PR <N> whose head is this tree in ${UP:+$UP or }$SELF"; exit 1; }
+PR_REFS=$(gh pr view <N> -R "$R" --json baseRefName,headRefName) \
+  || { echo "cannot resolve the PR branches"; exit 1; }
+BASE=$(printf %s "$PR_REFS" | jq -r '.baseRefName // ""')
+HEAD_BRANCH=$(printf %s "$PR_REFS" | jq -r '.headRefName // ""')
+[ -n "$BASE" ] && [ -n "$HEAD_BRANCH" ] \
+  || { echo "cannot resolve the PR branches"; exit 1; }
+
+# Check the exit status. `--delete-branch` makes gh switch branches as a side effect, so a
+# FAILED merge still leaves you somewhere plausible-looking; without this the steps below
+# "confirm $BASE is healthy" on a tree where nothing landed, and any caller that closes a
+# tracker item after this block closes it for a merge that never happened.
+# $REVIEWED_TIP is the SHA bot-gate checked in § 7, not a fresh `git rev-parse HEAD`.
+# Re-reading HEAD here re-adopts whatever is current — a late amend or concurrent
+# automation that pushed after the gate returned — and pins the merge to that, so GitHub
+# ACCEPTS the unreviewed head instead of refusing it. The pin is only a guard if it names
+# the tree that was actually reviewed.
+# Run the gate and REQUIRE its exit status. A command substitution swallows it: bot-gate
+# prints its JSON — `tip` included — before exiting 1 on BLOCKED, so `$(... | jq -r .tip)`
+# yields a perfectly good SHA from a run that said do not merge, and jq's own exit 0 hides
+# it. An amend landing between § 7 and here then produces a BLOCKED gate whose tip is the
+# new head, the equality check compares the new head to itself and passes, and the merge
+# takes the unreviewed tree — the exact outcome this pin exists to refuse.
+# Re-resolved here: this block re-derives $R and $BASE so it can run standalone, and an
+# unset $BOT_GATE would execute an empty command and report "do NOT merge" for a gate that
+# was merely not found.
+for d in "$HOME/.claude/skills/pr-with-codex-bot-review" \
+         "${CODEX_HOME:-$HOME/.codex}/skills/pr-with-codex-bot-review" \
+         "$HOME/.agents/skills/pr-with-codex-bot-review"; do
+  [ -x "$d/scripts/bot-gate" ] && { BOT_GATE="$d/scripts/bot-gate"; break; }
+done
+[ -n "${BOT_GATE:-}" ] || { echo "bot-gate not found — resolve it as in § 7"; exit 1; }
+unset REVIEWED_TIP
+# DEGRADED REENTRY A: stop here after repository and BOT_GATE resolution.
+GATE_RC=0
+GATE_JSON=$("$BOT_GATE" <N> --json) || GATE_RC=$?
+if [ "$GATE_RC" -eq 0 ]; then
+  [ "$(printf %s "$GATE_JSON" | jq -r .verdict)" = "NO_PENDING_EVIDENCE" ] \
+    || { echo "gate verdict is not NO_PENDING_EVIDENCE"; exit 1; }
+  REVIEWED_TIP=$(printf %s "$GATE_JSON" | jq -er .tip) \
+    || { echo "gate JSON has no tip"; exit 1; }
+elif [ "$GATE_RC" -eq 4 ]; then
+  GATE_EVIDENCE=$(git rev-parse --git-path "merge-gate-<N>.json") \
+    || { echo "cannot resolve the gate-evidence path"; exit 1; }
+  (umask 077; printf '%s\n' "$GATE_JSON" > "$GATE_EVIDENCE") \
+    || { echo "cannot preserve exit-4 gate JSON"; exit 1; }
+  echo "bot-gate exit 4: preserved JSON at $GATE_EVIDENCE; STOP and load exact skill pr-with-codex-bot-review § 8b"
+else
+  echo "bot-gate says do NOT merge (exit $GATE_RC)"
+  exit 1
+fi
+# The normal path sets REVIEWED_TIP above. Exit 4 deliberately leaves it unset: complete
+# main-skill § 8b and run its fresh live-gate check, then set REVIEWED_TIP only from that
+# new JSON before resuming at R_URL below. The saved file is incident evidence, never an
+# admission token. A pasted-through sequence cannot drift into a merge because this guard
+# refuses it, including in a reused shell that had REVIEWED_TIP set before this gate call.
+[ -n "${REVIEWED_TIP:-}" ] \
+  || { echo "REVIEWED_TIP unset — do NOT continue; complete § 8b first"; exit 1; }
+# Repository, ancestry, retarget, queue, evidence, and reset checks remain mandatory.
+# DEGRADED REENTRY B: resume here after completing main-skill § 8b.
+# The forge's own clone URL, not a hardcoded github.com one. `$R` is only `owner/repo`,
+# so on GitHub Enterprise the literal host either fails or — worse — resolves an unrelated
+# PUBLIC repo of the same name and validates ancestry against a stranger's branch.
+R_URL=$(gh repo view "$R" --json url -q .url 2>/dev/null) \
+  || { echo "cannot resolve the clone URL for $R — do NOT merge"; exit 1; }
+R_URL="$R_URL.git"
+# Fetch the base AFTER the potentially slow bot gate. Fetching it before the API sweep lets
+# the merge target advance during the gate, making the ancestry result stale at merge time.
+git fetch "$R_URL" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
+  || { echo "cannot fetch the merge target — base unknown, do NOT merge"; echo "  (on a private repo cloned over SSH this is usually missing git credentials for https, not a missing base)"; exit 1; }
+git merge-base --is-ancestor "refs/remotes/upstream/$BASE" HEAD \
+  || { echo "REBASE FIRST — $BASE advanced since the review"; exit 1; }
+[ "$REVIEWED_TIP" = "$(git rev-parse HEAD)" ] \
+  || { echo "local HEAD moved since the gate ran — re-run § 7"; exit 1; }
+# LAST, immediately before the merge. Ancestry answers "did $BASE advance"; it cannot
+# answer "is $BASE still the target". A RETARGET points the PR at a different branch
+# entirely: $BASE then names the old one, everything above validates that one, and
+# `gh pr merge` squashes onto whatever the PR points at now — with the head unmoved, so
+# --match-head-commit stays satisfied. Read it here rather than beside the gate because
+# every check between the read and the merge widens the window. The window is not zero and
+# cannot be: GitHub offers no base pin to match --match-head-commit. It is now one API call
+# wide instead of a fetch plus two checks, and a retarget is one click.
+BASE_NOW=$(gh pr view <N> -R "$R" --json baseRefName -q .baseRefName) \
+  || { echo "cannot re-read the merge target — do NOT merge"; exit 1; }
+[ -n "$BASE_NOW" ] && [ "$BASE_NOW" = "$BASE" ] \
+  || { echo "the PR was retargeted ($BASE -> ${BASE_NOW:-unknown}) — the panel reviewed a diff against $BASE; re-run § 7"; exit 1; }
+gh pr merge <N> -R "$R" --squash --delete-branch --match-head-commit "$REVIEWED_TIP" \
+  || { echo "merge did not land — do NOT proceed"; exit 1; }
+
+# `gh pr merge` returning 0 means the PR was accepted for merging — which, in a repo with a
+# required merge queue, means ENQUEUED, not landed. Fetching now would read the still-old
+# base and any caller that closes a tracker item here would close it for a merge that has
+# not happened. Wait for the state to actually reach MERGED.
+_n=0
+while [ "$_n" -lt 60 ]; do
+  _n=$((_n+1))
+  _ST=$(gh pr view <N> -R "$R" --json state -q .state 2>/dev/null || echo "")
+  [ "$_ST" = "MERGED" ] && break
+  [ "$_ST" = "CLOSED" ] && { echo "PR was closed without merging"; exit 1; }
+  sleep 10
+done
+[ "$_ST" = "MERGED" ] || { echo "PR still not merged (state=$_ST) — do NOT proceed"; exit 1; }
+
+# Keep $GATE_JSON: the merge report has to QUOTE it (see
+# the already-loaded owning skill's § 8a; see
+# ../pr-with-codex-bot-review/SKILL.md#8a-the-merge-report-must-quote-the-gate). Do not re-run the gate to
+# produce the quote — the PR is merged by now, so a fresh run describes a different world.
+printf '%s\n' "$GATE_JSON" > "${TMPDIR:-/tmp}/merge-evidence-<N>.json"
+
+# Re-fetch after the merge: the ref above predates the squash commit. Reset from where the
+# merge actually landed — `origin` is your fork and may not contain it at all. Fetch before
+# checkout, because in a single-branch fork clone neither a local `$BASE` nor `origin/$BASE`
+# exists, so `git checkout "$BASE"` fails and an unguarded reset then runs against whatever
+# branch is still checked out.
+git fetch "$R_URL" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
+  || { echo "cannot fetch the merge target"; exit 1; }
+# `checkout -B` repoints the branch ref unconditionally, and a clean worktree does not
+# protect COMMITTED work: a local bead closure or DRIVE.md update on $BASE awaiting its
+# metadata PR — a state this skill's own LAND flow produces — becomes unreachable except
+# via reflog. The exception is a same-name fork PR: local $BASE is the verified feature
+# head, and a squash commit does not descend from it. Matching the reviewed OID distinguishes
+# that head from later local-only commits, which must still stop the reset.
+if git show-ref --verify --quiet "refs/heads/$BASE" \
+   && ! git merge-base --is-ancestor "$BASE" "refs/remotes/upstream/$BASE"; then
+  if [ "$HEAD_BRANCH" != "$BASE" ] \
+     || [ "$(git rev-parse "refs/heads/$BASE")" != "$REVIEWED_TIP" ]; then
+    echo "local $BASE has commits upstream does not — refusing to reset; push or rebase them first"
+    exit 1
+  fi
+fi
+# Re-check the worktree HERE, not only at the top of this block: the merge-queue wait
+# above can run ten minutes, and `checkout -B` silently CARRIES any nonconflicting tracked
+# modification made meanwhile onto the fresh base — the build below then "confirms" a tree
+# that is not the branch tip. FULL status, untracked included: the top-of-block check ran
+# BEFORE the wait, so it cannot vouch for a file created during it — and checkout does not
+# remove an untracked file, so it sits in the "fresh" base worktree where the build and
+# whatever branches from here inherit it, unreviewed and invisible to `-uno`.
+_ST=$(git status --porcelain) || { echo "cannot re-read the worktree — not resetting"; exit 1; }
+[ -z "$_ST" ] || { echo "worktree changed while waiting for the merge — resolve that, then reset to $BASE by hand"; exit 1; }
+git checkout -B "$BASE" "refs/remotes/upstream/$BASE" \
+  || { echo "cannot reset to the merge target — do NOT treat what follows as a check of it"; exit 1; }
+nix build                                    # confirm the base is healthy
+```
+
+`--match-head-commit` takes the **full 40-char OID**, which is why the snippet pins
+`$REVIEWED_TIP` from the gate's JSON: it is already the full SHA, and it is the tip the
+gate actually checked. Do not substitute `git rev-parse HEAD` here — that re-reads the
+current head, so an amend after the gate ran gets pinned to itself and merges unreviewed.
+Nor the wrapper's body SHA, which may be abbreviated and would make every merge refuse
+with no hint why.
+
+Check before merging, and make it `exit 1` rather than print: a bare `git status
+--porcelain` exits 0 either way, and `--delete-branch` makes `gh pr merge` switch branches
+itself — so a dirty tree aborts *after* the squash has already landed. Stash if the change
+matters; discard only after looking, because `git checkout -- .` is not recoverable.
+
+`checkout -B` rather than `pull` because squash-merge rewrites history — the branch is
+repointed at the merge target, not merged with it.

--- a/skills/pr-with-codex-bot-review/SKILL.md
+++ b/skills/pr-with-codex-bot-review/SKILL.md
@@ -1,21 +1,13 @@
 ---
 name: pr-with-codex-bot-review
 description: >-
-  How to open and land a pull request through GitHub's `chatgpt-codex-connector` review bot
-  (the one that auto-comments "Codex Review" on PRs), gating also on `coderabbitai[bot]`
-  when it is configured on the repo. Covers writing the PR body, running local gates, a
-  local Claude pre-review before push so bot rounds start from the good diff, the
-  codex bot's actual behavior — auto-fires on substantive code PRs, often silent on
-  docs-only PRs, line-level findings live in PR review comments not the review body —
-  re-triggering with `@codex review`, addressing findings via amend + force-push, knowing
-  when to merge despite bot silence, and the squash-merge + branch-reset pattern. THE
-  MERGE DECISION IS MADE BY THE BUNDLED `scripts/bot-gate`, NOT BY JUDGMENT — run it and
-  quote its output; the manual reaction-and-comment procedure it replaced is gone, and
-  was wrong three different ways before it was. Use this skill whenever the user asks to
-  open a PR, "ship this", "merge it", "let the bot review", "land the change", or right
-  after substantial code work that's ready for review. Also when the user asks why the
-  bot "isn't reviewing", how to interpret what it left behind, or what to do when GitHub
-  itself is degraded and no review can be attributed to the tree being merged.
+  Open and land a pull request through GitHub's `chatgpt-codex-connector` review
+  bot, also accounting for CodeRabbit when configured. Covers local gates and Claude
+  pre-review, structured PRs, CI, bot re-triggers, finding disposition, degraded-forge
+  evidence, squash merge, and safe branch reset. The bundled `scripts/bot-gate` owns
+  the merge admission decision: require its exit status and quote its output. Use for
+  "open a PR", "ship this", "merge it", "let the bot review", "land the change",
+  bot-silence diagnosis, or substantial code ready for review.
 argument-hint: "[pr-number-or-branch]"
 allowed-tools:
   - Bash
@@ -23,6 +15,7 @@ allowed-tools:
   - Edit
   - Write
   - Grep
+  - Skill
 ---
 
 # pr-with-codex-bot-review
@@ -386,8 +379,10 @@ while you watch it, and the measured behaviour is that it does not exit on its o
 
 Every reviewer invocation *this skill and the panel skills own* is bounded for the same
 reason. Not every one in the repo is: `orchestrating-with-rb-lite` documents **three**
-unbounded `claude -p` reviewer commands that rb-lite itself dispatches — `SKILL.md:111`
-pinning `claude-opus-5`, and `:1296`/`:1298` pinning `opus` — which carry no timeout
+unbounded `claude -p` reviewer commands that rb-lite itself dispatches — the default
+reviewer command in `orchestrating-with-rb-lite` § **Tool dependencies** pins
+`claude-opus-5`, and two under `orchestrating-with-rb-lite` § **Customizing the panel**
+pin `opus` — all carry no timeout
 because this repo does not launch them. All three hang on exactly the failure this
 change removes elsewhere; tracked in #51 rather than claimed as covered here.
 
@@ -662,8 +657,9 @@ condition:
      gh pr merge 42 …` — and it merges on a condition the gate never checked: the gate
      reasons about the *head*, and says nothing about whether the base branch advanced
      while the bot rounds were running. A behind branch squash-merges into a composition
-     no reviewer saw. § 8 is the merge sequence and it checks that; run it, don't inline a
-     shorter version of it here.
+     no reviewer saw. Exact companion skill
+     [`pr-with-codex-bot-review-merge`](../pr-with-codex-bot-review-merge/SKILL.md)
+     checks that; run it, don't inline a shorter version here.
 
      `scripts/bot-gate.test` runs it against a stubbed `gh` with canned API responses —
      one case per defect a reviewer actually found — the suite prints its own count, so
@@ -753,9 +749,10 @@ condition:
   Filter reactions on `content=="+1"` when you do read them: a fresh `eyes` means the bot
   is *still reviewing*, and an unfiltered query counts it as approval-shaped activity.
 
-  Then pin the merge to **the tip this gate just checked** — § 8 captures it from the
-  gate's own JSON. Re-reading `git rev-parse HEAD` at merge time looks equivalent and is
-  not: it re-adopts whatever is current, so an amend landing in between gets pinned to
+  Then pin the merge to **the tip this gate just checked** — the
+  [exact companion skill `pr-with-codex-bot-review-merge`](../pr-with-codex-bot-review-merge/SKILL.md)
+  captures it from the gate's own JSON. Re-reading `git rev-parse HEAD` at merge time is
+  not equivalent: it re-adopts whatever is current, so an amend landing in between gets pinned to
   itself and GitHub *accepts* it. The pin only guards when it names the reviewed tree.
 - CI is green.
 - CodeRabbit's status is **read, not required** — the gate does not act on it. A `SUCCESS`
@@ -799,175 +796,20 @@ ignoring the actual signal.**
 
 ### 8. Squash-merge and clean up
 
-```bash
-# Two checks, because a FAILED `git status` also prints nothing: a corrupt index would
-# read as a clean tree, in the merging direction.
-_ST=$(git status --porcelain) || { echo "cannot read the worktree — do NOT merge"; exit 1; }
-[ -z "$_ST" ] || { echo "tree dirty — do NOT merge"; exit 1; }
-# Resolve by matching HEAD, not by preferring the parent. A fork can host its own PRs, and
-# both repos can carry PR number N — so parent-first targets a missing or unrelated PR and
-# the real one can never be landed. `bot-gate` resolves the same way for the same reason.
-# BOTH matching is ambiguous, not a tiebreak: the same branch can be opened as a PR against
-# the parent AND the fork, and the two PRs were gated separately — silently merging the
-# parent's can land a PR whose reviews nobody checked. Refuse and make the caller say
-# which repo.
-# Guarded, because a failed lookup is not an answer: an unguarded SELF empties the loop's
-# only sure candidate, and a failed parent lookup silently reads as "not a fork" — dropping
-# the very candidate whose second PR the ambiguity refusal below exists to catch.
-SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
-  || { echo "cannot resolve this repository — do NOT merge"; exit 1; }
-UP=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
-  || { echo "cannot resolve the fork parent — a PR there would be invisible; do NOT merge"; exit 1; }
-# "No such PR" and "the query failed" share an exit code, so absence is read out of gh's
-# own error text; any other failure may be hiding the second match. bot-gate makes the
-# same split, but this loop picks the repo the MERGE targets, so it cannot lean on that.
-# PullRequest-level not-found only: both candidates are repos the API just named, so a
-# Repository-level "could not resolve" or an HTTP 404 is lost access, not absence.
-_GH_ERR=$(mktemp); trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it || { echo "mktemp failed"; exit 1; }
-R=""; _M=0
-for _c in ${UP:+"$UP"} "$SELF"; do
-  if ! _h=$(gh pr view <N> -R "$_c" --json headRefOid -q .headRefOid 2>"$_GH_ERR"); then
-    grep -qiE 'could not resolve to a pullrequest|no pull requests found' "$_GH_ERR" \
-      || { echo "cannot query PR <N> in $_c — absence not established; do NOT merge"; exit 1; }
-    _h=""
-  fi
-  if [ "$_h" = "$(git rev-parse HEAD)" ]; then
-    _M=$((_M+1)); [ -n "$R" ] || R="$_c"
-  fi
-done
-[ "$_M" -le 1 ] || { echo "PR <N> matches this head in BOTH $UP and $SELF — ambiguous; re-run with the intended repo pinned in every -R"; exit 1; }
-[ -n "$R" ] || { echo "no PR <N> whose head is this tree in ${UP:+$UP or }$SELF"; exit 1; }
-PR_REFS=$(gh pr view <N> -R "$R" --json baseRefName,headRefName) \
-  || { echo "cannot resolve the PR branches"; exit 1; }
-BASE=$(printf %s "$PR_REFS" | jq -r '.baseRefName // ""')
-HEAD_BRANCH=$(printf %s "$PR_REFS" | jq -r '.headRefName // ""')
-[ -n "$BASE" ] && [ -n "$HEAD_BRANCH" ] \
-  || { echo "cannot resolve the PR branches"; exit 1; }
-
-# Check the exit status. `--delete-branch` makes gh switch branches as a side effect, so a
-# FAILED merge still leaves you somewhere plausible-looking; without this the steps below
-# "confirm $BASE is healthy" on a tree where nothing landed, and any caller that closes a
-# tracker item after this block closes it for a merge that never happened.
-# $REVIEWED_TIP is the SHA bot-gate checked in § 7, not a fresh `git rev-parse HEAD`.
-# Re-reading HEAD here re-adopts whatever is current — a late amend or concurrent
-# automation that pushed after the gate returned — and pins the merge to that, so GitHub
-# ACCEPTS the unreviewed head instead of refusing it. The pin is only a guard if it names
-# the tree that was actually reviewed.
-# Run the gate and REQUIRE its exit status. A command substitution swallows it: bot-gate
-# prints its JSON — `tip` included — before exiting 1 on BLOCKED, so `$(... | jq -r .tip)`
-# yields a perfectly good SHA from a run that said do not merge, and jq's own exit 0 hides
-# it. An amend landing between § 7 and here then produces a BLOCKED gate whose tip is the
-# new head, the equality check compares the new head to itself and passes, and the merge
-# takes the unreviewed tree — the exact outcome this pin exists to refuse.
-# Re-resolved here: this block re-derives $R and $BASE so it can run standalone, and an
-# unset $BOT_GATE would execute an empty command and report "do NOT merge" for a gate that
-# was merely not found.
-for d in "$HOME/.claude/skills/pr-with-codex-bot-review" \
-         "${CODEX_HOME:-$HOME/.codex}/skills/pr-with-codex-bot-review" \
-         "$HOME/.agents/skills/pr-with-codex-bot-review"; do
-  [ -x "$d/scripts/bot-gate" ] && { BOT_GATE="$d/scripts/bot-gate"; break; }
-done
-[ -n "${BOT_GATE:-}" ] || { echo "bot-gate not found — resolve it as in § 7"; exit 1; }
-GATE_JSON=$("$BOT_GATE" <N> --json) || { echo "bot-gate says do NOT merge"; exit 1; }
-[ "$(printf %s "$GATE_JSON" | jq -r .verdict)" = "NO_PENDING_EVIDENCE" ] \
-  || { echo "gate verdict is not NO_PENDING_EVIDENCE"; exit 1; }
-REVIEWED_TIP=$(printf %s "$GATE_JSON" | jq -r .tip)
-# The forge's own clone URL, not a hardcoded github.com one. `$R` is only `owner/repo`,
-# so on GitHub Enterprise the literal host either fails or — worse — resolves an unrelated
-# PUBLIC repo of the same name and validates ancestry against a stranger's branch.
-R_URL=$(gh repo view "$R" --json url -q .url 2>/dev/null) \
-  || { echo "cannot resolve the clone URL for $R — do NOT merge"; exit 1; }
-R_URL="$R_URL.git"
-# Fetch the base AFTER the potentially slow bot gate. Fetching it before the API sweep lets
-# the merge target advance during the gate, making the ancestry result stale at merge time.
-git fetch "$R_URL" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
-  || { echo "cannot fetch the merge target — base unknown, do NOT merge"; echo "  (on a private repo cloned over SSH this is usually missing git credentials for https, not a missing base)"; exit 1; }
-git merge-base --is-ancestor "refs/remotes/upstream/$BASE" HEAD \
-  || { echo "REBASE FIRST — $BASE advanced since the review"; exit 1; }
-[ "$REVIEWED_TIP" = "$(git rev-parse HEAD)" ] \
-  || { echo "local HEAD moved since the gate ran — re-run § 7"; exit 1; }
-# LAST, immediately before the merge. Ancestry answers "did $BASE advance"; it cannot
-# answer "is $BASE still the target". A RETARGET points the PR at a different branch
-# entirely: $BASE then names the old one, everything above validates that one, and
-# `gh pr merge` squashes onto whatever the PR points at now — with the head unmoved, so
-# --match-head-commit stays satisfied. Read it here rather than beside the gate because
-# every check between the read and the merge widens the window. The window is not zero and
-# cannot be: GitHub offers no base pin to match --match-head-commit. It is now one API call
-# wide instead of a fetch plus two checks, and a retarget is one click.
-BASE_NOW=$(gh pr view <N> -R "$R" --json baseRefName -q .baseRefName) \
-  || { echo "cannot re-read the merge target — do NOT merge"; exit 1; }
-[ -n "$BASE_NOW" ] && [ "$BASE_NOW" = "$BASE" ] \
-  || { echo "the PR was retargeted ($BASE -> ${BASE_NOW:-unknown}) — the panel reviewed a diff against $BASE; re-run § 7"; exit 1; }
-gh pr merge <N> -R "$R" --squash --delete-branch --match-head-commit "$REVIEWED_TIP" \
-  || { echo "merge did not land — do NOT proceed"; exit 1; }
-
-# `gh pr merge` returning 0 means the PR was accepted for merging — which, in a repo with a
-# required merge queue, means ENQUEUED, not landed. Fetching now would read the still-old
-# base and any caller that closes a tracker item here would close it for a merge that has
-# not happened. Wait for the state to actually reach MERGED.
-_n=0
-while [ "$_n" -lt 60 ]; do
-  _n=$((_n+1))
-  _ST=$(gh pr view <N> -R "$R" --json state -q .state 2>/dev/null || echo "")
-  [ "$_ST" = "MERGED" ] && break
-  [ "$_ST" = "CLOSED" ] && { echo "PR was closed without merging"; exit 1; }
-  sleep 10
-done
-[ "$_ST" = "MERGED" ] || { echo "PR still not merged (state=$_ST) — do NOT proceed"; exit 1; }
-
-# Keep $GATE_JSON: the merge report has to QUOTE it (see below). Do not re-run the gate to
-# produce the quote — the PR is merged by now, so a fresh run describes a different world.
-printf '%s\n' "$GATE_JSON" > "${TMPDIR:-/tmp}/merge-evidence-<N>.json"
-
-# Re-fetch after the merge: the ref above predates the squash commit. Reset from where the
-# merge actually landed — `origin` is your fork and may not contain it at all. Fetch before
-# checkout, because in a single-branch fork clone neither a local `$BASE` nor `origin/$BASE`
-# exists, so `git checkout "$BASE"` fails and an unguarded reset then runs against whatever
-# branch is still checked out.
-git fetch "$R_URL" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
-  || { echo "cannot fetch the merge target"; exit 1; }
-# `checkout -B` repoints the branch ref unconditionally, and a clean worktree does not
-# protect COMMITTED work: a local bead closure or DRIVE.md update on $BASE awaiting its
-# metadata PR — a state this skill's own LAND flow produces — becomes unreachable except
-# via reflog. The exception is a same-name fork PR: local $BASE is the verified feature
-# head, and a squash commit does not descend from it. Matching the reviewed OID distinguishes
-# that head from later local-only commits, which must still stop the reset.
-if git show-ref --verify --quiet "refs/heads/$BASE" \
-   && ! git merge-base --is-ancestor "$BASE" "refs/remotes/upstream/$BASE"; then
-  if [ "$HEAD_BRANCH" != "$BASE" ] \
-     || [ "$(git rev-parse "refs/heads/$BASE")" != "$REVIEWED_TIP" ]; then
-    echo "local $BASE has commits upstream does not — refusing to reset; push or rebase them first"
-    exit 1
-  fi
-fi
-# Re-check the worktree HERE, not only at the top of this block: the merge-queue wait
-# above can run ten minutes, and `checkout -B` silently CARRIES any nonconflicting tracked
-# modification made meanwhile onto the fresh base — the build below then "confirms" a tree
-# that is not the branch tip. FULL status, untracked included: the top-of-block check ran
-# BEFORE the wait, so it cannot vouch for a file created during it — and checkout does not
-# remove an untracked file, so it sits in the "fresh" base worktree where the build and
-# whatever branches from here inherit it, unreviewed and invisible to `-uno`.
-_ST=$(git status --porcelain) || { echo "cannot re-read the worktree — not resetting"; exit 1; }
-[ -z "$_ST" ] || { echo "worktree changed while waiting for the merge — resolve that, then reset to $BASE by hand"; exit 1; }
-git checkout -B "$BASE" "refs/remotes/upstream/$BASE" \
-  || { echo "cannot reset to the merge target — do NOT treat what follows as a check of it"; exit 1; }
-nix build                                    # confirm the base is healthy
-```
-
-`--match-head-commit` takes the **full 40-char OID**, which is why the snippet pins
-`$REVIEWED_TIP` from the gate's JSON: it is already the full SHA, and it is the tip the
-gate actually checked. Do not substitute `git rev-parse HEAD` here — that re-reads the
-current head, so an amend after the gate ran gets pinned to itself and merges unreviewed.
-Nor the wrapper's body SHA, which may be abbreviated and would make every merge refuse
-with no hint why.
-
-Check before merging, and make it `exit 1` rather than print: a bare `git status
---porcelain` exits 0 either way, and `--delete-branch` makes `gh pr merge` switch branches
-itself — so a dirty tree aborts *after* the squash has already landed. Stash if the change
-matters; discard only after looking, because `git checkout -- .` is not recoverable.
-
-`checkout -B` rather than `pull` because squash-merge rewrites history — the branch is
-repointed at the merge target, not merged with it.
+Load exact companion skill
+[`pr-with-codex-bot-review-merge`](../pr-with-codex-bot-review-merge/SKILL.md)
+before merging. It contains the required gate re-check, repository disambiguation,
+base-freshness and retarget checks, merge-queue wait, evidence capture, safe branch
+reset, and post-merge build. Run that sequence as written for the normal
+`NO_PENDING_EVIDENCE` path. For a deliberate `BLOCKED_UNATTRIBUTED` degraded merge,
+start the companion normally and complete its repository disambiguation first. When its
+gate call returns exit 4, § 8b may replace only the gate-admission predicate: preserve
+the original gate JSON, pin its tip to the locally verified and attested tree, then
+resume at the companion's `DEGRADED REENTRY B` marker. Base and retarget checks,
+merge-queue wait, evidence capture, and safe reset remain mandatory. § 8a governs
+reporting in either case.
+**Companion unavailable: stop, rerun the same installer command once, reload it, and do
+not improvise this procedure.**
 
 ### 8a. The merge report must quote the gate
 
@@ -1039,6 +881,51 @@ verdict and exit code, what you ran locally with which SHA, what the status page
 who attested to what. The failure this section exists to prevent is not merging during an
 outage — that is sometimes correct — it is **improvising a merge policy during one and
 leaving no trace of the trade you made.**
+
+The merge companion preserves the first exit-4 response under the git directory before
+its unset-tip guard aborts; keep that file as incident evidence, not merge admission.
+After the human authorizes the degraded substitution above, return to the shell that
+already completed the companion's repository disambiguation. If that shell exited, rerun
+the companion from its start through its `DEGRADED REENTRY A` marker, stopping before
+the initial gate call. Then run
+the gate **again** immediately before re-entry. A live exit 0 uses the normal verdict; a
+live exit 4 may use the authorized degraded substitution; every other exit still blocks.
+Set `AUTHORIZED_TIP` to the exact SHA covered by both the recorded local CI and the human
+authorization before running this block:
+
+```bash
+[ -n "${AUTHORIZED_TIP:-}" ] \
+  || { echo "set AUTHORIZED_TIP to the SHA covered by local CI and human authorization"; exit 1; }
+[ "$(git rev-parse HEAD)" = "$AUTHORIZED_TIP" ] \
+  || { echo "HEAD moved after degraded authorization; repeat § 8b for this tree"; exit 1; }
+unset REVIEWED_TIP
+LIVE_GATE_RC=0
+LIVE_GATE_JSON=$("$BOT_GATE" <N> --json) || LIVE_GATE_RC=$?
+if [ "$LIVE_GATE_RC" -eq 0 ]; then
+  [ "$(printf %s "$LIVE_GATE_JSON" | jq -r .verdict)" = "NO_PENDING_EVIDENCE" ] \
+    || { echo "live gate exit 0 carried the wrong verdict"; exit 1; }
+elif [ "$LIVE_GATE_RC" -eq 4 ]; then
+  [ "$(printf %s "$LIVE_GATE_JSON" | jq -r .verdict)" = "BLOCKED_UNATTRIBUTED" ] \
+    || { echo "live gate exit 4 carried the wrong verdict"; exit 1; }
+else
+  echo "live gate now blocks with exit $LIVE_GATE_RC — do NOT merge"
+  exit 1
+fi
+GATE_JSON=$LIVE_GATE_JSON
+LIVE_GATE_TIP=$(printf %s "$GATE_JSON" | jq -er .tip) \
+  || { echo "live gate JSON has no tip"; exit 1; }
+[ "$LIVE_GATE_TIP" = "$AUTHORIZED_TIP" ] \
+  || { echo "live gate names a tree that was not authorized; repeat § 8b"; exit 1; }
+REVIEWED_TIP=$AUTHORIZED_TIP
+_LIVE_TREE=$(git status --porcelain) \
+  || { echo "cannot inspect the worktree after degraded authorization"; exit 1; }
+[ -z "$_LIVE_TREE" ] \
+  || { echo "worktree changed during degraded authorization — do NOT merge"; exit 1; }
+```
+
+Now resume at the companion's `DEGRADED REENTRY B` marker. Preserve both the initial incident JSON and
+this live `GATE_JSON` in the § 8a report; do not present an initial exit 4 as the state at
+merge time if the live recheck returned something else.
 
 ## Iteration patterns observed
 

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -1,0 +1,538 @@
+---
+name: rb-lite-backlog-drain
+description: >-
+  Internal companion procedure for orchestrating-with-rb-lite's serialized bead
+  backlog drain. Load this exact skill only when orchestrating-with-rb-lite or a
+  sibling skill directs you here; it is not a standalone workflow selector.
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Backlog-drain workflow
+
+The complete operating procedure for rb-lite's serialized `br` backlog-drain mode.
+When `orchestrating-with-rb-lite` directs a full backlog drain, read it before selecting
+the first bead and follow all twelve steps in order. When a sibling skill links to one
+numbered section for recovery, execute only that cited section; do not start a drain or
+touch unrelated beads.
+
+## Contents
+
+- Steps 1–4: pick, read, branch, and write the task file
+- Steps 5–7: run rb-lite, interpret its summary, and run local gates
+- Steps 8–10: commit, push, wait for CI, merge, and reset
+- Step 11: close the bead through a reviewed metadata path
+- Step 12: resume safely and continue until the scoped backlog is empty
+
+Use this mode when the user wants to clear an existing `br` backlog with
+rb-lite. The beads are the input; do not invent a fresh work list. Codex is
+operating the queue and PR workflow, while rb-lite handles the inner
+implement → review loop for each bead.
+
+1. **Pick.** Run `br ready --limit 10`. Take the top P0 first; if none,
+   the lowest-numbered P1; only descend to P2 if the user says so or the
+   P1 list is empty / oversized.
+
+2. **Read.** Run `br show <id>` (and `br show <id> --json` if structured
+   fields help). If the acceptance criteria are vague, pause and ask the
+   user before writing the task.
+
+3. **Sync base and branch.** Confirm there is no unrelated dirty work, fetch
+   the selected base, and start the bead from that clean base. Use one branch
+   per bead, e.g. `feat/<bead-id>-<short-slug>`. Let rb-lite create/switch the
+   branch with `--branch` unless the branch already exists and the user
+   explicitly wants to resume it. Do not pile multiple beads onto one branch.
+
+4. **Task file.** Write a focused task file, usually under
+   `.rb-lite/tasks/bead-<id>.md`, using the
+   [already-loaded owning skill's backlog task template](../orchestrating-with-rb-lite/SKILL.md#backlog-task-template). Keep it outside
+   the committed source diff unless the repo intentionally tracks task
+   files.
+
+5. **Run rb-lite.**
+
+   ```bash
+   rb-lite run \
+     --implementer claude,codex \
+     --task-file .rb-lite/tasks/bead-<id>.md \
+     --base origin/main \
+     --branch feat/<bead-id>-<short-slug> \
+     --run-dir /tmp/rb-lite-<bead-id>-run
+   ```
+
+   If using the nix fallback, prefix the same `run ...` arguments with
+   `nix run --refresh github:douglaz/rb-lite --`.
+
+6. **Read the JSON summary.** Exit `0` with status `clean` means the panel
+   had no P0/P1/P2 findings. For exit `10`, `11`, `12`, `13`, or `70`, use
+   the [already-loaded owning skill's exit-code diagnosis table](../orchestrating-with-rb-lite/SKILL.md#exit-codes-and-json-schema) and
+   inspect the run artifacts before
+   deciding whether to rerun, fix manually, or file a dogfood bead.
+
+<a id="backlog-step-7"></a>
+
+7. **Run local gates.** Use the repo's own verification contract. In the
+   Rust/Nix repos this skill was built for, the default gate set is:
+
+   ```bash
+   nix develop -c cargo fmt --check
+   nix develop -c cargo clippy --locked -- -D warnings
+   nix develop -c cargo test --locked --features test-stub
+   nix build
+   ```
+
+   Treat real failures as part of the bead. Treat pre-existing flakiness as
+   a separate bead; don't hand-tune the branch to hide a flaky CI failure.
+
+   **These gates were already green before the bead, so passing them proves
+   nothing about it.** For **each** load-bearing behavior the bead introduces —
+   a new invariant, an ordering, a clock or lock choice — invert it in the
+   working tree, one at a time, and confirm the assertion that pins *that*
+   behavior goes red; then revert. Read the failure rather than just observing
+   one: a mutation that trips an initialization error or an unrelated assertion
+   proves nothing, and a mutation that changes no test outcome means the drain
+   shipped a behavior nothing covers.
+
+   **Protect the accepted diff before you invert anything.** rb-lite leaves its
+   changes UNCOMMITTED until step 8, so the obvious way to undo a mutation —
+   `git restore <file>` / `git checkout -- <file>` — discards rb-lite's accepted
+   implementation in that file along with your inversion. The gates ran before the
+   mutation and nothing re-runs after the revert, so step 8 would commit and push
+   a tree missing part of the work. Commit or stash the accepted diff first, or
+   mutate in a scratch copy — not "revert and re-run green". When the accepted fix and a
+   regression test sit in the same file, the file-level restore removes both and the suite
+   then passes *because* the test that would expose the loss is gone. Verify by diffing the
+   restored tree against the preserved diff, not by trusting a green run.
+
+   **A mutation that stays green STOPS the drain — it is not a note to carry into
+   step 8.** Diagnosing an uncovered behavior and then committing anyway ships
+   exactly what the check was added to catch, and step 8 pushes immediately, so
+   there is no later point that is cheaper. Add or repair the test that pins the
+   behavior, observe its red run against the inverted code AND its green run
+   against the correct code, and only then continue.
+
+   **That repair was never reviewed.** rb-lite returned its verdict on the tree
+   before you touched it, and step 9's SHA guard assumes local `HEAD` is the tree
+   the panel read — which it no longer is. Red/green proves the test detects the
+   behavior; it says nothing about the test's cleanup, isolation, or fixtures.
+   Neither obvious continuation is allowed here, which is the real problem: a second
+   rb-lite run breaks the one-bead/one-run invariant, and carrying it forward reaches
+   step 9's SHA guard, which asserts local `HEAD` is the tree rb-lite reviewed. So take
+   the third path — **stop the drain and track the repair as its own work**, on its own
+   branch with its own review. If the repair is small enough to belong to this bead, a
+   separate reviewer pass over the amended tree is the only in-band option; say which you
+   chose. Do not let it ride out on a clean verdict that predates it, and do not pretend
+   a second rb-lite run is permitted. If you cannot pin it — the
+   behavior is not reachable from a test, or the fix is out of the bead's scope —
+   say so and stop; that is a finding about the bead, not a formality to wave
+   through. Full rationale is in the [already-loaded owning skill's Verify the landed diff](../orchestrating-with-rb-lite/SKILL.md#verify-the-landed-diff).
+
+<a id="backlog-step-8"></a>
+
+8. **Commit, push, PR.** Add only intentional source/docs/config changes and
+   any bead-state sync files the repo expects. Do not commit `.rb-lite/` run
+   artifacts. Commit with a real message, push, and create a PR with a body
+   that includes the bead id, rb-lite status/rounds, and local test plan.
+
+9. **CI.** Capture the head *before* waiting, then wait for green:
+
+    ```bash
+    # Persisted to a file, not just a shell variable. Steps 9 and 10 usually run as
+    # separate tool calls, so a variable set here is gone by the merge — and the guard
+    # there would then abort a correct drain with "local HEAD moved". Under the git dir,
+    # so it is per-checkout and never committed (ADR 0001).
+    # Probe both repositories: a fork can host its own PR, and a colliding number in the
+    # parent can otherwise make the drain watch checks for somebody else's tree.
+    # Guarded: a failed parent lookup is not "not a fork" — it silently drops the one
+    # candidate whose same-number PR the ambiguity refusal below exists to catch.
+    SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
+      || { echo "cannot resolve this repository"; exit 1; }
+    PARENT=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
+      || { echo "cannot resolve the parent repository — a PR there would be invisible"; exit 1; }
+    LOCAL_HEAD=$(git rev-parse HEAD)
+    # Both repos matching is ambiguous, not a tiebreak: the same branch can be opened as a
+    # PR against the parent AND the fork, and picking the parent silently can watch and
+    # merge a PR the drain never gated. Refuse; pin the intended repo in every -R instead.
+    # And a FAILED query is not a miss: "no such PR" is read out of gh's own error text,
+    # because a transient failure treated as absence erases one candidate — and with it
+    # the refusal — leaving the drain watching whichever PR the outage left visible.
+    # PullRequest-level not-found only: both candidates are repos the API just named, so
+    # a Repository-level "could not resolve" or an HTTP 404 is lost access, not absence.
+    _GH_ERR=$(mktemp) || { echo "mktemp failed"; exit 1; }; trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it
+    R=""; _M=0
+    for _r in ${PARENT:+"$PARENT"} "$SELF"; do
+      if ! _h=$(gh pr view <pr> -R "$_r" --json headRefOid -q .headRefOid 2>"$_GH_ERR"); then
+        grep -qiE 'could not resolve to a pullrequest|no pull requests found' "$_GH_ERR" \
+          || { echo "cannot query PR <pr> in $_r — absence not established"; exit 1; }
+        _h=""
+      fi
+      if [ "$_h" = "$LOCAL_HEAD" ]; then _M=$((_M+1)); [ -n "$R" ] || R="$_r"; fi
+    done
+    [ "$_M" -le 1 ] || { echo "PR <pr> matches this head in BOTH $PARENT and $SELF — ambiguous"; exit 1; }
+    [ -n "$R" ] || { echo "cannot find PR <pr> for local HEAD"; exit 1; }
+    MERGING_SHA=$(gh pr view <pr> -R "$R" --json headRefOid -q .headRefOid)
+    [ -n "$MERGING_SHA" ] || { echo "cannot resolve the PR head"; exit 1; }
+    printf '%s\n' "$MERGING_SHA" > "$(git rev-parse --git-path rb-lite-merging-sha)"
+    # Bind it to the commit that was actually reviewed. The remote head is only the right
+    # thing to merge if it IS your local HEAD — the tree rb-lite ran on and step 7's gates
+    # passed on. If the branch moved since step 8, green CI would otherwise merge code no
+    # panel and no gate ever saw.
+    [ "$MERGING_SHA" = "$(git rev-parse HEAD)" ] \
+      || { echo "PR head $MERGING_SHA is not the reviewed local HEAD — re-run the panel"; exit 1; }
+    gh pr checks <pr> -R "$R" --watch
+    ```
+
+   Capture first, because the SHA is what makes the pin mean anything. Reading it
+   *after* the checks pass adopts whatever is there then — so a force-push landing
+   between green CI and the merge gets pinned to itself and sails through the very
+   guard meant to catch it. Pinning the pre-CI SHA makes GitHub reject the merge
+   instead; rerun the checks against the new head and try again.
+
+   On known-flaky CI, rerun failed jobs via `gh run rerun <id> --failed`; do not
+   keep changing product code just to dodge a flake.
+
+10. **Merge and reset.** Squash-merge the PR, delete the branch, then reset local state
+    to *where the merge landed* — not to `origin`, which on a fork is your own copy — and rerun the
+    authoritative build gate before taking the next bead:
+
+    ```bash
+    # Read the step-9 pin before resolving the host. Matching the PR against that SHA keeps
+    # a same-number PR in the parent from winning when the real PR is owned by the fork.
+    MERGING_SHA=$(cat "$(git rev-parse --git-path rb-lite-merging-sha)" 2>/dev/null || echo "")
+    [ -n "$MERGING_SHA" ] || { echo "no pinned SHA — re-run step 9"; exit 1; }
+    SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
+      || { echo "cannot resolve this repository"; exit 1; }
+    PARENT=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
+      || { echo "cannot resolve the parent repository — a PR there would be invisible"; exit 1; }
+    # Same ambiguity rule as step 9: both repos carrying PR <pr> at the pinned SHA means
+    # two distinct PRs, and merging the parent's silently can land the one nobody gated.
+    # Same absence rule too: only gh's own "no such PR" counts as a miss — a transient
+    # failure treated as one hides the second match and merges the survivor. And only the
+    # PullRequest-level text: a Repository-level "could not resolve" or an HTTP 404 on a
+    # repo the API just named is lost access, not absence.
+    _GH_ERR=$(mktemp) || { echo "mktemp failed"; exit 1; }; trap 'rm -f "$_GH_ERR"' EXIT   # both scripts do this; the snippets leaked it
+    R=""; _M=0
+    for _r in ${PARENT:+"$PARENT"} "$SELF"; do
+      if ! _h=$(gh pr view <pr> -R "$_r" --json headRefOid -q .headRefOid 2>"$_GH_ERR"); then
+        grep -qiE 'could not resolve to a pullrequest|no pull requests found' "$_GH_ERR" \
+          || { echo "cannot query PR <pr> in $_r — absence not established; do NOT merge"; exit 1; }
+        _h=""
+      fi
+      if [ "$_h" = "$MERGING_SHA" ]; then _M=$((_M+1)); [ -n "$R" ] || R="$_r"; fi
+    done
+    [ "$_M" -le 1 ] || { echo "PR <pr> matches the pinned SHA in BOTH $PARENT and $SELF — ambiguous"; exit 1; }
+    [ -n "$R" ] || { echo "cannot find PR <pr> for the pinned SHA"; exit 1; }
+    PR_REFS=$(gh pr view <pr> -R "$R" --json baseRefName,headRefName) \
+      || { echo "cannot resolve the PR branches"; exit 1; }
+    BASE=$(printf %s "$PR_REFS" | jq -r '.baseRefName // ""')
+    HEAD_BRANCH=$(printf %s "$PR_REFS" | jq -r '.headRefName // ""')
+    [ -n "$BASE" ] && [ -n "$HEAD_BRANCH" ] \
+      || { echo "cannot resolve the PR branches"; exit 1; }
+    # Check the merge's exit status. `--delete-branch` makes gh switch branches as a side
+    # effect, so a FAILED merge still leaves you somewhere plausible-looking — and step 11
+    # then closes the bead for a merge that never happened, which is the exact state this
+    # skill's reviewed-closure path exists to prevent.
+    # The base moves while a bead is built and reviewed, and --match-head-commit pins only
+    # the HEAD — a squash replays onto the CURRENT base, so a behind branch lands a
+    # composition nobody reviewed while every SHA still matches. Fetch the live base and
+    # test ancestry before merging, the same way the PR workflow's merge procedure does.
+    # gh's own clone URL: `owner/repo` alone points at public github.com, which on GitHub
+    # Enterprise either fails or resolves an unrelated public repo of the same name.
+    R_URL=$(gh repo view "$R" --json url -q .url 2>/dev/null) \
+  || { echo "cannot resolve the clone URL for $R — do NOT merge"; exit 1; }
+    git fetch "$R_URL.git" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
+      || { echo "cannot fetch the merge target — base unknown, do NOT merge"; echo "  (on a private repo cloned over SSH this is usually missing git credentials for https, not a missing base)"; exit 1; }
+    # Against $MERGING_SHA, not HEAD: that is the commit --match-head-commit pins and the
+    # one GitHub will squash. A local rebase during CI that was never pushed would make
+    # HEAD pass this test while the pinned remote SHA is still behind the base.
+    [ "$MERGING_SHA" = "$(git rev-parse HEAD)" ] \
+      || { echo "local HEAD moved since step 9 — re-run the panel and the checks"; exit 1; }
+    git merge-base --is-ancestor "refs/remotes/upstream/$BASE" "$MERGING_SHA" \
+      || { echo "REBASE FIRST — $BASE advanced since the review"; exit 1; }
+    # LAST, immediately before the merge, for the reason given at the same spot in the
+    # PR workflow's merge procedure: ancestry
+    # answers "did $BASE advance", never "is $BASE still the
+    # target". A retarget points the PR at a different branch, leaving every check above
+    # validating the old one while gh squashes onto the new one — and the head never moves,
+    # so --match-head-commit stays satisfied. Read here, not earlier: each check between
+    # this read and the merge widens the window. It cannot reach zero (GitHub has no base
+    # pin), but it is one API call wide.
+    BASE_NOW=$(gh pr view <pr> -R "$R" --json baseRefName -q .baseRefName) \
+      || { echo "cannot re-read the merge target — do NOT merge"; exit 1; }
+    [ -n "$BASE_NOW" ] && [ "$BASE_NOW" = "$BASE" ] \
+      || { echo "the PR was retargeted ($BASE -> ${BASE_NOW:-unknown}) — the panel reviewed against $BASE; re-run the panel"; exit 1; }
+    gh pr merge <pr> -R "$R" --squash --delete-branch --match-head-commit "$MERGING_SHA" \
+      || { echo "merge did not land — do NOT close the bead"; exit 1; }
+
+    # `gh pr merge` returning 0 means the PR was accepted for merging — which, in a repo with a
+    # required merge queue, means ENQUEUED, not landed. Fetching now would read the still-old
+    # base and any caller that closes a tracker item here would close it for a merge that has
+    # not happened. Wait for the state to actually reach MERGED.
+    _n=0
+    while [ "$_n" -lt 60 ]; do
+      _n=$((_n+1))
+      _ST=$(gh pr view <pr> -R "$R" --json state -q .state 2>/dev/null || echo "")
+      [ "$_ST" = "MERGED" ] && break
+      [ "$_ST" = "CLOSED" ] && { echo "PR was closed without merging"; exit 1; }
+      sleep 10
+    done
+    [ "$_ST" = "MERGED" ] || { echo "PR still not merged (state=$_ST) — do NOT proceed"; exit 1; }
+
+    # Reset from where the merge LANDED. On a fork clone `origin` is your fork and does
+    # not contain the upstream squash commit, so resetting to origin/$BASE silently starts
+    # the next bead from a tree missing the one just merged — its PR then replays or
+    # conflicts with it.
+    # gh's own clone URL: `owner/repo` alone points at public github.com, which on GitHub
+    # Enterprise either fails or resolves an unrelated public repo of the same name.
+    R_URL=$(gh repo view "$R" --json url -q .url 2>/dev/null) \
+  || { echo "cannot resolve the clone URL for $R — do NOT merge"; exit 1; }
+    git fetch "$R_URL.git" "+refs/heads/$BASE:refs/remotes/upstream/$BASE" \
+      || { echo "cannot fetch the merge target"; echo "  (on a private repo cloned over SSH this is usually missing git credentials for https, not a missing base)"; exit 1; }
+    # `checkout -B` moves the branch ref unconditionally, and a clean worktree does not
+    # protect committed work: any local commit on $BASE that upstream lacks becomes
+    # unreachable. A same-name fork PR is different: local $BASE is the feature head, and
+    # the squash commit cannot contain it. Allow only the verified, pinned PR head itself;
+    # a later local commit still refuses the reset.
+    if git show-ref --verify --quiet "refs/heads/$BASE" \
+       && ! git merge-base --is-ancestor "$BASE" "refs/remotes/upstream/$BASE"; then
+      if [ "$HEAD_BRANCH" != "$BASE" ] \
+         || [ "$(git rev-parse "refs/heads/$BASE")" != "$MERGING_SHA" ]; then
+        echo "local $BASE has commits upstream does not — refusing to reset; rebase or push them first"
+        exit 1
+      fi
+    fi
+    # Refuse a dirty worktree HERE, immediately before the reset: the merge-queue wait
+    # above can run ten minutes, and `checkout -B` silently CARRIES any nonconflicting
+    # tracked modification onto the fresh base — the build below then passes and the next
+    # bead inherits work that was never on this branch. FULL status, untracked included:
+    # checkout does not move an untracked file, but it does not remove it either, so a
+    # file created during the wait sits in the "fresh" base worktree where the build and
+    # the next bead's branch inherit it — unreviewed, and invisible to `-uno`.
+    _WT=$(git status --porcelain) || { echo "cannot read the worktree — not resetting"; exit 1; }
+    [ -z "$_WT" ] || { echo "worktree changed while waiting for the merge — resolve that before resetting to $BASE"; exit 1; }
+    git checkout -B "$BASE" "refs/remotes/upstream/$BASE" \
+      || { echo "cannot reset to the merge target"; exit 1; }
+    nix build
+    ```
+
+    Substitute `master` only when the repo actually uses `master`.
+
+<a id="backlog-step-11"></a>
+
+11. **Close the bead, through a reviewed path.** Run `br update <bead-id> -s closed`
+    after the merged code is present on the base branch. That write lands in the
+    tracked `.beads/*.jsonl`, so do **not** commit it straight to the default branch —
+    it would reach the branch unreviewed. Carry the closure commit into the next bead's
+    branch, where it rides that PR; when the queue is empty and there is no next branch,
+    open one small metadata PR for it **and land it** — carry it through review and merge
+    like any other. Opening it is not enough: until it merges, the closure never reaches
+    the default branch and a fresh clone still shows the bead open, which is the failure
+    this reviewed path exists to prevent. The drain is not done until that PR is merged. Do not leave it uncommitted either, or the next
+    run starts from a dirty base and silently carries the previous closure into its diff.
+
+    **Give the PR body a machine-readable marker line, one per bead it closes:**
+
+    ```text
+    bead-closure: <bead-id>
+    ```
+
+    Step 8 puts the bead id in every ordinary work PR body too, so the id alone cannot
+    distinguish "the work merged" from "the closure merged" — and step 12's resume
+    discovery depends on telling them apart. The marker is what it filters on.
+
+    Verify it landed with a checked *explicit* sync: it propagates a real exit code, which
+    the automatic flush after `br update` does not — that one swallows its error. The
+    mutation is already in the shared DB, so the sync either writes it out or fails loudly:
+
+    ```bash
+    # DIVERGENCE CHECK FIRST — `br update` auto-flushes, so an unstaged hand-edit in the
+    # JSONL is destroyed by this very command, and neither the index nor HEAD holds it.
+        _bw=$(br where --json) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
+        BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
+    # Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so a FAILED
+    # inspection reads as a clean tree and lets the write through — the guard failing open at
+    # exactly the moment it matters. Compare against HEAD, not the index: a damaged JSONL that
+    # is staged leaves a worktree-vs-index diff empty while HEAD holds the good bodies.
+    _st=$(git status --porcelain -- "$BEADS_JSONL") \
+      || { echo "cannot read the worktree — do NOT write"; exit 1; }
+    [ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
+      echo "JSONL differs from HEAD — read that diff and resolve it BEFORE writing"; exit 1; }
+    br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
+    br sync --flush-only || { echo "not persisted"; exit 1; }
+    ```
+
+    **Check for divergence BEFORE the first `br` write.** `br update` auto-flushes, so a
+    hand-edit sitting unstaged in the JSONL is destroyed by the very first mutation — and
+    since neither the index nor `HEAD` holds it, every later diff shows only your intended
+    change, which makes the loss *undetectable*, not merely unrecoverable. Resolve the real
+    path (`br where --json | jq -er .jsonl_path`; `.beads/issues.jsonl` is only the default
+    layout, and a hardcoded path diffs nothing on a `.beads.jsonl` repo — a false
+    all-clear) and run `git status --porcelain` on it before any `br` command.
+
+    **That sync proves the closure reached the file. It says nothing about what else the
+    same write overwrote.** Every `br` write flushes the whole gitignored cache over the
+    tracked JSONL, so a write to **one** bead rewrites **all** of them, and any body the
+    cache holds a stale copy of is reverted. Observed on `br 0.2.19`: closing a single bead
+    silently reverted ~40 KB of specification text across three *other* beads and deleted a
+    fourth. Exit 0, success message, nothing failed. This step is the last write of every
+    bead, which is how the drain routes you into it every time.
+
+    Hand-editing the JSONL is what makes the cache stale — a hand edit does not advance
+    `updated_at`, so cache and file hold different bodies under identical timestamps and
+    nothing can tell them apart. **Write bead text through `br update -d/--notes`, never
+    the file.** The task template's ".beads/ is orchestration state" line is a *reviewing*
+    scope rule, not an editing licence. And the advertised guard does not help: `br sync
+    --help`'s "Stale DB Guard" is an **id**-level check, so same-id-different-body — the
+    case that loses text — is unguarded by design.
+
+    So field-diff the resolved path before committing any `br` write. A full-file
+    re-serialization with every id on both sides is normal; ids on only one side, or a
+    `description` you did not touch, is the tell.
+
+    **Recovery depends on which side holds the good text, and guessing cements the loss.**
+
+    - **(a) cache stale, file still good** — rebuild the cache from the file.
+      `br sync --import-only` alone cannot do it: it compares `updated_at`, so equal
+      timestamps with different bodies report `Skipped: N (up-to-date)` forever. The stale
+      DB has to go first.
+    - **(b) the flush already ran and the diff shows damage** — the working copy *is* the
+      damaged artifact. Restore it from the good side, **rebuild the cache**, and only then
+      replay: replaying first lets the still-stale cache auto-flush over what you just
+      restored. Read `git diff --cached` and `git diff` and decide explicitly which of
+      the index or `HEAD` holds the good bodies; a staged copy only proves a choice exists,
+      and an earlier flush may have been staged before anyone noticed.
+
+    Four things the recipe must do in both cases, each learned by getting it wrong: back up
+    the cache and **check the copy succeeded**; **verify the DB and its `-wal`/`-shm`
+    siblings are actually gone** (`rm -f` is silent on a permissions failure, and a
+    surviving cache makes the import skip equal-timestamp records and report success);
+    **check the import and the replay before any flush** (the stale DB is already deleted,
+    so a failed import leaves an empty one and the flush writes *that* over what you just
+    restored); and **rebuild the cache BEFORE replaying anything** — restore, delete and
+    re-import the DB, and only then replay. Restoring the file and replaying straight away
+    lets the first `br` command auto-flush the *still-stale* cache over what you just
+    restored, destroying the recovery with the recovery. And **replay the complete intended
+    delta**, not one command: the drain's case is a single closure, but
+    `plan-to-beads-transfer` and `bead-polish-loop` batch, so restoring from git there
+    discards their legitimate work unless the whole manifest is replayed.
+
+    **A round summary is not a replay manifest.** It records what you decided, not the
+    generated ids, the exact field values, or the order they were written in — and recovery
+    discards the working JSONL before you can go back and read them off it. So batching
+    callers must write the manifest *before* the first mutation: one line per intended `br`
+    command, complete enough to re-run verbatim. A coverage matrix or a round summary
+    reconstructed afterwards is a description of the work, not a copy of it.
+
+    Git is the whole recovery, which is why the field-diff must happen **before** you stage
+    anything: an uncommitted hand-edit that a flush overwrote is simply gone. That is the
+    sharpest reason never to write bead text through the file.
+
+    This is **not** the pre-0.1.45 corruption bug in
+    [owning skill's Tool dependencies](../orchestrating-with-rb-lite/SKILL.md#tool-dependencies): no
+    `ISSUE_NOT_FOUND`, no branch reset, and every command reported success.
+
+    Closing on the feature branch before the merge is **not** a safe shortcut, however
+    transactional it looks — the beads DB is shared across branches with no git
+    awareness, and import is last-write-wins, so the closure leaks. See
+    `docs/adr/0003-bead-closure-stays-post-merge.md` for the code evidence.
+
+<a id="backlog-step-12"></a>
+
+12. **Loop.** Return to `br ready --limit 10` — but **on a resumed drain, look for an
+    in-flight closure PR before selecting work.** A closure lives on its metadata branch
+    until it merges, so a fresh clone of the default branch sees the old JSONL with the
+    bead still open and will happily rebuild and re-merge work that is already done. The
+    queue cannot tell you this; only the forge can:
+
+    ```bash
+    SELF=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
+      || { echo "cannot resolve this repository — closure-PR discovery is incomplete"; exit 1; }
+    PARENT=$(gh repo view --json parent -q 'if .parent then "\(.parent.owner.login)/\(.parent.name)" else "" end') \
+      || { echo "cannot resolve the parent repository — closure-PR discovery is incomplete"; exit 1; }
+    CLOSURE_PRS=()
+    for UP in ${PARENT:+"$PARENT"} "$SELF"; do
+      # `url` is not decoration: this loop MERGES parent and fork results, and a bare
+      # `number` is ambiguous across them — #42 exists in both. Acting on a parent hit with
+      # the fork's `-R` opens an unrelated same-numbered PR. The url carries the repository.
+      _PRS=$(gh pr list -R "$UP" --state all --limit 1000 --json number,state,headRefName,title,body,url) \
+        || { echo "cannot query closure PRs in $UP — do not resume work from partial results"; exit 1; }
+      CLOSURE_PRS+=("$_PRS")
+      # 1000 is a CAP, not "all of them". With more newer PRs than that, the older closure
+      # or work PR this recovery exists to find falls outside the snapshot, both filters
+      # come back empty, and the drain rebuilds work that already merged. A saturated page
+      # is the only case where anything can hide, so pay for the search only then.
+      if [ "$(printf '%s' "$_PRS" | jq 'length')" -ge 1000 ]; then
+        _MORE=$(gh pr list -R "$UP" --state all --limit 1000 --search "$BEAD_ID in:body" \
+                  --json number,state,headRefName,title,body,url) \
+          || { echo "closure search in $UP failed — do not resume from partial results"; exit 1; }
+        CLOSURE_PRS+=("$_MORE")
+      fi
+    done
+    printf '%s\n' "${CLOSURE_PRS[@]}" \
+      | jq -s --arg id "$BEAD_ID" 'add | unique_by(.url) | .[] | select($id != "" and ((.body // "") | ascii_downcase
+        | test("(^|\\r|\\n)[[:space:]]*bead-closure:[[:space:]]*" + ($id|ascii_downcase|gsub("\\.";"\\.")) + "[[:space:]]*(\\r|\\n|$)")))'
+    # SAME shell, same snapshot: the bead's work PRs, MERGED **or still OPEN**. Consulted
+    # whenever the marker query above is empty — see below. MERGED-only hid the third
+    # resume state: a work PR opened but not yet landed carries the bead id and no
+    # `bead-closure:` marker, so neither query saw it and the drain re-entered step 6 to
+    # rebuild work that was already open for review. Run separately this would re-fetch,
+    # and a fetch that failed here while the marker query succeeded would silently read as
+    # "nothing merged", the exact collapse this query exists to close.
+    printf '%s\n' "${CLOSURE_PRS[@]}" \
+      | jq -s --arg id "$BEAD_ID" 'add | unique_by(.url) | .[] | select(.state=="MERGED" or .state=="OPEN")
+          | select($id != "" and ((.body // "") | ascii_downcase
+            | test("(^|[^a-z0-9._-])" + ($id|ascii_downcase|gsub("\\.";"\\.")) + "([^a-z0-9._-]|$)")))'
+    ```
+
+    `BEAD_ID` is the bead you are about to take — loop this query over each open bead from
+    `br ready`/`br list` rather than assuming a variable survived the clone. Empty, the
+    filter rejects everything and the closure PR this exists to find is missed.
+
+    Keyed on the **`bead-closure:` marker plus the bead id**, not on the id alone: step 8
+    puts the id in every ordinary work PR body, so an id-only filter returns the merged
+    work PR for any bead whose work landed — which on a fresh clone looks exactly like
+    closure history when no closure was ever opened, and defeats the guard. Not a
+    branch-naming convention either — nothing mandates one. The raised `--limit` matters
+    because `gh pr list` returns 30 by default — an older closure PR hides behind newer
+    work PRs, which is the resume case this exists for.
+
+    **An empty result from the marker query answers only "no closure PR was opened" — it
+    is NOT evidence that nothing merged.** A drain that stops between step 10's merge and
+    step 11's closure PR leaves exactly that state: the work merged, the bead still open
+    in the JSONL, and no marker anywhere for the first query to find. Reading empty as
+    "unfinished" there rebuilds and re-merges code already on the base. The second query
+    in the block is what tells those apart: it asks the same snapshot whether the bead's
+    WORK already merged.
+
+    Read any hit before acting on it. **Take the repository from the hit's `url`, never
+    from the number alone** — these results merge the parent's PRs with the fork's, and
+    #42 exists in both; a parent hit acted on with the fork's `-R` lands you on an
+    unrelated PR. Then **read its `state` — it names where to resume**. `MERGED`: a merged PR carrying the id is almost certainly the work PR, and
+    the bead open in the default branch's JSONL beside it is precisely the interrupted
+    state; do **not** rebuild the bead, its code is on the base — resume at step 11, close
+    the bead and land the closure PR. `OPEN`: the work PR is up and has not landed, so
+    resume *that* PR's review-and-merge flow at step 9 rather than rebuilding — a rebuild
+    here races an open review and lands the bead twice.
+
+    Only when *both* queries are empty does "not started" stand, which is a narrower claim
+    than the "not started *or* not merged" this once read as — that phrasing quietly
+    folded the OPEN work PR into the same answer. On a drain older than these markers and
+    id-carrying bodies, even that needs the hits read by hand, because neither convention
+    was in force when its PRs were written.
+
+    An OPEN one: land it before taking another bead. A CLOSED-but-unmerged one is worse — the
+    work PR already merged, the closure never did, and `--state open` cannot see it: reopen
+    or replace it rather than rebuilding the bead. `drive`'s resume checklist does
+    the same discovery for the same reason (`skills/drive/references/phases.md` § LAND).
+
+    Stop when the queue is empty **and** any
+    final metadata PR from step 11 has merged — an open closure PR means the drain is
+    still in flight, however empty the queue looks. Also stop when
+    the user says stop, a bead needs human product/security judgment, or a
+    P0/P1 dogfood bead interrupts the queue.

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -180,7 +180,10 @@ recorded acceptance of the reduced review coverage.
    # reverted — exit 0, no warning — and an audit over a truncated graph reviews text the
    # reviewers will never see. Check BEFORE flushing: afterwards the file matches the index
    # again, so the diff comes back empty and the loss is undetectable. Recovery is in
-   # ../orchestrating-with-rb-lite/SKILL.md step 11.
+   # exact companion skill rb-lite-backlog-drain, step 11:
+   # ../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
+   # Companion unavailable: stop, rerun the same installer command once, reload it, and
+   # do not improvise this procedure.
    _bw=$(br where --json) || { echo "cannot resolve the JSONL"; exit 1; }
    BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
    # INSPECT, do not gate on cleanliness: the normal bead-polish-loop handoff arrives with

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -174,7 +174,8 @@ br sync --flush-only || { echo "flush failed — do not audit an unwritten graph
 # would have objected to is already gone. Field-diff it, key the +/- lines by `id`, and
 # assert only the fields you meant to change moved. Ids on one side only, or a
 # `description` this session did not write, is the tell. Recovery:
-# ../../orchestrating-with-rb-lite/SKILL.md step 11.
+# exact companion skill rb-lite-backlog-drain, step 11:
+# ../../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
 git diff -- "$BEADS_JSONL"
 ```
 


### PR DESCRIPTION
## Summary

- split three oversized workflows into exact-name internal companion skills so Tau can load every procedure within its 65,536-byte source limit
- teach selective installation and target-local upgrade repair about companion dependencies
- pin Tau source/description limits, companion contracts, installer self-reexec, and upgrade edge cases in install.test
- harden moved backlog-drain and PR-merge procedures while preserving their owning workflow entry points

## Tradeoffs

- internal companions are model-loadable by exact name and set user-invocable: false
- explicit selective installs receive dependency closure; upgrade reconciliation repairs one direct hop per target to avoid silently adding standalone workflows
- a pre-self-reexec installer may require the documented one-time repeated selective update

## Verification

- ./install.test — passed 25, failed 0
- ./skills/pr-with-codex-bot-review/scripts/bot-gate.test — passed 124, failed 0
- ./skills/drive/scripts/drive-status.test — passed 70, failed 0
- git diff --cached --check — clean before commit

## Local review

Codex gpt-5.6-sol at xhigh and Claude Opus 5 at high effort reviewed iteratively through 21 confirmation rounds. Accepted findings were fixed and covered where practical.

Per explicit disposition, the final three findings are filed rather than included in this PR:

- #61 — zero-argument installer behavior on Bash 4.0–4.3
- #62 — modified secondary checkout can reexec shared-clone code
- #63 — quoted YAML-equivalent companion names are rejected

## GitHub review

- CI: pending
- chatgpt-codex-connector: pending
- CodeRabbit: pending if configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated companion-skill discovery, installation, upgrade, and repair.
  * Added workflows for delegated review edits, backlog processing, and safe pull request merging.
  * Added validation for skill descriptions, required files, links, and recovery guidance.

* **Documentation**
  * Clarified gate outcomes, merge-blocking statuses, installation behavior, and companion-skill usage.
  * Updated workflow references and evaluation criteria.

* **Tests**
  * Expanded coverage for installer updates, selective installation, companion recovery, validation, and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->