### PR TITLE
Add fail-closed Beads JSONL resolver

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+./skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
 ./install.test
 ./skills/pr-with-codex-bot-review/scripts/bot-gate.test
 ./skills/drive/scripts/drive-status.test

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -989,7 +989,10 @@ on success. Sweep every executable block, prose instruction, and comment that
 resolves the Beads JSONL to use the exact installed companion path. When no
 installed target resolves, the operator may explicitly invoke the checkout owner's
 resolver by its trusted absolute path; do not auto-execute a repository-relative
-fallback. Require:
+fallback. Installed resolver candidates and the fully canonical targets of
+PATH-selected `br`/`jq` must be single-link regular files outside the driven
+worktree so an external pathname cannot alias worktree-controlled proof code.
+Require:
 
 ```bash
 _bw_file=$(mktemp) ||

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -995,6 +995,22 @@ worktree so an external pathname cannot alias worktree-controlled proof code.
 Installed candidates retain the canonical `#!/bin/sh` entry point, while
 `br`/`jq` run with the implementation's POSIX utility path so a script cannot
 resolve its interpreter or child utilities from the driven worktree.
+Every later Beads command runs as
+`"$BEADS_JSONL_RESOLVER" --run-br <args...>`, which revalidates and launches
+the same `br` through that clean environment rather than returning to a
+caller-shell function or PATH lookup.
+The installed companion also owns a validated `git-clean` sibling: caller-side
+diff/add commands run through it so inherited `GIT*` selectors cannot
+reappear after the resolver child exits; the runner pins trusted Git, disables
+replacement objects and fsmonitor, and uses the POSIX utility path. Diff
+consumers additionally disable external diff drivers and textconv filters, and
+add consumers hash/stage the exact file bytes without repository clean filters.
+When the documented transaction immediately commits and pushes that staged
+JSONL, it stays inside the runner, with inherited transport selectors,
+repository hooks, and signing disabled. Push additionally disables credential
+helpers, askpass, SSH config commands, and interactive prompts while retaining
+the caller's SSH agent. HTTPS re-enables only system/global credential helpers
+after refusing a `HOME` or `XDG_CONFIG_HOME` inside the driven worktree.
 Require:
 
 ```bash

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -986,8 +986,10 @@ Create exact companion owner:
 `resolve-beads-jsonl` runs the following resolution, additionally verifies that
 the result is inside the current Git worktree, and prints only that absolute path
 on success. Sweep every executable block, prose instruction, and comment that
-resolves the Beads JSONL to use the exact installed companion path, falling back
-to the checkout owner only when no installed target resolves. Require:
+resolves the Beads JSONL to use the exact installed companion path. When no
+installed target resolves, the operator may explicitly invoke the checkout owner's
+resolver by its trusted absolute path; do not auto-execute a repository-relative
+fallback. Require:
 
 ```bash
 _bw_file=$(mktemp) ||
@@ -1028,6 +1030,7 @@ BEADS_JSONL=$(
          ((.[0] | type) == "object") and
          ((.[0].jsonl_path | type) == "string") and
          ((.[0].jsonl_path | length) > 0) and
+         (.[0].jsonl_path | startswith("/")) and
          ((.[0].jsonl_path | contains("\u0000")) | not) and
          ((.[0].jsonl_path | test("[\r\n]")) | not)
        then .[0].jsonl_path
@@ -1046,7 +1049,7 @@ or one tested fact owner with equivalent fail-closed behavior.
 The displayed shell captures raw stdout to a private file and rejects a NUL at
 the byte level before JSON parsing or command substitution; only validated jq
 output enters a shell variable. It also pins JSON cardinality and rejects
-NUL/CR/LF in the decoded path before jq emits it. The companion owns
+relative or NUL/CR/LF-bearing decoded paths before jq emits one. The companion owns
 the remaining byte-safe inspection. It canonicalizes the current worktree root
 and resolved parent without following the final path, requires the path to be
 inside that root, and reads raw NUL-delimited `git ls-files --stage -z`,
@@ -1060,6 +1063,20 @@ worktree bytes without filters and requires all three byte strings to be
 identical before printing the path. It therefore refuses staged, unstaged,
 mode-only, hidden-index-flag, unmerged, missing, ignored/untracked, symlink,
 gitlink, and wrong-worktree states rather than trusting porcelain visibility.
+
+The companion also exposes two explicit read-only modes required by existing
+handoffs. `--allow-dirty` relaxes only the three-way byte-identity requirement;
+it retains containment, one normally flagged tracked stage-0 `100644` index
+entry, a matching regular HEAD entry, and a non-symlink regular `100644`
+worktree file before returning a path. Because `git ls-files -v` reports `H`
+for an fsmonitor-valid entry, that mode additionally reads `git ls-files -f -z`
+and, when Git is answering for the path from the monitor's cache, requires the
+index blob and worktree bytes to match: a missed write would otherwise leave the
+consumer's own `git status` and `git diff HEAD` showing a clean file. `--recovery` may name an absent or
+untracked path after byte-safe resolution and containment, but it still refuses
+symlink and nonregular occupants. Recovery mode names an artifact for
+restoration only and never authorizes a subsequent Beads query, mutation, or
+flush.
 
 Likely consumers include Drive, plan transfer, bead polish, rb-lite backlog
 drain, and orchestration guidance. Add this companion to their selective-install

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -1055,8 +1055,11 @@ and resolved parent without following the final path, requires the path to be
 inside that root, and reads raw NUL-delimited `git ls-files --stage -z`,
 `git ls-files -v -z`, and
 `git ls-tree -z HEAD -- "$BEADS_JSONL_REL"` records, where
-`BEADS_JSONL_REL` is the validated worktree-relative path. Success requires exactly
-one stage-0 tracked regular-file entry, mode `100644`, tag `H` (not lowercase
+`BEADS_JSONL_REL` is the validated worktree-relative path. Every Git inspection
+uses that literal path with replacement objects and `core.fsmonitor` disabled;
+disabling the monitor prevents a repository-configured executable hook from
+running during this read-only proof. Success requires exactly one stage-0
+tracked regular-file entry, mode `100644`, tag `H` (not lowercase
 assume-unchanged or `S` skip-worktree), the same regular mode in HEAD, and a
 non-symlink regular worktree file. It reads the HEAD blob, index blob, and
 worktree bytes without filters and requires all three byte strings to be
@@ -1069,12 +1072,10 @@ handoffs. `--allow-dirty` relaxes only the three-way byte-identity requirement;
 it retains containment, one normally flagged tracked stage-0 `100644` index
 entry that is not intent-to-add, a matching regular HEAD entry, and a
 non-symlink regular `100644` worktree file before returning a path. Because
-`git ls-files -v` reports `H`
-for an fsmonitor-valid entry, that mode additionally reads `git ls-files -f -z`
-and, when Git is answering for the path from the monitor's cache, requires the
-index blob and worktree bytes to match: a missed write would otherwise leave the
-consumer's own `git status` and `git diff HEAD` showing a clean file. `--recovery` may name an absent or
-untracked path after byte-safe resolution and containment, but it still refuses
+the resolver and every documented consumer force `core.fsmonitor=false`, a
+stale monitor answer cannot hide the content difference this mode intentionally
+permits from the consumer's own `git status` or `git diff HEAD`. `--recovery`
+may name an absent or untracked path after byte-safe resolution and containment, but it still refuses
 symlink and nonregular occupants and every path equal to or below `$GIT_DIR`,
 `--git-common-dir`, or `<worktree>/.git`. Recovery mode names an artifact for
 restoration only and never authorizes a subsequent Beads query, mutation, or

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -1067,14 +1067,16 @@ gitlink, and wrong-worktree states rather than trusting porcelain visibility.
 The companion also exposes two explicit read-only modes required by existing
 handoffs. `--allow-dirty` relaxes only the three-way byte-identity requirement;
 it retains containment, one normally flagged tracked stage-0 `100644` index
-entry, a matching regular HEAD entry, and a non-symlink regular `100644`
-worktree file before returning a path. Because `git ls-files -v` reports `H`
+entry that is not intent-to-add, a matching regular HEAD entry, and a
+non-symlink regular `100644` worktree file before returning a path. Because
+`git ls-files -v` reports `H`
 for an fsmonitor-valid entry, that mode additionally reads `git ls-files -f -z`
 and, when Git is answering for the path from the monitor's cache, requires the
 index blob and worktree bytes to match: a missed write would otherwise leave the
 consumer's own `git status` and `git diff HEAD` showing a clean file. `--recovery` may name an absent or
 untracked path after byte-safe resolution and containment, but it still refuses
-symlink and nonregular occupants. Recovery mode names an artifact for
+symlink and nonregular occupants and every path equal to or below `$GIT_DIR`,
+`--git-common-dir`, or `<worktree>/.git`. Recovery mode names an artifact for
 restoration only and never authorizes a subsequent Beads query, mutation, or
 flush.
 
@@ -1088,9 +1090,9 @@ returning nonzero after emitting valid JSON; missing, null, empty, or non-string
 `jq`; NUL/CR/LF path values; and a resolved path outside the current worktree.
 Focused fixtures prove that each failure performs no Beads mutation or flush.
 Further fixtures cover staged-only, unstaged-only, staged-plus-unstaged,
-mode-only, assume-unchanged, skip-worktree, unmerged, symlink, gitlink,
+mode-only, intent-to-add, assume-unchanged, skip-worktree, unmerged, symlink, gitlink,
 ignored/untracked, missing, and nonregular JSONL state, plus a path inside a
-different worktree; each is refused before any mutation or flush. This is P0
+different worktree and a Git administrative path; each is refused before any mutation or flush. This is P0
 because the
 first `br` write after an ambiguous resolution can export a stale cache over the
 tracked JSONL and silently destroy unstaged bead bodies.

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -992,6 +992,9 @@ resolver by its trusted absolute path; do not auto-execute a repository-relative
 fallback. Installed resolver candidates and the fully canonical targets of
 PATH-selected `br`/`jq` must be single-link regular files outside the driven
 worktree so an external pathname cannot alias worktree-controlled proof code.
+Installed candidates retain the canonical `#!/bin/sh` entry point, while
+`br`/`jq` run with the implementation's POSIX utility path so a script cannot
+resolve its interpreter or child utilities from the driven worktree.
 Require:
 
 ```bash

--- a/docs/specs/backlog-execution-plan.md
+++ b/docs/specs/backlog-execution-plan.md
@@ -1061,7 +1061,7 @@ disabling the monitor prevents a repository-configured executable hook from
 running during this read-only proof. Success requires exactly one stage-0
 tracked regular-file entry, mode `100644`, tag `H` (not lowercase
 assume-unchanged or `S` skip-worktree), the same regular mode in HEAD, and a
-non-symlink regular worktree file. It reads the HEAD blob, index blob, and
+non-symlink, single-link regular worktree file. It reads the HEAD blob, index blob, and
 worktree bytes without filters and requires all three byte strings to be
 identical before printing the path. It therefore refuses staged, unstaged,
 mode-only, hidden-index-flag, unmerged, missing, ignored/untracked, symlink,
@@ -1076,7 +1076,7 @@ the resolver and every documented consumer force `core.fsmonitor=false`, a
 stale monitor answer cannot hide the content difference this mode intentionally
 permits from the consumer's own `git status` or `git diff HEAD`. `--recovery`
 may name an absent or untracked path after byte-safe resolution and containment, but it still refuses
-symlink and nonregular occupants and every path equal to or below `$GIT_DIR`,
+symlink, multiply linked, and nonregular occupants and every path equal to or below `$GIT_DIR`,
 `--git-common-dir`, or `<worktree>/.git`. Recovery mode names an artifact for
 restoration only and never authorizes a subsequent Beads query, mutation, or
 flush.
@@ -1091,7 +1091,8 @@ returning nonzero after emitting valid JSON; missing, null, empty, or non-string
 `jq`; NUL/CR/LF path values; and a resolved path outside the current worktree.
 Focused fixtures prove that each failure performs no Beads mutation or flush.
 Further fixtures cover staged-only, unstaged-only, staged-plus-unstaged,
-mode-only, intent-to-add, assume-unchanged, skip-worktree, unmerged, symlink, gitlink,
+mode-only, intent-to-add, assume-unchanged, skip-worktree, unmerged, symlink,
+hard-link, gitlink,
 ignored/untracked, missing, and nonregular JSONL state, plus a path inside a
 different worktree and a Git administrative path; each is refused before any mutation or flush. This is P0
 because the

--- a/install.sh
+++ b/install.sh
@@ -116,10 +116,10 @@ companion_dependencies() {
       printf '%s\n' multi-reviewer-loop
       ;;
     orchestrating-with-rb-lite|bead-polish-loop|plan-to-beads-transfer|second-model-bead-audit)
-      printf '%s\n' rb-lite-backlog-drain
+      printf '%s\n' rb-lite-backlog-drain beads-jsonl-path
       ;;
     rb-lite-backlog-drain)
-      printf '%s\n' orchestrating-with-rb-lite
+      printf '%s\n' orchestrating-with-rb-lite beads-jsonl-path
       ;;
     pr-with-codex-bot-review)
       printf '%s\n' pr-with-codex-bot-review-merge
@@ -128,7 +128,7 @@ companion_dependencies() {
       printf '%s\n' pr-with-codex-bot-review
       ;;
     drive)
-      printf '%s\n' rb-lite-backlog-drain pr-with-codex-bot-review-merge
+      printf '%s\n' rb-lite-backlog-drain pr-with-codex-bot-review-merge beads-jsonl-path
       ;;
   esac
 }

--- a/install.test
+++ b/install.test
@@ -525,8 +525,8 @@ skills/plan-to-beads-transfer/SKILL.md|beads-jsonl-path/scripts/resolve-beads-js
 skills/plan-to-beads-transfer/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
 skills/second-model-bead-audit/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
 skills/second-model-bead-audit/references/reviewer-panel.md|beads-jsonl-path/scripts/resolve-beads-jsonl
-skills/second-model-bead-audit/references/reviewer-panel.md|git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
-skills/second-model-bead-audit/SKILL.md|git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
+skills/second-model-bead-audit/references/reviewer-panel.md|git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
+skills/second-model-bead-audit/SKILL.md|git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
 skills/rb-lite-backlog-drain/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
 skills/rb-lite-backlog-drain/SKILL.md|"$BEADS_JSONL_RESOLVER" --recovery
 skills/drive/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
@@ -899,7 +899,7 @@ while IFS= read -r consumer; do
     resolver_consistency_failures+="$consumer accepts a relative installed target; "
   elif ! grep -Fq -- 'case $_bjp_root:$_bjp_candidate_dir in' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not compare canonical resolver location to the worktree; "
-  elif ! grep -Fq -- '_bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel' \
+  elif ! grep -Fq -- '_bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel' \
       "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer caches or replacement-spoofs the driven worktree root; "
   elif ! grep -Fq -- 'installed beads-jsonl-path target is inside the current Git worktree' \
@@ -994,11 +994,11 @@ fi
 # bytes. Every later Git operation must preserve that byte identity and ignore
 # replacement objects: otherwise a pathspec can name a sibling, or a replacement
 # ref can make an unsafe pre-flush diff appear empty.
-t="every Git consumer treats the resolved JSONL literally without replacement objects"
+t="every Git consumer treats the resolved JSONL literally without replacement objects or fsmonitor hooks"
 literal_pathspec_failures=""
 while IFS= read -r occurrence; do
   case $occurrence in
-    *'git --no-replace-objects --literal-pathspecs '*) ;;
+    *'git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs '*) ;;
     *) literal_pathspec_failures+="$occurrence; " ;;
   esac
 done < <(

--- a/install.test
+++ b/install.test
@@ -577,12 +577,12 @@ b=$(mktemp -d "$WORK/locator.XXXXXX")
 mkdir -p "$b/home/.claude/skills/beads-jsonl-path/scripts" \
   "$b/codexhome/skills/beads-jsonl-path/scripts"
 command cat >"$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'CLAUDE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' claude >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/claude.jsonl
 CLAUDE_RESOLVER
 command cat >"$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'CODEX_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' codex >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/codex.jsonl
 CODEX_RESOLVER
@@ -631,7 +631,7 @@ b=$(mktemp -d "$WORK/locator.XXXXXX")
 mkdir -p "$b/repo/.codex/skills/beads-jsonl-path/scripts" "$b/home"
 git init -q "$b/repo"
 command cat >"$b/repo/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'WORKTREE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' worktree >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/worktree.jsonl
 WORKTREE_RESOLVER
@@ -659,7 +659,7 @@ b=$(mktemp -d "$WORK/locator.XXXXXX")
 mkdir -p "$b/repo" "$b/home/.claude/skills/beads-jsonl-path/scripts"
 git init -q "$b/repo"
 command cat >"$b/repo/planted-resolver" <<'HARDLINKED_WORKTREE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' hardlink >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/hardlink.jsonl
 HARDLINKED_WORKTREE_RESOLVER
@@ -682,6 +682,42 @@ else
   pass "$t"
 fi
 
+# The canonical resolver enters through absolute /bin/sh. Refuse an installed
+# script whose interpreter is PATH-resolved, otherwise a driven worktree can
+# supply that interpreter after the trusted locator returns to the caller shell.
+t="resolver locator refuses a PATH-resolved candidate interpreter"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/repo/bin" "$b/home/.claude/skills/beads-jsonl-path/scripts"
+git init -q "$b/repo"
+command cat >"$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'ENV_INTERPRETER_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' interpreter >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/interpreter.jsonl
+ENV_INTERPRETER_RESOLVER
+chmod +x "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+trusted_bash=$(command -p -v bash)
+command cat >"$b/repo/bin/bash" <<PATH_BASH
+#!/bin/sh
+printf '%s\n' bash >>"\$LOCATOR_EXECUTIONS"
+exec "$trusted_bash" "\$@"
+PATH_BASH
+chmod +x "$b/repo/bin/bash"
+(
+  cd "$b/repo" || exit 98
+  HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
+    PATH="$b/repo/bin:$PATH" "$trusted_bash" -c "$locator_block" >"$b/stdout" 2>"$b/stderr"
+)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "a PATH-resolved resolver interpreter was accepted"
+elif [[ -e "$b/executions" ]]; then
+  fail "$t" "the PATH-resolved resolver interpreter executed"
+elif ! grep -Fq -- 'installed beads-jsonl-path resolver has an unexpected interpreter' "$b/stderr"; then
+  fail "$t" "missing interpreter diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
 # Hostile functions, PATH executables, and Git repository selectors arrive from
 # the caller at the same time as a repository-controlled absolute CODEX_HOME.
 # The legacy control reports /etc as the worktree, so it executes the planted
@@ -700,7 +736,7 @@ git -C "$b/main" worktree add -q -b locator-second "$b/second" HEAD
 git init -q --bare "$b/hostile-admin"
 mkdir -p "$b/second/.codex/skills/beads-jsonl-path/scripts" "$b/second/bin"
 command cat >"$b/second/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'HOSTILE_WORKTREE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' planted >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/planted.jsonl
 HOSTILE_WORKTREE_RESOLVER
@@ -790,12 +826,12 @@ mkdir -p "$b/repo-a" "$b/repo-b/.codex/skills/beads-jsonl-path/scripts" \
 git init -q "$b/repo-a"
 git init -q "$b/repo-b"
 command cat >"$b/safe-home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'SAFE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' safe >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/safe.jsonl
 SAFE_RESOLVER
 command cat >"$b/repo-b/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'SECOND_WORKTREE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' worktree >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/worktree.jsonl
 SECOND_WORKTREE_RESOLVER
@@ -835,7 +871,7 @@ mkdir -p "$b/home/.claude/skills/beads-jsonl-path" \
 printf -- '---\nname: beads-jsonl-path\n---\n' \
   >"$b/home/.claude/skills/beads-jsonl-path/SKILL.md"
 command cat >"$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'SIBLING_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' codex >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/codex.jsonl
 SIBLING_RESOLVER
@@ -858,7 +894,7 @@ mkdir -p "$b/home/.claude/skills/beads-jsonl-path/scripts" "$b/codexhome/skills"
 printf -- '---\nname: beads-jsonl-path\n---\n' \
   >"$b/home/.claude/skills/beads-jsonl-path/SKILL.md"
 command cat >"$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'UNUSABLE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' claude >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/claude.jsonl
 UNUSABLE_RESOLVER
@@ -882,7 +918,7 @@ t="resolver locator refuses a relative installed target before execution"
 b=$(mktemp -d "$WORK/locator.XXXXXX")
 mkdir -p "$b/home" "$b/driven/.codex/skills/beads-jsonl-path/scripts"
 command cat >"$b/driven/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'RELATIVE_RESOLVER'
-#!/usr/bin/env bash
+#!/bin/sh
 printf '%s\n' relative >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/relative.jsonl
 RELATIVE_RESOLVER
@@ -923,6 +959,9 @@ while IFS= read -r consumer; do
   elif ! grep -Fq -- 'installed beads-jsonl-path resolver has multiple hard links' \
       "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer accepts a multiply linked resolver candidate; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path resolver has an unexpected interpreter' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer accepts a PATH-resolved resolver interpreter; "
   elif ! grep -Fq -- '_bjp_git_environment=( "${!GIT_@}" )' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not clear inherited Git repository selectors; "
   elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then' \

--- a/install.test
+++ b/install.test
@@ -1545,9 +1545,13 @@ elif ! grep -Fq -- 'cannot push the reviewed JSONL commit' "$transaction"; then
 elif ! grep -Fq -- '-c core.hooksPath=/dev/null' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
   fail "$t" 'clean commit can execute repository hooks'
-elif ! grep -Fq -- 'command unset SSH_ASKPASS SSH_ASKPASS_REQUIRE DISPLAY WAYLAND_DISPLAY' \
+elif ! grep -Fq -- '_bjg_push_environment=(' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- '"$_bjg_env" -i "PATH=$_bjg_safe_path" "LC_ALL=C"' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- 'exec "${_bjg_push_environment[@]}" "$_bjg_git"' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
-  fail "$t" 'clean push retains caller-selected askpass execution'
+  fail "$t" 'clean push does not cross an explicit environment allowlist'
 elif ! grep -Fq -- 'ProxyCommand=none -o PermitLocalCommand=no -o BatchMode=yes' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
   fail "$t" 'clean push retains caller-selected SSH command execution'

--- a/install.test
+++ b/install.test
@@ -27,6 +27,15 @@ PASS=0; FAIL=0
 pass() { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
 fail() { FAIL=$((FAIL+1)); printf '  FAIL %s\n         %s\n' "$1" "$2"; }
 
+add_locator_git_runner() {
+  local resolver=$1 runner=${1%/*}/git-clean
+  command cat >"$runner" <<'LOCATOR_GIT_RUNNER'
+#!/bin/sh
+exit 97
+LOCATOR_GIT_RUNNER
+  chmod +x "$runner"
+}
+
 # A self-contained clone plus two target roots, so no test can see another's state or
 # the real $HOME.
 # mktemp, not a counter: this runs inside `$( )`, so an `N=$((N+1))` here increments a
@@ -525,8 +534,6 @@ skills/plan-to-beads-transfer/SKILL.md|beads-jsonl-path/scripts/resolve-beads-js
 skills/plan-to-beads-transfer/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
 skills/second-model-bead-audit/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
 skills/second-model-bead-audit/references/reviewer-panel.md|beads-jsonl-path/scripts/resolve-beads-jsonl
-skills/second-model-bead-audit/references/reviewer-panel.md|git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
-skills/second-model-bead-audit/SKILL.md|git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
 skills/rb-lite-backlog-drain/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
 skills/rb-lite-backlog-drain/SKILL.md|"$BEADS_JSONL_RESOLVER" --recovery
 skills/drive/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
@@ -588,6 +595,8 @@ printf '%s\n' /tmp/codex.jsonl
 CODEX_RESOLVER
 chmod +x "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" \
   "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+add_locator_git_runner "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+add_locator_git_runner "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
 locator_block=$(awk '
   $0 == "```bash" && !found { found = 1; next }
   found && $0 == "```" { exit }
@@ -718,6 +727,48 @@ else
   pass "$t"
 fi
 
+# Metadata and shebang reads must never open an executable FIFO/device candidate.
+t="resolver locator refuses an executable nonregular candidate without blocking"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/repo" "$b/home/.claude/skills/beads-jsonl-path/scripts"
+git init -q "$b/repo"
+mkfifo "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+chmod 700 "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+(
+  cd "$b/repo" || exit 98
+  HOME="$b/home" CODEX_HOME="$b/codexhome" TRUSTED_BASH="$trusted_bash" \
+    LOCATOR_BLOCK="$locator_block" LOCATOR_STDOUT="$b/stdout" LOCATOR_STDERR="$b/stderr" \
+    python3 - <<'PY'
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+try:
+    completed = subprocess.run(
+        [os.environ["TRUSTED_BASH"], "-c", os.environ["LOCATOR_BLOCK"]],
+        env=os.environ,
+        capture_output=True,
+        timeout=3,
+    )
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+Path(os.environ["LOCATOR_STDOUT"]).write_bytes(completed.stdout)
+Path(os.environ["LOCATOR_STDERR"]).write_bytes(completed.stderr)
+sys.exit(completed.returncode)
+PY
+)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "an executable FIFO resolver was accepted"
+elif [[ $rc -eq 124 || $rc -eq 137 ]]; then
+  fail "$t" "locator blocked while opening the executable FIFO"
+elif ! grep -Fq -- 'installed beads-jsonl-path resolver is not a regular file' "$b/stderr"; then
+  fail "$t" "missing nonregular diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
 # Hostile functions, PATH executables, and Git repository selectors arrive from
 # the caller at the same time as a repository-controlled absolute CODEX_HOME.
 # The legacy control reports /etc as the worktree, so it executes the planted
@@ -837,6 +888,7 @@ printf '%s\n' /tmp/worktree.jsonl
 SECOND_WORKTREE_RESOLVER
 chmod +x "$b/safe-home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" \
   "$b/repo-b/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+add_locator_git_runner "$b/safe-home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
 LOCATOR_BLOCK="$locator_block" LOCATOR_EXECUTIONS="$b/executions" \
   REPO_A="$b/repo-a" REPO_B="$b/repo-b" SAFE_HOME="$b/safe-home" \
   EMPTY_HOME="$b/empty-home" bash -c '
@@ -876,6 +928,7 @@ printf '%s\n' codex >>"$LOCATOR_EXECUTIONS"
 printf '%s\n' /tmp/codex.jsonl
 SIBLING_RESOLVER
 chmod +x "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+add_locator_git_runner "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
 HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
   bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"; rc=$?
 if [[ $rc -ne 0 ]]; then
@@ -959,14 +1012,29 @@ while IFS= read -r consumer; do
   elif ! grep -Fq -- 'installed beads-jsonl-path resolver has multiple hard links' \
       "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer accepts a multiply linked resolver candidate; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path resolver is not a regular file' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer may open a nonregular resolver candidate; "
   elif ! grep -Fq -- 'installed beads-jsonl-path resolver has an unexpected interpreter' \
       "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer accepts a PATH-resolved resolver interpreter; "
-  elif ! grep -Fq -- '_bjp_git_environment=( "${!GIT_@}" )' "$HERE/$consumer"; then
+  elif ! grep -Fq -- 'installed beads-jsonl-path Git runner has multiple hard links' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer accepts a multiply linked Git runner; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path Git runner is not a regular file' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer may open a nonregular Git runner; "
+  elif ! grep -Fq -- 'BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not expose the validated clean Git runner; "
+  elif ! grep -Fq -- '_bjp_git_environment=( "${!GIT@}" )' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not clear inherited Git repository selectors; "
-  elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then' \
+  elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"' \
     "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not compare installed resolver candidates; "
+  elif ! grep -Fq -- '|| ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then' \
+    "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not compare installed Git runners; "
   elif ! grep -Fq -- 'installed beads-jsonl-path companions disagree' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer lacks the divergence refusal; "
   elif ! grep -Fq -- 'installed beads-jsonl-path target is not absolute' "$HERE/$consumer"; then
@@ -1068,15 +1136,21 @@ fi
 # bytes. Every later Git operation must preserve that byte identity and ignore
 # replacement objects: otherwise a pathspec can name a sibling, or a replacement
 # ref can make an unsafe pre-flush diff appear empty.
-t="every Git consumer treats the resolved JSONL literally without replacement objects or fsmonitor hooks"
+t="every Git consumer uses the clean runner and treats the resolved JSONL literally"
 literal_pathspec_failures=""
 while IFS= read -r occurrence; do
   case $occurrence in
-    *'git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs '*) ;;
+    *'"$BEADS_GIT_RUNNER" --literal-pathspecs diff '*)
+      case $occurrence in
+        *' diff --no-ext-diff --no-textconv --text '*) ;;
+        *) literal_pathspec_failures+="$occurrence lacks external-diff refusal; " ;;
+      esac
+      ;;
+    *'"$BEADS_GIT_RUNNER" --literal-pathspecs '*) ;;
     *) literal_pathspec_failures+="$occurrence; " ;;
   esac
 done < <(
-  grep -nHE -- 'git .*(status|diff|add).*\$BEADS_JSONL' \
+  grep -nHE -- '(git |BEADS_GIT_RUNNER).*(status|diff|add)[[:space:]].*\$BEADS_JSONL' \
     "$HERE/skills/beads-jsonl-path/SKILL.md" \
     "$HERE/skills/orchestrating-with-rb-lite/references/harden-until-clean.md" \
     "$HERE/skills/rb-lite-backlog-drain/SKILL.md" \
@@ -1089,6 +1163,358 @@ done < <(
 )
 if [[ -n "$literal_pathspec_failures" ]]; then
   fail "$t" "$literal_pathspec_failures"
+else
+  pass "$t"
+fi
+
+t="resolver and clean Git runner purge the full GIT environment prefix"
+git_environment_failures=""
+for sanitizer in \
+  skills/beads-jsonl-path/scripts/resolve-beads-jsonl \
+  skills/beads-jsonl-path/scripts/git-clean; do
+  if ! grep -Fq -- '"${!GIT@}"' "$HERE/$sanitizer"; then
+    git_environment_failures+="$sanitizer does not include GITPERLLIB-class variables; "
+  fi
+done
+if [[ -n "$git_environment_failures" ]]; then
+  fail "$t" "$git_environment_failures"
+else
+  pass "$t"
+fi
+
+t="every Beads consumer keeps commands inside the validated br runner"
+bare_br_failures=""
+while IFS= read -r consumer; do
+  if grep -nE '^[[:space:]]*br[[:space:]]' "$HERE/$consumer" \
+      >"$WORK/bare-br.$$"; then
+    bare_br_failures+="$consumer:$(tr '\n' ',' <"$WORK/bare-br.$$"); "
+  fi
+done <<'BR_RUNNER_CONSUMERS'
+skills/bead-polish-loop/SKILL.md
+skills/drive/SKILL.md
+skills/drive/references/phases.md
+skills/orchestrating-with-rb-lite/SKILL.md
+skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+skills/plan-to-beads-transfer/SKILL.md
+skills/rb-lite-backlog-drain/SKILL.md
+skills/second-model-bead-audit/SKILL.md
+skills/second-model-bead-audit/references/reviewer-panel.md
+BR_RUNNER_CONSUMERS
+rm -f "$WORK/bare-br.$$"
+if [[ -n "$bare_br_failures" ]]; then
+  fail "$t" "$bare_br_failures"
+else
+  pass "$t"
+fi
+
+t="graph snapshots use clean copy and comparison utilities"
+panel="$HERE/skills/second-model-bead-audit/references/reviewer-panel.md"
+if grep -Eq -- '^[[:space:]]*cp[[:space:]].*\$BEADS_JSONL|^[[:space:]]*diff[[:space:]]+-u' \
+    "$panel"; then
+  fail "$t" 'review panel returns to caller copy/diff utilities'
+elif ! grep -Fq -- '"$BEADS_GIT_RUNNER" copy-file' "$panel"; then
+  fail "$t" 'review panel lacks clean snapshot copies'
+elif ! grep -Fq -- '"$BEADS_GIT_RUNNER" diff-files' "$panel"; then
+  fail "$t" 'review panel lacks clean byte comparison'
+elif ! grep -Fq -- '"$BEADS_GIT_RUNNER" snapshot-files' "$panel" \
+    || ! grep -Fq -- '"$BEADS_GIT_RUNNER" verify-files' "$panel"; then
+  fail "$t" 'review panel does not keep source capture and drift admission clean'
+elif grep -Eq -- '^[[:space:]]*(cp|cmp|tr|sha256sum|shasum)[[:space:]]' "$panel"; then
+  fail "$t" 'review panel returns to caller utilities for audit evidence'
+elif grep -Eq -- '^[[:space:]]*(bv|timeout|gtimeout|codex|claude|cat)[[:space:]]' \
+    "$panel" \
+    || ! grep -Fq -- '"$BEADS_GIT_RUNNER" run-audit-tool bv' "$panel" \
+    || ! grep -Fq -- '"$BEADS_GIT_RUNNER" resolve-tool codex' "$panel" \
+    || ! grep -Fq -- '"$BEADS_GIT_RUNNER" resolve-tool claude' "$panel"; then
+  fail "$t" 'review panel returns to caller-selected audit/model tools'
+elif ! grep -Fq -- 'unset BEADS_DIFF_REVIEWED' "$panel"; then
+  fail "$t" 'review panel can reuse a stale pre-flush acknowledgement'
+elif ! grep -Fq -- 'unset BEADS_POSTFLUSH_REVIEWED' "$panel"; then
+  fail "$t" 'review panel can reuse a stale post-flush acknowledgement'
+elif ! grep -Fq -- '0|1) ;;' "$panel"; then
+  fail "$t" 'review panel does not distinguish content differences from diff errors'
+else
+  pass "$t"
+fi
+
+t="final audit drift check preserves a concurrent JSONL edit before any flush"
+drift_dir="$WORK/audit-drift.$$"
+mkdir -p "$drift_dir"
+printf '%s\n' baseline >"$drift_dir/baseline"
+printf '%s\n' concurrent-edit >"$drift_dir/live"
+cp "$drift_dir/baseline" "$drift_dir/cache"
+cat >"$drift_dir/resolver" <<'AUDIT_DRIFT_RESOLVER'
+#!/bin/sh
+case $1 in
+  --allow-dirty) printf '%s\n' "$AUDIT_DRIFT_LIVE" ;;
+  --run-br)
+    cp "$AUDIT_DRIFT_CACHE" "$AUDIT_DRIFT_LIVE"
+    : >"$AUDIT_DRIFT_SYNC_RAN"
+    ;;
+  *) exit 2 ;;
+esac
+AUDIT_DRIFT_RESOLVER
+cat >"$drift_dir/runner" <<'AUDIT_DRIFT_RUNNER'
+#!/bin/sh
+case $1 in
+  copy-file) cp "$2" "$3" ;;
+  verify-files) exit 0 ;;
+  *) exit 2 ;;
+esac
+AUDIT_DRIFT_RUNNER
+chmod +x "$drift_dir/resolver" "$drift_dir/runner"
+drift_block=$(awk '
+  /^PANEL_INVALID=false$/ { capture=1 }
+  capture && /^```$/ { exit }
+  capture { print }
+' "$panel")
+if (
+  BEADS_JSONL_RESOLVER="$drift_dir/resolver"
+  BEADS_GIT_RUNNER="$drift_dir/runner"
+  BEADS_JSONL="$drift_dir/live"
+  GRAPH_AFTER_JSONL="$drift_dir/after"
+  GRAPH_AFTER_SYNC_JSONL="$drift_dir/after-sync"
+  SOURCE_STATE_BEFORE="$drift_dir/source-before"
+  SOURCE_STATE_AFTER="$drift_dir/source-after"
+  SOURCE_FILES=()
+  GRAPH_FINGERPRINT=$(git hash-object --no-filters "$drift_dir/baseline")
+  fingerprint_file() { git hash-object --no-filters "$1"; }
+  export AUDIT_DRIFT_LIVE="$drift_dir/live" AUDIT_DRIFT_CACHE="$drift_dir/cache"
+  export AUDIT_DRIFT_SYNC_RAN="$drift_dir/sync-ran"
+  eval "$drift_block"
+) >"$drift_dir/stdout" 2>"$drift_dir/stderr"; then
+  drift_rc=0
+else
+  drift_rc=$?
+fi
+rm -f "$drift_dir/sync-ran"
+cp "$drift_dir/baseline" "$drift_dir/alternate"
+if (
+  BEADS_JSONL_RESOLVER="$drift_dir/resolver"
+  BEADS_GIT_RUNNER="$drift_dir/runner"
+  BEADS_JSONL="$drift_dir/baseline"
+  GRAPH_AFTER_JSONL="$drift_dir/switched-after"
+  GRAPH_AFTER_SYNC_JSONL="$drift_dir/switched-after-sync"
+  SOURCE_STATE_BEFORE="$drift_dir/switched-source-before"
+  SOURCE_STATE_AFTER="$drift_dir/switched-source-after"
+  SOURCE_FILES=()
+  GRAPH_FINGERPRINT=$(git hash-object --no-filters "$drift_dir/baseline")
+  fingerprint_file() { git hash-object --no-filters "$1"; }
+  export AUDIT_DRIFT_LIVE="$drift_dir/alternate"
+  export AUDIT_DRIFT_CACHE="$drift_dir/cache"
+  export AUDIT_DRIFT_SYNC_RAN="$drift_dir/sync-ran"
+  eval "$drift_block"
+) >"$drift_dir/switched.stdout" 2>"$drift_dir/switched.stderr"; then
+  switch_rc=0
+else
+  switch_rc=$?
+fi
+if [[ $drift_rc -eq 0 ]]; then
+  fail "$t" 'concurrent edit did not invalidate the panel'
+elif [[ $(<"$drift_dir/live") != concurrent-edit ]]; then
+  fail "$t" 'final drift check overwrote the concurrent edit'
+elif [[ -e "$drift_dir/sync-ran" ]]; then
+  fail "$t" 'final drift check flushed before blocking on live drift'
+elif [[ ! -e "$drift_dir/after" || $(<"$drift_dir/after") != concurrent-edit ]]; then
+  fail "$t" 'final drift check did not preserve the changed live bytes'
+elif [[ $switch_rc -eq 0 ]]; then
+  fail "$t" 'equal-byte JSONL target switch did not invalidate the panel'
+elif [[ -e "$drift_dir/sync-ran" ]]; then
+  fail "$t" 'final drift check flushed after the JSONL target switched'
+else
+  pass "$t"
+fi
+
+t="second-model audit delegates destructive graph capture to one hardened owner"
+audit_owner="$HERE/skills/second-model-bead-audit/SKILL.md"
+if grep -Fq -- 'BEADS_DIFF_REVIEWED' "$audit_owner" \
+    || grep -Fq -- 'BEADS_POSTFLUSH_REVIEWED' "$audit_owner"; then
+  fail "$t" 'owning skill duplicates the panel flush/acknowledgement transaction'
+elif ! grep -Fq -- \
+    '[Shared graph snapshot procedure](references/reviewer-panel.md#shared-graph-snapshot)' \
+    "$audit_owner"; then
+  fail "$t" 'owning skill does not delegate to the hardened snapshot owner'
+else
+  pass "$t"
+fi
+
+t="audit JSON decisions stay inside the validated jq runner"
+if grep -Fq -- 'ISSUE_IDS=$(jq' "$panel" \
+    || grep -Fq -- 'if jq -' "$panel" \
+    || grep -Fq -- 'CLAUDE_DENIALS=$(jq' "$panel" \
+    || grep -Eq -- '^[[:space:]]*jq -r' "$panel"; then
+  fail "$t" 'review panel returns to caller-shell jq for an audit decision'
+elif [[ $(grep -Fc -- '"$BEADS_JSONL_RESOLVER" --run-jq' "$panel") -lt 4 ]]; then
+  fail "$t" 'review panel does not route every audit JSON decision through validated jq'
+elif grep -Fq -- "grep -qE '^(Read|Glob|Grep)$'" "$panel"; then
+  fail "$t" 'review panel hands a denial decision back to caller-shell grep'
+else
+  pass "$t"
+fi
+
+t="Claude model probe stays inside validated audit-tool and jq boundaries"
+probe_dir="$WORK/claude-probe.$$"
+mkdir -p "$probe_dir/path" "$probe_dir/audit"
+probe_jq=$(command -p -v jq)
+cat >"$probe_dir/runner" <<'CLEAN_PROBE_RUNNER'
+#!/bin/sh
+case $1 in
+  resolve-tool)
+    [ "$2" = claude ] || exit 2
+    printf '%s\n' /validated/claude
+    ;;
+  run-audit-tool)
+    shift
+    [ "$1" = timeout ] || exit 2
+    case " $* " in
+      *" /validated/claude "*)
+        _probe_args=" $* "
+        for _probe_required in --no-session-persistence --safe-mode \
+          --strict-mcp-config --mcp-config --tools --allowedTools; do
+          case $_probe_args in
+            *" $_probe_required "*) ;;
+            *) exit 94 ;;
+          esac
+        done
+        printf '%s\n' '{"is_error":false,"result":"PANEL_OK"}'
+        ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *) exit 2 ;;
+esac
+CLEAN_PROBE_RUNNER
+cat >"$probe_dir/resolver" <<CLEAN_PROBE_RESOLVER
+#!/bin/sh
+[ "\$1" = --run-jq ] || exit 2
+shift
+exec "$probe_jq" "\$@"
+CLEAN_PROBE_RESOLVER
+chmod +x "$probe_dir/runner" "$probe_dir/resolver"
+for probe_tool in timeout gtimeout claude jq command; do
+  cat >"$probe_dir/path/$probe_tool" <<PROBE_PATH_SHIM
+#!/bin/sh
+printf '%s\n' '$probe_tool' >>'$probe_dir/ambient-ran'
+exit 1
+PROBE_PATH_SHIM
+  chmod +x "$probe_dir/path/$probe_tool"
+done
+probe_block=$(awk '
+  /^CLAUDE_MODEL=""$/ { capture=1 }
+  capture { print }
+  /^unset _CLAUDE_PROBE_TIMEOUT _rc$/ { exit }
+' "$panel")
+if (
+  for probe_tool in timeout gtimeout claude jq command; do
+    eval "$probe_tool() { printf '%s\\n' '$probe_tool' >>'$probe_dir/ambient-ran'; return 1; }"
+    export -f "$probe_tool"
+  done
+  PATH="$probe_dir/path:$PATH"
+  BEADS_GIT_RUNNER="$probe_dir/runner"
+  BEADS_JSONL_RESOLVER="$probe_dir/resolver"
+  AUDIT_DIR="$probe_dir/audit"
+  CLAUDE_REVIEWER_MODELS=fable
+  eval "$probe_block"
+  [ "$CLAUDE_MODEL" = fable ]
+) >"$probe_dir/stdout" 2>"$probe_dir/stderr"; then
+  probe_rc=0
+else
+  probe_rc=$?
+fi
+if [[ $probe_rc -ne 0 ]]; then
+  fail "$t" "clean probe exit $probe_rc: $(<"$probe_dir/stderr")"
+elif [[ -e "$probe_dir/ambient-ran" ]]; then
+  fail "$t" 'model probe executed a caller function or PATH shim'
+else
+  pass "$t"
+fi
+
+t="clean Git runner pins pager and textual diff behavior"
+git_runner_diff_arm=$(sed -n '/^  diff)$/,/^  add)$/p' \
+  "$HERE/skills/beads-jsonl-path/scripts/git-clean")
+if [[ "$git_runner_diff_arm" != *'"$_bjg_git" --no-pager --no-replace-objects'* ]]; then
+  fail "$t" 'git-clean does not disable caller-selected pagers'
+elif [[ "$git_runner_diff_arm" != *'diff --no-ext-diff --no-textconv --text'* ]]; then
+  fail "$t" 'git-clean can hide JSON bodies behind attributes or diff drivers'
+else
+  pass "$t"
+fi
+
+t="Beads staging transaction keeps commit and push inside the clean Git runner"
+transaction="$HERE/skills/orchestrating-with-rb-lite/references/harden-until-clean.md"
+transaction_block=$(sed -n '/Then flush and commit/,/Do not stage that file unread/p' \
+  "$transaction")
+if ! grep -Fq -- 'BEADS_COMMIT_OID=$("$BEADS_GIT_RUNNER" commit --only-reviewed "$BEADS_JSONL"' \
+    "$transaction" \
+    || ! grep -Fq -- '--expect-oid "$BEADS_REVIEWED_OID"' "$transaction" \
+    || ! grep -Fq -- '--expect-head "$BEADS_REVIEWED_HEAD"' "$transaction"; then
+  fail "$t" 'Beads transaction returns to caller-shell Git for commit'
+elif ! grep -Fq -- '"$BEADS_GIT_RUNNER" push --remote origin --branch "$WORK_BRANCH"' \
+    "$transaction" \
+    || ! grep -Fq -- '--expect-head "$BEADS_COMMIT_OID"' "$transaction"; then
+  fail "$t" 'Beads transaction returns to caller-shell Git for push'
+elif ! grep -Fq -- 'BEADS_REVIEWED_OID=$("$BEADS_GIT_RUNNER" hash-file "$BEADS_JSONL")' \
+    "$transaction" \
+    || ! grep -Fq -- 'BEADS_REVIEWED_HEAD=$("$BEADS_GIT_RUNNER" head-oid)' \
+    "$transaction" \
+    || ! grep -Fq -- 'BEADS_POSTDIFF_OID=$("$BEADS_GIT_RUNNER" hash-file "$BEADS_JSONL")' \
+    "$transaction" \
+    || ! grep -Fq -- 'BEADS_POSTDIFF_HEAD=$("$BEADS_GIT_RUNNER" head-oid)' \
+    "$transaction" \
+    || ! grep -Fq -- 'add --expect-oid "$BEADS_REVIEWED_OID" -- "$BEADS_JSONL"' \
+    "$transaction"; then
+  fail "$t" 'Beads transaction does not bind staging to the reviewed JSONL bytes'
+elif [[ "$transaction_block" != *$'unset BEADS_DIFF_REVIEWED\n"$BEADS_GIT_RUNNER" --literal-pathspecs diff'* ]]; then
+  fail "$t" 'Beads transaction resets its acknowledgement after rather than before the diff'
+elif ! grep -Fq -- 'cannot stage the reviewed JSONL — do NOT commit' "$transaction"; then
+  fail "$t" 'Beads transaction continues after staging failure'
+elif ! grep -Fq -- 'cannot commit the reviewed JSONL — do NOT push' "$transaction"; then
+  fail "$t" 'Beads transaction continues after commit failure'
+elif ! grep -Fq -- 'cannot push the reviewed JSONL commit' "$transaction"; then
+  fail "$t" 'Beads transaction masks push failure'
+elif ! grep -Fq -- '-c core.hooksPath=/dev/null' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean commit can execute repository hooks'
+elif ! grep -Fq -- 'command unset SSH_ASKPASS SSH_ASKPASS_REQUIRE DISPLAY WAYLAND_DISPLAY' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push retains caller-selected askpass execution'
+elif ! grep -Fq -- 'ProxyCommand=none -o PermitLocalCommand=no -o BatchMode=yes' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push retains caller-selected SSH command execution'
+elif ! grep -Fq -- '-c push.gpgSign=false -c core.askPass=' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push retains repository-selected askpass execution'
+elif ! grep -Fq -- '-c protocol.allow=never \' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- '_bjg_transport_config+=( -c protocol.ssh.allow=always' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- '_bjg_transport_config+=( -c protocol.ssh.allow=never )' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push permits unreviewed transport helpers'
+elif ! grep -Fq -- '-c protocol.https.allow=always -c protocol.http.allow=never' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push permits plaintext credential-bearing transport'
+elif ! grep -Fq -- 'configured credential helper is not a simple named helper' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- 'credential helper resolves inside the current Git worktree' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push trusts an unvalidated credential helper'
+elif ! grep -Fq -- 'credential store requires an explicit --file path' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push accepts unvalidated default credential-store aliases'
+elif ! grep -Fq -- '_bjg_proof_environment=( "$_bjg_env" -i' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean proof utilities retain caller option/startup environments'
+elif ! grep -Fq -- '-c push.default=nothing -c push.followTags=false' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- 'push "$_bjg_push_remote" "$_bjg_push_head:refs/heads/$_bjg_push_branch"' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push can expand repository-selected refspecs'
+elif ! grep -Fq -- 'symbolic-ref --quiet --short HEAD' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- 'clean push branch does not match the current branch' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean push does not bind the remote branch to attached HEAD'
 else
   pass "$t"
 fi

--- a/install.test
+++ b/install.test
@@ -652,6 +652,36 @@ else
   pass "$t"
 fi
 
+# A candidate pathname outside the driven worktree may still be a hard link to
+# a worktree-controlled resolver inode. Reject it before executing those bytes.
+t="resolver locator refuses a hard-linked worktree companion"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/repo" "$b/home/.claude/skills/beads-jsonl-path/scripts"
+git init -q "$b/repo"
+command cat >"$b/repo/planted-resolver" <<'HARDLINKED_WORKTREE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' hardlink >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/hardlink.jsonl
+HARDLINKED_WORKTREE_RESOLVER
+chmod +x "$b/repo/planted-resolver"
+ln "$b/repo/planted-resolver" \
+  "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+(
+  cd "$b/repo" || exit 98
+  HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
+    bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"
+)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "a hard-linked worktree resolver was accepted"
+elif [[ -e "$b/executions" ]]; then
+  fail "$t" "the hard-linked worktree resolver executed"
+elif ! grep -Fq -- 'installed beads-jsonl-path resolver has multiple hard links' "$b/stderr"; then
+  fail "$t" "missing hard-link diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
 # Hostile functions, PATH executables, and Git repository selectors arrive from
 # the caller at the same time as a repository-controlled absolute CODEX_HOME.
 # The legacy control reports /etc as the worktree, so it executes the planted
@@ -888,6 +918,11 @@ while IFS= read -r consumer; do
     resolver_consistency_failures+="$consumer does not pin Git to Bash's POSIX utility path; "
   elif ! grep -Fq -- '_bjp_cmp=$(command -p -v cmp)' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not pin cmp to Bash's POSIX utility path; "
+  elif ! grep -Fq -- '_bjp_stat=$(command -p -v stat)' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not pin stat to Bash's POSIX utility path; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path resolver has multiple hard links' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer accepts a multiply linked resolver candidate; "
   elif ! grep -Fq -- '_bjp_git_environment=( "${!GIT_@}" )' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not clear inherited Git repository selectors; "
   elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then' \

--- a/install.test
+++ b/install.test
@@ -652,12 +652,12 @@ else
   pass "$t"
 fi
 
-# Hostile functions and PATH executables arrive from the caller at the same time
-# as a repository-controlled absolute CODEX_HOME. The legacy control has the old
-# ambient selection shape: poisoned `git` reports /etc as the worktree, so it
-# executes the planted resolver. The documented block must cross its clean Bash
-# boundary and pin proof utilities before it asks Git or compares candidates.
-t="resolver locator isolates hostile functions and PATH tools before CODEX_HOME provenance"
+# Hostile functions, PATH executables, and Git repository selectors arrive from
+# the caller at the same time as a repository-controlled absolute CODEX_HOME.
+# The legacy control reports /etc as the worktree, so it executes the planted
+# resolver. The documented block must cross its clean Bash boundary, clear
+# inherited GIT_* state, and pin proof utilities before provenance checks.
+t="resolver locator isolates hostile shell and Git state before CODEX_HOME provenance"
 b=$(mktemp -d "$WORK/locator.XXXXXX")
 mkdir -p "$b/main" "$b/home"
 git init -q "$b/main"
@@ -667,6 +667,7 @@ printf '%s\n' baseline >"$b/main/baseline"
 git -C "$b/main" add -- baseline
 git -C "$b/main" commit -qm baseline
 git -C "$b/main" worktree add -q -b locator-second "$b/second" HEAD
+git init -q --bare "$b/hostile-admin"
 mkdir -p "$b/second/.codex/skills/beads-jsonl-path/scripts" "$b/second/bin"
 command cat >"$b/second/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'HOSTILE_WORKTREE_RESOLVER'
 #!/usr/bin/env bash
@@ -706,6 +707,7 @@ done
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 97
 '
 HOME="$b/home" CODEX_HOME="$b/second/.codex" DRIVEN_WORKTREE="$b/second" \
+  GIT_DIR="$b/hostile-admin" GIT_WORK_TREE=/etc \
   HOSTILE_PATH_TOOLS_RAN="$b/path-tools-ran" PATH="$b/second/bin:$PATH" \
   LOCATOR_EXECUTIONS="$b/executions" LEGACY_LOCATOR_BLOCK="$legacy_locator_block" bash -c '
     git() { printf "%s\n" /etc; }
@@ -722,6 +724,7 @@ else
   unlink "$b/executions"
   rm -f "$b/path-tools-ran"
   if HOME="$b/home" CODEX_HOME="$b/second/.codex" DRIVEN_WORKTREE="$b/second" \
+      GIT_DIR="$b/hostile-admin" GIT_WORK_TREE=/etc \
       HOSTILE_PATH_TOOLS_RAN="$b/path-tools-ran" PATH="$b/second/bin:$PATH" \
       LOCATOR_EXECUTIONS="$b/executions" LOCATOR_BLOCK="$locator_block" bash -c '
         git() { printf "%s\n" /etc; }
@@ -885,6 +888,8 @@ while IFS= read -r consumer; do
     resolver_consistency_failures+="$consumer does not pin Git to Bash's POSIX utility path; "
   elif ! grep -Fq -- '_bjp_cmp=$(command -p -v cmp)' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not pin cmp to Bash's POSIX utility path; "
+  elif ! grep -Fq -- '_bjp_git_environment=( "${!GIT_@}" )' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not clear inherited Git repository selectors; "
   elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then' \
     "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not compare installed resolver candidates; "

--- a/install.test
+++ b/install.test
@@ -1207,6 +1207,17 @@ else
   pass "$t"
 fi
 
+t="Beads write guidance names a complete valid update command"
+invalid_update_guidance=$(grep -RFl --include='*.md' -- '-d/--notes' \
+  "$HERE/skills/bead-polish-loop" "$HERE/skills/drive" \
+  "$HERE/skills/rb-lite-backlog-drain" "$HERE/skills/plan-to-beads-transfer" \
+  "$HERE/skills/orchestrating-with-rb-lite" || true)
+if [[ -n "$invalid_update_guidance" ]]; then
+  fail "$t" "invalid combined br update flag remains in: $invalid_update_guidance"
+else
+  pass "$t"
+fi
+
 t="graph snapshots use clean copy and comparison utilities"
 panel="$HERE/skills/second-model-bead-audit/references/reviewer-panel.md"
 if grep -Eq -- '^[[:space:]]*cp[[:space:]].*\$BEADS_JSONL|^[[:space:]]*diff[[:space:]]+-u' \
@@ -1233,6 +1244,11 @@ elif ! grep -Fq -- 'unset BEADS_POSTFLUSH_REVIEWED' "$panel"; then
   fail "$t" 'review panel can reuse a stale post-flush acknowledgement'
 elif ! grep -Fq -- '0|1) ;;' "$panel"; then
   fail "$t" 'review panel does not distinguish content differences from diff errors'
+elif grep -Fq -- 'grep -cE' "$panel" \
+    && grep -Fq -- '|| true)' "$panel"; then
+  fail "$t" 'review panel masks audit finding-count I/O errors'
+elif [[ $(grep -Fc -- '[ "$grep_rc" -eq 1 ] || return 1' "$panel") -lt 3 ]]; then
+  fail "$t" 'review panel does not distinguish grep no-match from grep failure'
 else
   pass "$t"
 fi

--- a/install.test
+++ b/install.test
@@ -632,6 +632,55 @@ else
   pass "$t"
 fi
 
+# Loader variables must be cleared in the already-running caller shell. Clearing
+# them inside a shebang script is too late because its interpreter has already
+# loaded LD_PRELOAD. Exercise the documented locator on Linux when a C compiler
+# is available; the source contract above remains mandatory on every platform.
+t="resolver locator clears loader injection before starting any child"
+if [[ $(uname -s) == Linux ]] && loader_cc=$(command -p -v cc 2>/dev/null); then
+  b=$(mktemp -d "$WORK/locator-loader.XXXXXX")
+  mkdir -p "$b/repo" "$b/home/.claude/skills/beads-jsonl-path/scripts"
+  git init -q "$b/repo"
+  command cat >"$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'LOADER_SAFE_RESOLVER'
+#!/bin/sh
+printf '%s\n' safe >"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/safe.jsonl
+LOADER_SAFE_RESOLVER
+  chmod +x "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+  add_locator_git_runner "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+  command cat >"$b/preload.c" <<'LOADER_PRELOAD_SOURCE'
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+__attribute__((constructor)) static void loaded(void) {
+  const char *path = getenv("LOADER_MARKER");
+  if (!path) return;
+  int fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0600);
+  if (fd >= 0) { (void)write(fd, "loaded\n", 7); (void)close(fd); }
+}
+LOADER_PRELOAD_SOURCE
+  "$loader_cc" -shared -fPIC -o "$b/repo/preload.so" "$b/preload.c"
+  (
+    cd "$b/repo" || exit 98
+    HOME="$b/home" CODEX_HOME="$b/codexhome" \
+      LOCATOR_EXECUTIONS="$b/executions" LOADER_MARKER="$b/loader-ran" \
+      LOADER_LIBRARY="$b/repo/preload.so" LOCATOR_BLOCK="$locator_block" \
+      bash -c 'export LD_PRELOAD=$LOADER_LIBRARY; eval "$LOCATOR_BLOCK"'
+  ) >"$b/stdout" 2>"$b/stderr"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    fail "$t" "loader-clean locator exit $rc: $(<"$b/stderr")"
+  elif [[ -e "$b/loader-ran" ]]; then
+    fail "$t" 'a child loaded the worktree-selected preload library'
+  elif [[ ! -e "$b/executions" || $(<"$b/executions") != safe ]]; then
+    fail "$t" 'loader-clean locator did not execute the validated resolver'
+  else
+    pass "$t"
+  fi
+else
+  pass "$t"
+fi
+
 # CODEX_HOME is caller-controlled. An absolute spelling is not enough: a
 # repository can point it at its own `.codex` tree and plant the resolver there.
 # The locator must reject that candidate before its executable bytes run.
@@ -1027,6 +1076,11 @@ while IFS= read -r consumer; do
   elif ! grep -Fq -- 'BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean' \
       "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not expose the validated clean Git runner; "
+  elif ! grep -Fq -- '# Clear loader injection in this already-running shell before the locator starts' \
+      "$HERE/$consumer" \
+      || ! grep -Fq -- '\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer starts a child before clearing loader injection; "
   elif ! grep -Fq -- '_bjp_git_environment=( "${!GIT@}" )' "$HERE/$consumer"; then
     resolver_consistency_failures+="$consumer does not clear inherited Git repository selectors; "
   elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"' \
@@ -1093,7 +1147,7 @@ paths = [
 def locator(path):
     lines = path.read_text().splitlines(keepends=True)
     for start, line in enumerate(lines):
-        if line.lstrip(' \t') == 'BEADS_JSONL_RESOLVER=$(\n':
+        if line.lstrip(' \t') == '# Clear loader injection in this already-running shell before the locator starts\n':
             indent = line[:len(line) - len(line.lstrip(' \t'))]
             break
     else:

--- a/install.test
+++ b/install.test
@@ -1516,8 +1516,11 @@ transaction_block=$(sed -n '/Then flush and commit/,/Do not stage that file unre
   "$transaction")
 if ! grep -Fq -- 'BEADS_COMMIT_OID=$("$BEADS_GIT_RUNNER" commit --only-reviewed "$BEADS_JSONL"' \
     "$transaction" \
+    || ! grep -Fq -- 'BEADS_REVIEWED_BRANCH=$("$BEADS_GIT_RUNNER" head-branch)' \
+    "$transaction" \
     || ! grep -Fq -- '--expect-oid "$BEADS_REVIEWED_OID"' "$transaction" \
-    || ! grep -Fq -- '--expect-head "$BEADS_REVIEWED_HEAD"' "$transaction"; then
+    || ! grep -Fq -- '--expect-head "$BEADS_REVIEWED_HEAD"' "$transaction" \
+    || ! grep -Fq -- '--expect-branch "$BEADS_REVIEWED_BRANCH"' "$transaction"; then
   fail "$t" 'Beads transaction returns to caller-shell Git for commit'
 elif ! grep -Fq -- '"$BEADS_GIT_RUNNER" push --remote origin --branch "$WORK_BRANCH"' \
     "$transaction" \
@@ -1545,6 +1548,9 @@ elif ! grep -Fq -- 'cannot push the reviewed JSONL commit' "$transaction"; then
 elif ! grep -Fq -- '-c core.hooksPath=/dev/null' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
   fail "$t" 'clean commit can execute repository hooks'
+elif ! grep -Fq -- "--no-deref -m 'commit: reviewed Beads JSONL' \"\$_bjg_commit_ref\"" \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
+  fail "$t" 'clean commit updates symbolic HEAD instead of the reviewed branch ref'
 elif ! grep -Fq -- '_bjg_push_environment=(' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
     || ! grep -Fq -- '"$_bjg_env" -i "PATH=$_bjg_safe_path" "LC_ALL=C"' \
@@ -1584,7 +1590,9 @@ elif ! grep -Fq -- '-c push.default=nothing -c push.followTags=false' \
     || ! grep -Fq -- 'push "$_bjg_push_remote" "$_bjg_push_head:refs/heads/$_bjg_push_branch"' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then
   fail "$t" 'clean push can expand repository-selected refspecs'
-elif ! grep -Fq -- 'symbolic-ref --quiet --short HEAD' \
+elif ! grep -Fq -- 'symbolic-ref --quiet --no-recurse HEAD' \
+    "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
+    || ! grep -Fq -- '_bjg_push_current_branch=${_bjg_push_current_ref#refs/heads/}' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean" \
     || ! grep -Fq -- 'clean push branch does not match the current branch' \
     "$HERE/skills/beads-jsonl-path/scripts/git-clean"; then

--- a/install.test
+++ b/install.test
@@ -249,19 +249,25 @@ done <<'DEPENDENCIES'
 multi-reviewer-loop|multi-reviewer-loop-delegating-edits
 multi-reviewer-loop-delegating-edits|multi-reviewer-loop
 orchestrating-with-rb-lite|rb-lite-backlog-drain
+orchestrating-with-rb-lite|beads-jsonl-path
 rb-lite-backlog-drain|orchestrating-with-rb-lite
+rb-lite-backlog-drain|beads-jsonl-path
 pr-with-codex-bot-review|pr-with-codex-bot-review-merge
 pr-with-codex-bot-review-merge|pr-with-codex-bot-review
 drive|rb-lite-backlog-drain
 drive|orchestrating-with-rb-lite
 drive|pr-with-codex-bot-review-merge
 drive|pr-with-codex-bot-review
+drive|beads-jsonl-path
 bead-polish-loop|rb-lite-backlog-drain
 bead-polish-loop|orchestrating-with-rb-lite
+bead-polish-loop|beads-jsonl-path
 plan-to-beads-transfer|rb-lite-backlog-drain
 plan-to-beads-transfer|orchestrating-with-rb-lite
+plan-to-beads-transfer|beads-jsonl-path
 second-model-bead-audit|rb-lite-backlog-drain
 second-model-bead-audit|orchestrating-with-rb-lite
+second-model-bead-audit|beads-jsonl-path
 DEPENDENCIES
 if [[ -n "$dependency_failures" ]]; then fail "$t" "$dependency_failures"
 else pass "$t"; fi
@@ -286,6 +292,12 @@ while IFS='|' read -r owner companion; do
 done <<'UPGRADES'
 multi-reviewer-loop|multi-reviewer-loop-delegating-edits
 orchestrating-with-rb-lite|rb-lite-backlog-drain
+orchestrating-with-rb-lite|beads-jsonl-path
+rb-lite-backlog-drain|beads-jsonl-path
+drive|beads-jsonl-path
+bead-polish-loop|beads-jsonl-path
+plan-to-beads-transfer|beads-jsonl-path
+second-model-bead-audit|beads-jsonl-path
 pr-with-codex-bot-review|pr-with-codex-bot-review-merge
 UPGRADES
 if [[ -n "$upgrade_failures" ]]; then fail "$t" "$upgrade_failures"
@@ -297,7 +309,8 @@ ln -s "$b/clone/skills/drive" "$b/home/.claude/skills/drive"
 run "$b" --target claude voice-dna >/dev/null; rc=$?
 if [[ $rc -ne 0 ]]; then fail "$t" "asymmetric repair exited $rc"
 elif [[ ! -L "$b/home/.claude/skills/rb-lite-backlog-drain" \
-     || ! -L "$b/home/.claude/skills/pr-with-codex-bot-review-merge" ]]; then
+     || ! -L "$b/home/.claude/skills/pr-with-codex-bot-review-merge" \
+     || ! -L "$b/home/.claude/skills/beads-jsonl-path" ]]; then
   fail "$t" "drive's direct companions were not repaired"
 elif [[ -e "$b/home/.claude/skills/orchestrating-with-rb-lite" \
      || -e "$b/home/.claude/skills/pr-with-codex-bot-review" ]]; then
@@ -436,6 +449,7 @@ t="critical companion-skill handoffs remain loadable"
 link_failures=""
 backlog_ref="$HERE/skills/rb-lite-backlog-drain/SKILL.md"
 for required_ref in \
+  skills/beads-jsonl-path/SKILL.md \
   skills/multi-reviewer-loop-delegating-edits/SKILL.md \
   skills/pr-with-codex-bot-review-merge/SKILL.md; do
   if [[ ! -f "$HERE/$required_ref" ]]; then
@@ -455,6 +469,10 @@ while IFS='|' read -r consumer target; do
   fi
 done <<'LINKS'
 skills/rb-lite-backlog-drain/SKILL.md|name: rb-lite-backlog-drain
+skills/beads-jsonl-path/SKILL.md|name: beads-jsonl-path
+skills/beads-jsonl-path/SKILL.md|scripts/resolve-beads-jsonl
+skills/beads-jsonl-path/SKILL.md|user-invocable: false
+skills/beads-jsonl-path/SKILL.md|"$BEADS_JSONL_RESOLVER" --recovery
 skills/rb-lite-backlog-drain/SKILL.md|user-invocable: false
 skills/multi-reviewer-loop-delegating-edits/SKILL.md|name: multi-reviewer-loop-delegating-edits
 skills/multi-reviewer-loop-delegating-edits/SKILL.md|user-invocable: false
@@ -496,6 +514,22 @@ skills/bead-polish-loop/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-
 skills/plan-to-beads-transfer/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
 skills/second-model-bead-audit/SKILL.md|../rb-lite-backlog-drain/SKILL.md#backlog-step-11
 skills/second-model-bead-audit/references/reviewer-panel.md|../../rb-lite-backlog-drain/SKILL.md#backlog-step-11
+skills/orchestrating-with-rb-lite/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/orchestrating-with-rb-lite/references/harden-until-clean.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/rb-lite-backlog-drain/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/drive/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/drive/references/phases.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/bead-polish-loop/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/bead-polish-loop/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
+skills/plan-to-beads-transfer/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/plan-to-beads-transfer/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
+skills/second-model-bead-audit/SKILL.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/second-model-bead-audit/references/reviewer-panel.md|beads-jsonl-path/scripts/resolve-beads-jsonl
+skills/second-model-bead-audit/references/reviewer-panel.md|git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
+skills/second-model-bead-audit/SKILL.md|git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL"
+skills/rb-lite-backlog-drain/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
+skills/rb-lite-backlog-drain/SKILL.md|"$BEADS_JSONL_RESOLVER" --recovery
+skills/drive/SKILL.md|"$BEADS_JSONL_RESOLVER" --allow-dirty
 skills/multi-reviewer-loop/SKILL.md|Companion unavailable: do not delegate
 skills/pr-with-codex-bot-review/SKILL.md|Companion unavailable: stop
 skills/orchestrating-with-rb-lite/SKILL.md|Companion unavailable: stop
@@ -506,6 +540,502 @@ skills/second-model-bead-audit/SKILL.md|Companion unavailable: stop
 LINKS
 if [[ -n "$link_failures" ]]; then fail "$t" "$link_failures"
 else pass "$t"; fi
+
+# Every resolver snippet runs in the agent's shell inside the repository being driven, so a
+# candidate named relative to that repository is code THAT repository controls — the same
+# provenance bug drive's Phase 0 refuses. Take installed targets or fail closed; the
+# checkout fallback is an explicit absolute invocation, never an automatic relative one.
+t="no consumer executes a repository-relative beads resolver"
+provenance_failures=""
+while IFS= read -r consumer; do
+  if grep -Eq -- '(-x|exec|\$\()[[:space:]]*"?skills/beads-jsonl-path/scripts/resolve-beads-jsonl' \
+    "$HERE/$consumer"; then
+    provenance_failures+="$consumer executes a repo-relative resolver; "
+  fi
+done <<'RESOLVER_CONSUMERS'
+skills/beads-jsonl-path/SKILL.md
+skills/orchestrating-with-rb-lite/SKILL.md
+skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+skills/rb-lite-backlog-drain/SKILL.md
+skills/drive/SKILL.md
+skills/drive/references/phases.md
+skills/bead-polish-loop/SKILL.md
+skills/plan-to-beads-transfer/SKILL.md
+skills/second-model-bead-audit/SKILL.md
+skills/second-model-bead-audit/references/reviewer-panel.md
+RESOLVER_CONSUMERS
+if [[ -n "$provenance_failures" ]]; then fail "$t" "$provenance_failures"
+else pass "$t"; fi
+
+# A shared home can contain Claude and Codex installs from different --dir checkouts.
+# First-match selection would let the stale copy shadow the companion installed beside
+# the skill that is actually running. The portable fail-closed rule is to accept multiple
+# installed candidates only when their resolver bytes agree. Execute the owner's real
+# documented block against divergent stubs: comparison must refuse before either can run.
+t="resolver locator refuses divergent installed companions before execution"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/home/.claude/skills/beads-jsonl-path/scripts" \
+  "$b/codexhome/skills/beads-jsonl-path/scripts"
+command cat >"$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'CLAUDE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' claude >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/claude.jsonl
+CLAUDE_RESOLVER
+command cat >"$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'CODEX_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' codex >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/codex.jsonl
+CODEX_RESOLVER
+chmod +x "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" \
+  "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+locator_block=$(awk '
+  $0 == "```bash" && !found { found = 1; next }
+  found && $0 == "```" { exit }
+  found { print }
+' "$HERE/skills/beads-jsonl-path/SKILL.md")
+HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
+  bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"; rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "divergent installed copies were accepted"
+elif [[ -e "$b/executions" ]]; then
+  fail "$t" "a resolver executed before installed-copy agreement was proved"
+elif ! grep -Fq -- 'installed beads-jsonl-path companions disagree' "$b/stderr"; then
+  fail "$t" "missing divergence diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
+t="resolver locator accepts byte-identical installed companions"
+cp "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" \
+  "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+unlink "$b/stderr"
+unlink "$b/stdout"
+[[ ! -e "$b/executions" ]] || unlink "$b/executions"
+HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
+  bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"; rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "byte-identical installed copies were refused: $(<"$b/stderr")"
+elif [[ -s "$b/stdout" || -s "$b/stderr" ]]; then
+  fail "$t" "locator leaked output while capturing the resolved path"
+elif [[ $(<"$b/executions") != claude ]]; then
+  fail "$t" "locator executed an unexpected number or choice of resolver copies"
+else
+  pass "$t"
+fi
+
+# CODEX_HOME is caller-controlled. An absolute spelling is not enough: a
+# repository can point it at its own `.codex` tree and plant the resolver there.
+# The locator must reject that candidate before its executable bytes run.
+t="resolver locator refuses an absolute CODEX_HOME inside the driven worktree"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/repo/.codex/skills/beads-jsonl-path/scripts" "$b/home"
+git init -q "$b/repo"
+command cat >"$b/repo/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'WORKTREE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' worktree >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/worktree.jsonl
+WORKTREE_RESOLVER
+chmod +x "$b/repo/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+(
+  cd "$b/repo" || exit 98
+  HOME="$b/home" CODEX_HOME="$b/repo/.codex" LOCATOR_EXECUTIONS="$b/executions" \
+    bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"
+)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "an in-worktree CODEX_HOME companion was accepted"
+elif [[ -e "$b/executions" ]]; then
+  fail "$t" "the in-worktree companion executed"
+elif ! grep -Fq -- 'installed beads-jsonl-path target is inside the current Git worktree' "$b/stderr"; then
+  fail "$t" "missing in-worktree diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
+# Hostile functions and PATH executables arrive from the caller at the same time
+# as a repository-controlled absolute CODEX_HOME. The legacy control has the old
+# ambient selection shape: poisoned `git` reports /etc as the worktree, so it
+# executes the planted resolver. The documented block must cross its clean Bash
+# boundary and pin proof utilities before it asks Git or compares candidates.
+t="resolver locator isolates hostile functions and PATH tools before CODEX_HOME provenance"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/main" "$b/home"
+git init -q "$b/main"
+git -C "$b/main" config user.name 'Locator Test'
+git -C "$b/main" config user.email locator@example.invalid
+printf '%s\n' baseline >"$b/main/baseline"
+git -C "$b/main" add -- baseline
+git -C "$b/main" commit -qm baseline
+git -C "$b/main" worktree add -q -b locator-second "$b/second" HEAD
+mkdir -p "$b/second/.codex/skills/beads-jsonl-path/scripts" "$b/second/bin"
+command cat >"$b/second/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'HOSTILE_WORKTREE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' planted >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/planted.jsonl
+HOSTILE_WORKTREE_RESOLVER
+chmod +x "$b/second/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+command cat >"$b/second/bin/git" <<'HOSTILE_PATH_GIT'
+#!/bin/sh
+printf '%s\n' git >>"$HOSTILE_PATH_TOOLS_RAN"
+printf '%s\n' /etc
+HOSTILE_PATH_GIT
+command cat >"$b/second/bin/cmp" <<'HOSTILE_PATH_CMP'
+#!/bin/sh
+printf '%s\n' cmp >>"$HOSTILE_PATH_TOOLS_RAN"
+exit 0
+HOSTILE_PATH_CMP
+chmod +x "$b/second/bin/git" "$b/second/bin/cmp"
+legacy_locator_block='
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in /*) ;; *) exit 91 ;; esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  _bjp_root_raw=$(git --no-replace-objects rev-parse --show-toplevel) || exit 92
+  _bjp_root=$(cd -P -- "$_bjp_root_raw" && pwd -P) || exit 93
+  _bjp_candidate_dir=$(cd -P -- "$_bjp_dir/scripts" && pwd -P) || exit 94
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*) exit 95 ;;
+  esac
+  BEADS_JSONL_RESOLVER=$_bjp_candidate
+done
+[ -n "$BEADS_JSONL_RESOLVER" ] || exit 96
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 97
+'
+HOME="$b/home" CODEX_HOME="$b/second/.codex" DRIVEN_WORKTREE="$b/second" \
+  HOSTILE_PATH_TOOLS_RAN="$b/path-tools-ran" PATH="$b/second/bin:$PATH" \
+  LOCATOR_EXECUTIONS="$b/executions" LEGACY_LOCATOR_BLOCK="$legacy_locator_block" bash -c '
+    git() { printf "%s\n" /etc; }
+    command() { builtin command "$@"; }
+    cd() { builtin cd "$@"; }
+    cmp() { return 0; }
+    export -f git command cd cmp
+    bash -c '"'"'cd "$DRIVEN_WORKTREE" || exit 98; eval "$LEGACY_LOCATOR_BLOCK"'"'"'
+  ' >"$b/legacy.stdout" 2>"$b/legacy.stderr"
+legacy_rc=$?
+if [[ $legacy_rc -ne 0 || ! -e "$b/executions" || $(<"$b/executions") != planted ]]; then
+  fail "$t" "legacy ambient-shell control did not execute planted bytes (exit $legacy_rc): $(<"$b/legacy.stderr")"
+else
+  unlink "$b/executions"
+  rm -f "$b/path-tools-ran"
+  if HOME="$b/home" CODEX_HOME="$b/second/.codex" DRIVEN_WORKTREE="$b/second" \
+      HOSTILE_PATH_TOOLS_RAN="$b/path-tools-ran" PATH="$b/second/bin:$PATH" \
+      LOCATOR_EXECUTIONS="$b/executions" LOCATOR_BLOCK="$locator_block" bash -c '
+        git() { printf "%s\n" /etc; }
+        command() { builtin command "$@"; }
+        cd() { builtin cd "$@"; }
+        cmp() { return 0; }
+        export -f git command cd cmp
+        bash -c '"'"'cd "$DRIVEN_WORKTREE" || exit 98; eval "$LOCATOR_BLOCK"'"'"'
+      ' >"$b/stdout" 2>"$b/stderr"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [[ $rc -eq 0 ]]; then
+    fail "$t" "hostile exported functions let the second-worktree resolver run"
+  elif [[ -e "$b/executions" ]]; then
+    fail "$t" "the hardened locator executed planted second-worktree bytes"
+  elif [[ -e "$b/path-tools-ran" ]]; then
+    fail "$t" "the hardened locator ran a worktree PATH tool: $(tr '\n' ',' <"$b/path-tools-ran")"
+  elif ! grep -Fq -- 'installed beads-jsonl-path target is inside the current Git worktree' "$b/stderr"; then
+    fail "$t" "missing hostile-function provenance diagnostic: $(<"$b/stderr")"
+  else
+    pass "$t"
+  fi
+fi
+
+# A locator can be rerun in a long-lived agent shell. Its worktree root belongs to
+# the current invocation, not to a previous repository visited by that shell.
+t="resolver locator recomputes its worktree root on every invocation"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/repo-a" "$b/repo-b/.codex/skills/beads-jsonl-path/scripts" \
+  "$b/safe-home/.claude/skills/beads-jsonl-path/scripts" "$b/empty-home"
+git init -q "$b/repo-a"
+git init -q "$b/repo-b"
+command cat >"$b/safe-home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'SAFE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' safe >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/safe.jsonl
+SAFE_RESOLVER
+command cat >"$b/repo-b/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'SECOND_WORKTREE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' worktree >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/worktree.jsonl
+SECOND_WORKTREE_RESOLVER
+chmod +x "$b/safe-home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" \
+  "$b/repo-b/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+LOCATOR_BLOCK="$locator_block" LOCATOR_EXECUTIONS="$b/executions" \
+  REPO_A="$b/repo-a" REPO_B="$b/repo-b" SAFE_HOME="$b/safe-home" \
+  EMPTY_HOME="$b/empty-home" bash -c '
+    cd "$REPO_A" || exit 98
+    HOME=$SAFE_HOME CODEX_HOME=$SAFE_HOME/.codex eval "$LOCATOR_BLOCK"
+    cd "$REPO_B" || exit 98
+    HOME=$EMPTY_HOME CODEX_HOME=$REPO_B/.codex eval "$LOCATOR_BLOCK"
+  ' >"$b/stdout" 2>"$b/stderr"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "a stale root let the second worktree's companion execute"
+elif [[ ! -e "$b/executions" || $(<"$b/executions") != safe ]]; then
+  fail "$t" "the locator did not stop before executing the second worktree companion"
+elif ! grep -Fq -- 'installed beads-jsonl-path target is inside the current Git worktree' \
+    "$b/stderr"; then
+  fail "$t" "missing second-worktree diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
+# `reconcile_target_companions` treats any exact-name skill at the target path as
+# satisfying discovery, so a target can hold a `beads-jsonl-path` directory with no usable
+# resolver — a partial copy, or one whose script lost its executable bit — and the install
+# still reports success. The locator owns that consequence, and these two fixtures are why
+# the installer is allowed to stay generic: an unusable target is skipped so a sibling
+# still resolves, and when no target has an executable companion the block refuses with its
+# own diagnostic instead of executing something or falling through to a write.
+t="resolver locator skips a target without an executable companion"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/home/.claude/skills/beads-jsonl-path" \
+  "$b/codexhome/skills/beads-jsonl-path/scripts"
+printf -- '---\nname: beads-jsonl-path\n---\n' \
+  >"$b/home/.claude/skills/beads-jsonl-path/SKILL.md"
+command cat >"$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'SIBLING_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' codex >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/codex.jsonl
+SIBLING_RESOLVER
+chmod +x "$b/codexhome/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
+  bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"; rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "a usable sibling companion was refused: $(<"$b/stderr")"
+elif [[ -s "$b/stdout" || -s "$b/stderr" ]]; then
+  fail "$t" "locator leaked output while capturing the resolved path"
+elif [[ ! -e "$b/executions" || $(<"$b/executions") != codex ]]; then
+  fail "$t" "locator did not resolve through the one installed executable companion"
+else
+  pass "$t"
+fi
+
+t="resolver locator refuses when no target has an executable companion"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/home/.claude/skills/beads-jsonl-path/scripts" "$b/codexhome/skills"
+printf -- '---\nname: beads-jsonl-path\n---\n' \
+  >"$b/home/.claude/skills/beads-jsonl-path/SKILL.md"
+command cat >"$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'UNUSABLE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' claude >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/claude.jsonl
+UNUSABLE_RESOLVER
+chmod -x "$b/home/.claude/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+HOME="$b/home" CODEX_HOME="$b/codexhome" LOCATOR_EXECUTIONS="$b/executions" \
+  bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"; rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "an unusable installed companion was accepted"
+elif [[ -e "$b/executions" ]]; then
+  fail "$t" "locator executed a companion it could not have checked"
+elif ! grep -Fq -- 'beads-jsonl-path companion unavailable' "$b/stderr"; then
+  fail "$t" "missing unavailable diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
+# `install.sh` permits a relative CODEX_HOME, while this locator runs with the driven
+# repository as its working directory. Treating that value as an installed target would
+# let the driven checkout plant the executable that runs before any JSONL safety check.
+t="resolver locator refuses a relative installed target before execution"
+b=$(mktemp -d "$WORK/locator.XXXXXX")
+mkdir -p "$b/home" "$b/driven/.codex/skills/beads-jsonl-path/scripts"
+command cat >"$b/driven/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl" <<'RELATIVE_RESOLVER'
+#!/usr/bin/env bash
+printf '%s\n' relative >>"$LOCATOR_EXECUTIONS"
+printf '%s\n' /tmp/relative.jsonl
+RELATIVE_RESOLVER
+chmod +x "$b/driven/.codex/skills/beads-jsonl-path/scripts/resolve-beads-jsonl"
+(
+  cd "$b/driven" || exit 98
+  HOME="$b/home" CODEX_HOME=.codex LOCATOR_EXECUTIONS="$b/executions" \
+    bash -c "$locator_block" >"$b/stdout" 2>"$b/stderr"
+); rc=$?
+if [[ $rc -eq 0 ]]; then
+  fail "$t" "a repository-relative installed target was accepted"
+elif [[ -e "$b/executions" ]]; then
+  fail "$t" "the repository-relative resolver executed before refusal"
+elif ! grep -Fq -- 'installed beads-jsonl-path target is not absolute' "$b/stderr"; then
+  fail "$t" "missing relative-target diagnostic: $(<"$b/stderr")"
+else
+  pass "$t"
+fi
+
+t="resolver locators reject divergent installed companions"
+resolver_consistency_failures=""
+while IFS= read -r consumer; do
+  if ! grep -Fq -- 'for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \' \
+    "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer omits the Claude resolver target; "
+  elif ! grep -Fq -- '"${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \' \
+    "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer omits the Codex resolver target; "
+  elif ! grep -Fq -- '"$HOME/.agents/skills/beads-jsonl-path"; do' \
+    "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer omits the legacy Agents resolver target; "
+  elif ! grep -Fq -- '_bjp_git=$(command -p -v git)' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not pin Git to Bash's POSIX utility path; "
+  elif ! grep -Fq -- '_bjp_cmp=$(command -p -v cmp)' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not pin cmp to Bash's POSIX utility path; "
+  elif ! grep -Fq -- 'elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then' \
+    "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not compare installed resolver candidates; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path companions disagree' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer lacks the divergence refusal; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path target is not absolute' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer accepts a relative installed target; "
+  elif ! grep -Fq -- 'case $_bjp_root:$_bjp_candidate_dir in' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer does not compare canonical resolver location to the worktree; "
+  elif ! grep -Fq -- '_bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel' \
+      "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer caches or replacement-spoofs the driven worktree root; "
+  elif ! grep -Fq -- 'installed beads-jsonl-path target is inside the current Git worktree' \
+    "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer lacks the in-worktree resolver refusal; "
+  elif ! grep -Fq -- '[ ! -L "$_bjp_candidate" ]' "$HERE/$consumer"; then
+    resolver_consistency_failures+="$consumer accepts a resolver symlink whose final target was not canonicalized; "
+  fi
+done <<'RESOLVER_CONSUMERS'
+skills/beads-jsonl-path/SKILL.md
+skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+skills/rb-lite-backlog-drain/SKILL.md
+skills/drive/SKILL.md
+skills/drive/references/phases.md
+skills/bead-polish-loop/SKILL.md
+skills/plan-to-beads-transfer/SKILL.md
+skills/second-model-bead-audit/SKILL.md
+skills/second-model-bead-audit/references/reviewer-panel.md
+RESOLVER_CONSUMERS
+if [[ -n "$resolver_consistency_failures" ]]; then
+  fail "$t" "$resolver_consistency_failures"
+else
+  pass "$t"
+fi
+
+# These procedures are intentionally embedded so each can run without discovering a
+# companion document.  Fragment checks above catch required properties; this exact
+# normalized-code comparison catches a partial security update in any one of all nine
+# copies. Markdown list indentation is removed before comparison because it is not
+# part of the shell program a reader copies from a fenced block.
+t="all nine embedded resolver locators remain synchronized"
+if locator_sync_failures=$(python3 - "$HERE" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+paths = [
+    'skills/beads-jsonl-path/SKILL.md',
+    'skills/orchestrating-with-rb-lite/references/harden-until-clean.md',
+    'skills/rb-lite-backlog-drain/SKILL.md',
+    'skills/drive/SKILL.md',
+    'skills/drive/references/phases.md',
+    'skills/bead-polish-loop/SKILL.md',
+    'skills/plan-to-beads-transfer/SKILL.md',
+    'skills/second-model-bead-audit/SKILL.md',
+    'skills/second-model-bead-audit/references/reviewer-panel.md',
+]
+
+def locator(path):
+    lines = path.read_text().splitlines(keepends=True)
+    for start, line in enumerate(lines):
+        if line.lstrip(' \t') == 'BEADS_JSONL_RESOLVER=$(\n':
+            indent = line[:len(line) - len(line.lstrip(' \t'))]
+            break
+    else:
+        raise ValueError(f'{path.relative_to(root)} has no locator start')
+    for end in range(start + 1, len(lines)):
+        if lines[end].rstrip('\n') == indent + '```':
+            body = lines[start:end]
+            if any(not line.startswith(indent) for line in body if line != '\n'):
+                raise ValueError(f'{path.relative_to(root)} locator indentation is inconsistent')
+            body = ''.join(
+                line[len(indent):] if line.startswith(indent) else line
+                for line in body
+            )
+            selector_end = body.find('\n) || exit 1\n')
+            if selector_end < 0:
+                raise ValueError(f'{path.relative_to(root)} has no clean-boundary selector end')
+            return body[:selector_end + len('\n) || exit 1\n')]
+    raise ValueError(f'{path.relative_to(root)} has no locator fence close')
+
+try:
+    expected = locator(root / paths[0])
+    mismatches = [
+        path for path in paths[1:]
+        if locator(root / path) != expected
+    ]
+except (OSError, ValueError) as error:
+    print(error)
+    raise SystemExit(1)
+if mismatches:
+    print('embedded locator differs: ' + ', '.join(mismatches))
+    raise SystemExit(1)
+PY
+); then
+  pass "$t"
+else
+  fail "$t" "$locator_sync_failures"
+fi
+
+# The resolver accepts any tracked filename, including Git wildmatch and pathspec-magic
+# bytes. Every later Git operation must preserve that byte identity and ignore
+# replacement objects: otherwise a pathspec can name a sibling, or a replacement
+# ref can make an unsafe pre-flush diff appear empty.
+t="every Git consumer treats the resolved JSONL literally without replacement objects"
+literal_pathspec_failures=""
+while IFS= read -r occurrence; do
+  case $occurrence in
+    *'git --no-replace-objects --literal-pathspecs '*) ;;
+    *) literal_pathspec_failures+="$occurrence; " ;;
+  esac
+done < <(
+  grep -nHE -- 'git .*(status|diff|add).*\$BEADS_JSONL' \
+    "$HERE/skills/beads-jsonl-path/SKILL.md" \
+    "$HERE/skills/orchestrating-with-rb-lite/references/harden-until-clean.md" \
+    "$HERE/skills/rb-lite-backlog-drain/SKILL.md" \
+    "$HERE/skills/drive/SKILL.md" \
+    "$HERE/skills/drive/references/phases.md" \
+    "$HERE/skills/bead-polish-loop/SKILL.md" \
+    "$HERE/skills/plan-to-beads-transfer/SKILL.md" \
+    "$HERE/skills/second-model-bead-audit/SKILL.md" \
+    "$HERE/skills/second-model-bead-audit/references/reviewer-panel.md" || true
+)
+if [[ -n "$literal_pathspec_failures" ]]; then
+  fail "$t" "$literal_pathspec_failures"
+else
+  pass "$t"
+fi
+
+# Every locator block ends with the DEFAULT clean-mode call, and every pointer back to one
+# introduces a `--allow-dirty` or `--recovery` call — states the default mode exists to
+# refuse. A fresh shell that reruns the block verbatim therefore exits at that last line and
+# never reaches the mode it was sent there for, and the improvisation that unblocks it is
+# hardcoding `.beads/issues.jsonl`, which is the loss this companion prevents. So a pointer
+# must say where to stop.
+t="every locator rerun pointer stops before the block's clean-mode call"
+locator_rerun_failures=""
+locator_rerun_seen=0
+while IFS= read -r consumer; do
+  case $consumer in *-workspace/*) continue ;; esac
+  locator_rerun_seen=$((locator_rerun_seen + 1))
+  grep -Fq -- 'stopping before its final clean-mode `BEADS_JSONL=` call' "$consumer" ||
+    locator_rerun_failures+="${consumer#"$HERE/"} reruns the locator block through its clean call; "
+done < <(grep -rlF --include='*.md' -- 'resolver-locator block' "$HERE/skills")
+if [[ $locator_rerun_seen -eq 0 ]]; then
+  fail "$t" 'no locator rerun pointer found — the check would pass vacuously'
+elif [[ -n "$locator_rerun_failures" ]]; then
+  fail "$t" "$locator_rerun_failures"
+else
+  pass "$t"
+fi
 
 t="discipline gate wrapper returns an early && failure"
 repository_discipline_block="$HERE/skills/agents-md/references/discipline-block.md"

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -78,6 +78,14 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_git_environment=( "${!GIT_@}" )
+for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+  command unset -- "$_bjp_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+done
+unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -93,7 +93,7 @@ _bjp_regular_link_count() {
   fi
   printf '%s\n' "$count"
 }
-_bjp_git_environment=( "${!GIT_@}" )
+_bjp_git_environment=( "${!GIT@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
     printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -103,6 +103,7 @@ done
 unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
+BEADS_GIT_RUNNER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
   "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
   "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -147,6 +148,10 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  [ -f "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+    exit 1
+  }
   _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
     printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
     exit 1
@@ -165,16 +170,50 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_shebang
+  _bjp_runner="$_bjp_candidate_dir/git-clean"
+  [ -x "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+    exit 1
+  }
+  [ ! -L "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  [ -f "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+    exit 1
+  }
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
-  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    BEADS_GIT_RUNNER=$_bjp_runner
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+      || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
     printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
     exit 1
   fi
+  unset _bjp_runner
 done
 unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-[ -n "$BEADS_JSONL_RESOLVER" ] || {
+[ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
 }
@@ -182,6 +221,7 @@ printf '%s\n' "$BEADS_JSONL_RESOLVER"
 __BJP_TRUSTED_BASH__
   )
 ) || exit 1
+BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
 unset _bjp_candidate
 # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
 # is whatever executable the repo you are polishing planted there, and this snippet would
@@ -231,7 +271,7 @@ run `second-model-bead-audit` by default after the graph meets these gates.
 1. Establish the baseline:
 
    ```bash
-   br list --limit 0 --json -a
+   "$BEADS_JSONL_RESOLVER" --run-br list --limit 0 --json -a
    bv --robot-triage
    bv --robot-plan
    bv --robot-suggest
@@ -290,10 +330,10 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    written after the flush and records decisions, not the commands; recovery discards the
    working JSONL before you could read them back off it. Then apply the changes with `br`.
 
-5. Flush with an **explicit** `br sync --flush-only` and require it to succeed:
+5. Flush with an **explicit** `"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only` and require it to succeed:
 
    ```bash
-   br sync --flush-only || { echo "flush failed — mutations not persisted"; exit 1; }
+   "$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "flush failed — mutations not persisted"; exit 1; }
    ```
 
    The explicit sync is the whole guard: the hazard is the *automatic* flush after a
@@ -308,14 +348,14 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    the cache stale (a hand edit does not advance `updated_at`, so the two are
    indistinguishable by timestamp), and this skill rewrites long bead bodies for a living,
    which is exactly when opening the file is tempting. Write bead text with
-   `br update -d/--notes`, rerun the resolver-locator block from Preflight,
+   `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`, rerun the resolver-locator block from Preflight,
    stopping before its final clean-mode `BEADS_JSONL=` call, and resolve the post-write path
    with
    `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1` before field-diffing it
    (your own round is the divergence the default mode refuses; the `.beads/` layout is
    only the default, and a hardcoded path diffs nothing on the others): a full
    re-serialization with every id on both sides is normal, ids on only one side or a
-   `description` you did not touch is the tell. Recovery — and why `br sync --import-only`
+   `description` you did not touch is the tell. Recovery — and why `"$BEADS_JSONL_RESOLVER" --run-br sync --import-only`
    cannot do it — is in
    [exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11), with one
    caveat: its replay step assumes a SINGLE mutation, the drain's case. A polish round
@@ -373,7 +413,7 @@ Use these escalations:
 
 After convergence:
 
-1. Flush the final graph with `br sync --flush-only`.
+1. Flush the final graph with `"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only`.
 2. Invoke `second-model-bead-audit` with the source plan/spec path. Its default
    Codex + Claude panel is read-only and must not receive this skill's findings
    ledger or conclusions.
@@ -418,20 +458,20 @@ Do not:
 ## Command palette
 
 ```bash
-br list --limit 0 --json -a
-br show <id> --json
-br update <id> --description "..."
-br close <id> --reason "..."
-br dep add <issue> <depends-on>
-br dep remove <issue> <depends-on>
-br lint
+"$BEADS_JSONL_RESOLVER" --run-br list --limit 0 --json -a
+"$BEADS_JSONL_RESOLVER" --run-br show <id> --json
+"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "..."
+"$BEADS_JSONL_RESOLVER" --run-br close <id> --reason "..."
+"$BEADS_JSONL_RESOLVER" --run-br dep add <issue> <depends-on>
+"$BEADS_JSONL_RESOLVER" --run-br dep remove <issue> <depends-on>
+"$BEADS_JSONL_RESOLVER" --run-br lint
 bv --robot-triage
 bv --robot-plan
 bv --robot-suggest
 bv --robot-insights
 bv --robot-priority
 bv --robot-diff --diff-since <ref>
-br sync --flush-only
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only
 ```
 
 ## Pipeline position

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -43,6 +43,26 @@ unstaged, hidden-index, unmerged, type, mode, or wrong-worktree state must refus
 write before the cache can overwrite it:
 
 ```bash
+# Clear loader injection in this already-running shell before the locator starts
+# any new process. The resolver/git-clean script bodies are too late: a shebang
+# interpreter would already have loaded caller-selected libraries.
+_bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+_bjp_posixly_value=${POSIXLY_CORRECT-}
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+  printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+if [ -n "$_bjp_posixly_was_set" ]; then
+  POSIXLY_CORRECT=$_bjp_posixly_value
+  export POSIXLY_CORRECT
+else
+  \unset POSIXLY_CORRECT
+fi
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -348,7 +348,7 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    the cache stale (a hand edit does not advance `updated_at`, so the two are
    indistinguishable by timestamp), and this skill rewrites long bead bodies for a living,
    which is exactly when opening the file is tempting. Write bead text with
-   `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`, rerun the resolver-locator block from Preflight,
+   `"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "<full body>"`, rerun the resolver-locator block from Preflight,
    stopping before its final clean-mode `BEADS_JSONL=` call, and resolve the post-write path
    with
    `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1` before field-diffing it

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -26,13 +26,9 @@ merely plausible.
 
 ## Preflight
 
-- Confirm `br`, `bv`, **and `jq`** are on `PATH`. If any is missing, stop and say so.
-  `jq` is not a panel tool here: every `br` write can silently revert other beads
-  (step 5), and both the damage check and the recovery resolve the graph's real path
-  through `br where --json | jq`. Without it you can still mutate the graph and then
-  cannot tell whether you destroyed anything — the one ordering that must not be
-  possible. If `br where --json` cannot be parsed on this host, do not write to the
-  graph at all.
+- Confirm `br`, `bv`, and the exact `beads-jsonl-path` companion are available. The
+  companion diagnoses its own host dependencies, including `jq`; if it cannot resolve
+  and prove a clean tracked JSONL, do not write to the graph.
 - Record whether `codex` and `claude` are available for the final reviewer panel.
   Missing panel tools do not block polishing, but they determine whether the eventual
   audit can be full, degraded, or blocked.
@@ -41,39 +37,122 @@ merely plausible.
 - If polishing keeps surfacing architecture questions, step back into plan space instead of repeatedly fixing downstream symptoms.
 
 
-**Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
-auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
-first write — and since neither the index nor `HEAD` holds it, every later diff shows only
-your intended changes and the loss becomes *undetectable*. Resolve the path in its own
-checked steps, and check the inspection too — embedded in a `git status` argument the
-resolution's exit code is swallowed, and two of those failures are **silent** rather than
-loud. Measured on git 2.54.0 / jq 1.8.2:
-
-- `br where` exiting non-zero *after* emitting valid JSON. The pipeline reports only its
-  last command's status, so `jq` succeeds and the assignment returns 0.
-- `br where` emitting JSON without the key: `jq -er .jsonl_path` exits 1 **and prints
-  `null`**, so the substitution yields the literal pathspec `null` and
-  `git status --porcelain -- null` exits 0 printing nothing.
-
-(A genuinely empty pathspec is *not* the hazard — `git status --porcelain -- ""` fails
-loudly with `fatal: empty string is not a valid pathspec`, exit 128, on the version stated
-above. Behavior may differ on older git — unmeasured here; if you must support one,
-measure there.)
-
-And `git status` itself can fail — a JSONL resolved outside this worktree exits 128
-(`fatal: … is outside repository`) — printing nothing on **stdout**, so gating on stdout
-emptiness alone reads a failed inspection as a clean tree right before the destructive
-first flush:
+**Before the first `br` write, resolve and prove the JSONL clean through its exact fact
+owner.** Any `br` mutation auto-flushes the cache over the tracked file, so staged,
+unstaged, hidden-index, unmerged, type, mode, or wrong-worktree state must refuse the
+write before the cache can overwrite it:
 
 ```bash
-_bw=$(br where --json) || { echo "cannot resolve the beads JSONL"; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
-_st=$(git status --porcelain -- "$BEADS_JSONL") \
-  || { echo "cannot read the worktree — do NOT write"; exit 1; }
-printf '%s' "$_st"
+BEADS_JSONL_RESOLVER=$(
+  (
+    # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+    # prevents exported caller functions from redefining this trust path, and the
+    # subshell leaves the caller's shell state untouched.
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset -f command builtin exec unset 2>/dev/null || :
+    _bjp_bash=$(command -p -v bash) || {
+      printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+      exit 1
+    }
+    unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+    exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+# Privileged Bash ignores inherited functions. Clear the other startup controls too,
+# then perform every candidate, worktree, provenance, and byte-agreement decision here.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjp_function; do
+  command unset -f -- "$_bjp_function" || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjp_function
+_bjp_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_cmp=$(command -p -v cmp) || {
+  printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in
+    /*) ;;
+    *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+  esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+      printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+      exit 1
+      ;;
+  esac
+  unset _bjp_candidate_dir
+  if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+    BEADS_JSONL_RESOLVER=$_bjp_candidate
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+    exit 1
+  fi
+done
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+  exit 1
+}
+printf '%s\n' "$BEADS_JSONL_RESOLVER"
+__BJP_TRUSTED_BASH__
+  )
+) || exit 1
+unset _bjp_candidate
+# Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
+# is whatever executable the repo you are polishing planted there, and this snippet would
+# run it. From a checkout, run that checkout's copy by absolute path instead.
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  echo "beads-jsonl-path companion unavailable — do NOT write" >&2
+  exit 1
+}
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
 ```
 
-If it is not empty, resolve it first — recovery case (a) in
+If the owner refuses, resolve the reported state first — recovery case (a) in
 exact companion skill [`rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
 **Companion unavailable: stop, rerun the same installer command once, reload it, and do
 not improvise this procedure.**
@@ -188,9 +267,12 @@ run `second-model-bead-audit` by default after the graph meets these gates.
    the cache stale (a hand edit does not advance `updated_at`, so the two are
    indistinguishable by timestamp), and this skill rewrites long bead bodies for a living,
    which is exactly when opening the file is tempting. Write bead text with
-   `br update -d/--notes`, and field-diff the tracked JSONL before committing (resolve it
-   with `br where --json | jq -er .jsonl_path`; the `.beads/` layout is only the default,
-   and a hardcoded path diffs nothing on the others): a full
+   `br update -d/--notes`, rerun the resolver-locator block from Preflight,
+   stopping before its final clean-mode `BEADS_JSONL=` call, and resolve the post-write path
+   with
+   `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1` before field-diffing it
+   (your own round is the divergence the default mode refuses; the `.beads/` layout is
+   only the default, and a hardcoded path diffs nothing on the others): a full
    re-serialization with every id on both sides is normal, ids on only one side or a
    `description` you did not touch is the tell. Recovery — and why `br sync --import-only`
    cannot do it — is in

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -78,6 +78,21 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
 _bjp_git_environment=( "${!GIT_@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
@@ -132,6 +147,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -140,7 +164,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   fi
 done
-unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
 [ -n "$BEADS_JSONL_RESOLVER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -156,6 +156,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/bead-polish-loop/SKILL.md
+++ b/skills/bead-polish-loop/SKILL.md
@@ -101,7 +101,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
     exit 1
   }
-  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
     printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
     exit 1
   }

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -143,7 +143,7 @@ relative to the repository you are driving.
 
 On success, `BEADS_JSONL` is the only stdout: an absolute path inside the
 current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,
-worktree type and mode, and raw bytes all agree. Both the locator and resolver
+single-link worktree type and mode, and raw bytes all agree. Both the locator and resolver
 discard inherited `GIT_*` overrides before repository discovery, so a caller
 cannot redirect that proof to another worktree, index, object store, or config.
 Every Git inspection also forces `core.fsmonitor=false`, so the read-only owner
@@ -197,7 +197,8 @@ BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --recovery) || exit 1
 Recovery may need to name a missing export, so this mode retains byte-safe resolution and
 worktree containment but does not require tracked/index/HEAD state. It accepts only an
 absent path or a non-symlink regular file; a symlink, FIFO, directory, or other nonregular
-occupant still refuses. A path equal to or beneath `$GIT_DIR`, Git's common
+occupant still refuses, as does a regular file with another hard-link alias. A
+path equal to or beneath `$GIT_DIR`, Git's common
 administrative directory, or `<worktree>/.git` also refuses, including a linked
 worktree's `.git` pointer file. Never use recovery mode before a `br` write.
 Read the symlink half at its measured width: on br 0.2.19 a `.beads/issues.jsonl` symlink

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -53,6 +53,14 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_git_environment=( "${!GIT_@}" )
+for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+  command unset -- "$_bjp_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+done
+unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
@@ -135,7 +143,9 @@ relative to the repository you are driving.
 
 On success, `BEADS_JSONL` is the only stdout: an absolute path inside the
 current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,
-worktree type and mode, and raw bytes all agree.
+worktree type and mode, and raw bytes all agree. Both the locator and resolver
+discard inherited `GIT_*` overrides before repository discovery, so a caller
+cannot redirect that proof to another worktree, index, object store, or config.
 
 On failure, stop before any Beads write. Do not replace the owner with
 `git status`, porcelain parsing, or a hardcoded `.beads/issues.jsonl` path.
@@ -187,7 +197,9 @@ BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --recovery) || exit 1
 Recovery may need to name a missing export, so this mode retains byte-safe resolution and
 worktree containment but does not require tracked/index/HEAD state. It accepts only an
 absent path or a non-symlink regular file; a symlink, FIFO, directory, or other nonregular
-occupant still refuses. Never use recovery mode before a `br` write.
+occupant still refuses. A path equal to or beneath `$GIT_DIR`, Git's common
+administrative directory, or `<worktree>/.git` also refuses, including a linked
+worktree's `.git` pointer file. Never use recovery mode before a `br` write.
 Read the symlink half at its measured width: on br 0.2.19 a `.beads/issues.jsonl` symlink
 whose target exists is already resolved to that target before this owner sees it, so the
 refusal covers the dangling link and containment covers one pointing out of the worktree,

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -53,6 +53,21 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
 _bjp_git_environment=( "${!GIT_@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
@@ -107,6 +122,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -115,7 +139,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   fi
 done
-unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
 [ -n "$BEADS_JSONL_RESOLVER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
@@ -139,7 +163,10 @@ BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
 If nothing resolves you are running from a checkout rather than an install: rerun the
 same installer command once, or run this checkout's own `scripts/resolve-beads-jsonl` by
 absolute path — the copy in the skills checkout you are editing, never one named
-relative to the repository you are driving.
+relative to the repository you are driving. The locator refuses symbolic or
+multiply linked resolver candidates, and the resolver applies the same
+single-link rule to PATH-selected `br` and `jq`, so an outside pathname cannot
+alias executable bytes controlled by the driven worktree.
 
 On success, `BEADS_JSONL` is the only stdout: an absolute path inside the
 current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -131,6 +131,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -164,9 +173,11 @@ If nothing resolves you are running from a checkout rather than an install: reru
 same installer command once, or run this checkout's own `scripts/resolve-beads-jsonl` by
 absolute path — the copy in the skills checkout you are editing, never one named
 relative to the repository you are driving. The locator refuses symbolic or
-multiply linked resolver candidates, and the resolver applies the same
-single-link rule to PATH-selected `br` and `jq`, so an outside pathname cannot
-alias executable bytes controlled by the driven worktree.
+multiply linked resolver candidates and requires the canonical `#!/bin/sh`
+entry point. The resolver applies the same single-link rule to PATH-selected
+`br` and `jq` and launches them with the implementation's POSIX utility path, so
+neither an outside inode alias nor an indirect PATH-resolved interpreter can
+execute bytes controlled by the driven worktree.
 
 On success, `BEADS_JSONL` is the only stdout: an absolute path inside the
 current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -68,7 +68,7 @@ _bjp_regular_link_count() {
   fi
   printf '%s\n' "$count"
 }
-_bjp_git_environment=( "${!GIT_@}" )
+_bjp_git_environment=( "${!GIT@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
     printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -78,6 +78,7 @@ done
 unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
+BEADS_GIT_RUNNER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
   "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
   "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -122,6 +123,10 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  [ -f "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+    exit 1
+  }
   _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
     printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
     exit 1
@@ -140,16 +145,50 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_shebang
+  _bjp_runner="$_bjp_candidate_dir/git-clean"
+  [ -x "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+    exit 1
+  }
+  [ ! -L "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  [ -f "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+    exit 1
+  }
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
-  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    BEADS_GIT_RUNNER=$_bjp_runner
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+      || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
     printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
     exit 1
   fi
+  unset _bjp_runner
 done
 unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-[ -n "$BEADS_JSONL_RESOLVER" ] || {
+[ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
 }
@@ -157,6 +196,7 @@ printf '%s\n' "$BEADS_JSONL_RESOLVER"
 __BJP_TRUSTED_BASH__
   )
 ) || exit 1
+BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
 unset _bjp_candidate
 # Installed targets only — do NOT add a fallback to a relative
 # `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`. This snippet runs in the agent's
@@ -178,6 +218,10 @@ entry point. The resolver applies the same single-link rule to PATH-selected
 `br` and `jq` and launches them with the implementation's POSIX utility path, so
 neither an outside inode alias nor an indirect PATH-resolved interpreter can
 execute bytes controlled by the driven worktree.
+Every later Beads command uses
+`"$BEADS_JSONL_RESOLVER" --run-br <args...>`; that mode revalidates the same
+single-link `br` executable and launches it in the clean proof environment.
+Never return to a caller-shell `br`, function, or PATH lookup after resolution.
 
 On success, `BEADS_JSONL` is the only stdout: an absolute path inside the
 current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,
@@ -186,6 +230,18 @@ discard inherited `GIT_*` overrides before repository discovery, so a caller
 cannot redirect that proof to another worktree, index, object store, or config.
 Every Git inspection also forces `core.fsmonitor=false`, so the read-only owner
 does not execute a repository-configured monitor hook.
+`BEADS_GIT_RUNNER` names the validated installed sibling that clears the full
+`GIT*` environment and pins trusted Git, PATH, replacement-object, and fsmonitor
+behavior for every caller-side diff or add below. Do not substitute a
+bare caller-shell `git`; diff calls also disable external diff drivers and
+textconv filters, and add hashes/stages the exact file bytes without repository
+clean filters. Transactions that continue through commit/push keep using the
+runner so inherited repository/index/transport selectors cannot reappear;
+repository hooks and commit/push signing are disabled on that guarded path.
+Push also disables credential helpers, askpass, SSH configuration commands, and
+interactive prompts while retaining the caller's SSH agent. For HTTPS, it
+re-enables only system/global credential helpers after refusing a `HOME` or
+`XDG_CONFIG_HOME` inside the driven worktree.
 
 On failure, stop before any Beads write. Do not replace the owner with
 `git status`, porcelain parsing, or a hardcoded `.beads/issues.jsonl` path.
@@ -196,7 +252,7 @@ The default mode refuses a dirty JSONL, which is exactly right before a write an
 after one. Pass `--allow-dirty` when the file is *supposed* to differ from HEAD and you
 still need its real path:
 
-- the post-write field diff (`git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL"`) that reads what the
+- the post-write field diff (`"$BEADS_GIT_RUNNER" --literal-pathspecs diff --no-ext-diff --no-textconv --text HEAD -- "$BEADS_JSONL"`) that reads what the
   flush actually wrote;
 - a handoff that arrives flushed but uncommitted, such as `bead-polish-loop` →
   `second-model-bead-audit`, where the audit reads the diff rather than gating on it.
@@ -217,8 +273,8 @@ intent-to-add placeholder, plus a non-symlink regular worktree file. It therefor
 hidden flags, intent-to-add, untracked, unmerged, missing, wrong-mode, and wrong-type
 states before an audit flush.
 The resolver and every documented consumer force `core.fsmonitor=false`, so a
-monitor that missed a write cannot make the `git status` or `git diff HEAD` you
-are about to read report a clean file over changed bead bodies.
+monitor that missed a write cannot make the clean runner's `git diff HEAD` report
+a clean file over changed bead bodies.
 It still performs no Beads mutation or flush.
 
 ## Name a damaged path for recovery

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -262,6 +262,12 @@ Push also disables credential helpers, askpass, SSH configuration commands, and
 interactive prompts while retaining the caller's SSH agent. For HTTPS, it
 re-enables only system/global credential helpers after refusing a `HOME` or
 `XDG_CONFIG_HOME` inside the driven worktree.
+The runner's audit-tool modes validate every executable exposed by the caller's
+outside-worktree PATH directories at launch (including symbolic and hard-link
+provenance), then execute with only that admitted PATH. This is a static launch
+boundary, not protection from a concurrently hostile process running as the same
+OS user: if another same-identity process can rewrite those tool directories
+between validation and lookup, stop rather than starting the audit.
 
 On failure, stop before any Beads write. Do not replace the owner with
 `git status`, porcelain parsing, or a hardcoded `.beads/issues.jsonl` path.

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -18,6 +18,26 @@ its `br`, `jq`, or Git inspection in a consumer.
 Run this before the first `br` command that can mutate or flush:
 
 ```bash
+# Clear loader injection in this already-running shell before the locator starts
+# any new process. The resolver/git-clean script bodies are too late: a shebang
+# interpreter would already have loaded caller-selected libraries.
+_bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+_bjp_posixly_value=${POSIXLY_CORRECT-}
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+  printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+if [ -n "$_bjp_posixly_was_set" ]; then
+  POSIXLY_CORRECT=$_bjp_posixly_value
+  export POSIXLY_CORRECT
+else
+  \unset POSIXLY_CORRECT
+fi
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -76,7 +76,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
     exit 1
   }
-  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
     printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
     exit 1
   }
@@ -146,6 +146,8 @@ current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,
 worktree type and mode, and raw bytes all agree. Both the locator and resolver
 discard inherited `GIT_*` overrides before repository discovery, so a caller
 cannot redirect that proof to another worktree, index, object store, or config.
+Every Git inspection also forces `core.fsmonitor=false`, so the read-only owner
+does not execute a repository-configured monitor hook.
 
 On failure, stop before any Beads write. Do not replace the owner with
 `git status`, porcelain parsing, or a hardcoded `.beads/issues.jsonl` path.
@@ -156,7 +158,7 @@ The default mode refuses a dirty JSONL, which is exactly right before a write an
 after one. Pass `--allow-dirty` when the file is *supposed* to differ from HEAD and you
 still need its real path:
 
-- the post-write field diff (`git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL"`) that reads what the
+- the post-write field diff (`git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL"`) that reads what the
   flush actually wrote;
 - a handoff that arrives flushed but uncommitted, such as `bead-polish-loop` →
   `second-model-bead-audit`, where the audit reads the diff rather than gating on it.
@@ -176,11 +178,9 @@ entry with mode `100644` in the index and HEAD, holding real content rather than
 intent-to-add placeholder, plus a non-symlink regular worktree file. It therefore refuses
 hidden flags, intent-to-add, untracked, unmerged, missing, wrong-mode, and wrong-type
 states before an audit flush.
-Where it does still read content is the file system monitor: when Git is answering for
-this path from a monitor's cache rather than the filesystem, the mode compares the index
-blob to the worktree bytes and refuses a difference. A monitor that missed a write leaves
-the `git status` and `git diff HEAD` you are about to read reporting a clean file over
-changed bead bodies.
+The resolver and every documented consumer force `core.fsmonitor=false`, so a
+monitor that missed a write cannot make the `git status` or `git diff HEAD` you
+are about to read report a clean file over changed bead bodies.
 It still performs no Beads mutation or flush.
 
 ## Name a damaged path for recovery

--- a/skills/beads-jsonl-path/SKILL.md
+++ b/skills/beads-jsonl-path/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: beads-jsonl-path
+description: >-
+  Internal companion owner of the current repository's Beads JSONL path. Load
+  this exact skill only when another skill directs you here: to resolve the real
+  JSONL path, to prove that its HEAD, index, and worktree bytes are identical
+  before a writing `br` command, or to refuse staged, unstaged, hidden-index,
+  unmerged, symlink, gitlink, untracked, missing, nonregular, or wrong-worktree
+  state without touching the Beads store.
+user-invocable: false
+---
+
+Resolve and inspect the Beads JSONL through the bundled script. Do not reproduce
+its `br`, `jq`, or Git inspection in a consumer.
+
+## Resolve before writing
+
+Run this before the first `br` command that can mutate or flush:
+
+```bash
+BEADS_JSONL_RESOLVER=$(
+  (
+    # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+    # prevents exported caller functions from redefining this trust path, and the
+    # subshell leaves the caller's shell state untouched.
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset -f command builtin exec unset 2>/dev/null || :
+    _bjp_bash=$(command -p -v bash) || {
+      printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+      exit 1
+    }
+    unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+    exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+# Privileged Bash ignores inherited functions. Clear the other startup controls too,
+# then perform every candidate, worktree, provenance, and byte-agreement decision here.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjp_function; do
+  command unset -f -- "$_bjp_function" || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjp_function
+_bjp_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_cmp=$(command -p -v cmp) || {
+  printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in
+    /*) ;;
+    *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+  esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+      printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+      exit 1
+      ;;
+  esac
+  unset _bjp_candidate_dir
+  if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+    BEADS_JSONL_RESOLVER=$_bjp_candidate
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+    exit 1
+  fi
+done
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+  exit 1
+}
+printf '%s\n' "$BEADS_JSONL_RESOLVER"
+__BJP_TRUSTED_BASH__
+  )
+) || exit 1
+unset _bjp_candidate
+# Installed targets only — do NOT add a fallback to a relative
+# `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`. This snippet runs in the agent's
+# shell inside the repository being driven, so that path is whatever executable THAT
+# repository planted there, and every consumer would run it automatically.
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  echo "beads-jsonl-path companion unavailable — do NOT write" >&2
+  exit 1
+}
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
+```
+
+If nothing resolves you are running from a checkout rather than an install: rerun the
+same installer command once, or run this checkout's own `scripts/resolve-beads-jsonl` by
+absolute path — the copy in the skills checkout you are editing, never one named
+relative to the repository you are driving.
+
+On success, `BEADS_JSONL` is the only stdout: an absolute path inside the
+current Git worktree whose stage-0 index entry, normal index flags, HEAD entry,
+worktree type and mode, and raw bytes all agree.
+
+On failure, stop before any Beads write. Do not replace the owner with
+`git status`, porcelain parsing, or a hardcoded `.beads/issues.jsonl` path.
+
+## Inspect dirty content without dropping path ownership
+
+The default mode refuses a dirty JSONL, which is exactly right before a write and wrong
+after one. Pass `--allow-dirty` when the file is *supposed* to differ from HEAD and you
+still need its real path:
+
+- the post-write field diff (`git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL"`) that reads what the
+  flush actually wrote;
+- a handoff that arrives flushed but uncommitted, such as `bead-polish-loop` →
+  `second-model-bead-audit`, where the audit reads the diff rather than gating on it.
+
+In a session that has not already set `BEADS_JSONL_RESOLVER`, rerun the resolver-locator
+block above, stopping before its final clean-mode `BEADS_JSONL=` call — that call is the
+one this mode exists to get past, so running it first exits 1 on exactly the dirty JSONL
+you came here for.
+
+```bash
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
+```
+
+`--allow-dirty` stops requiring HEAD, index, and worktree bytes to be identical, and
+changes nothing else. It still requires one normally flagged, tracked stage-0 regular
+entry with mode `100644` in the index and HEAD, holding real content rather than an
+intent-to-add placeholder, plus a non-symlink regular worktree file. It therefore refuses
+hidden flags, intent-to-add, untracked, unmerged, missing, wrong-mode, and wrong-type
+states before an audit flush.
+Where it does still read content is the file system monitor: when Git is answering for
+this path from a monitor's cache rather than the filesystem, the mode compares the index
+blob to the worktree bytes and refuses a difference. A monitor that missed a write leaves
+the `git status` and `git diff HEAD` you are about to read reporting a clean file over
+changed bead bodies.
+It still performs no Beads mutation or flush.
+
+## Name a damaged path for recovery
+
+Use `--recovery` only after deciding recovery is required. Recovery is the fresh-session
+case by definition, so rerun the resolver-locator block above first,
+stopping before its final clean-mode `BEADS_JSONL=` call — a destroyed JSONL is precisely
+what that call refuses.
+
+```bash
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --recovery) || exit 1
+```
+
+Recovery may need to name a missing export, so this mode retains byte-safe resolution and
+worktree containment but does not require tracked/index/HEAD state. It accepts only an
+absent path or a non-symlink regular file; a symlink, FIFO, directory, or other nonregular
+occupant still refuses. Never use recovery mode before a `br` write.
+Read the symlink half at its measured width: on br 0.2.19 a `.beads/issues.jsonl` symlink
+whose target exists is already resolved to that target before this owner sees it, so the
+refusal covers the dangling link and containment covers one pointing out of the worktree,
+while a live in-worktree link is inspected — and named — as the file `br` writes through
+it. Recovery still tells you where the bytes land; it does not vet the configuration that
+put them there.
+Successful recovery resolution only names the artifact; it is not a safety gate that
+authorizes a subsequent Beads query, mutation, or flush. Follow the owning recovery
+procedure before any such command.

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -1,0 +1,1130 @@
+#!/bin/sh
+# Run one Git command through a clean, non-repository-controlled environment.
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset -f command builtin exec unset 2>/dev/null || :
+_bjg_bash=$(command -p -v bash) || {
+  printf '%s\n' 'cannot locate a trusted Bash for clean Git' >&2
+  exit 1
+}
+unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+\exec 3<&0
+\exec "$_bjg_bash" --noprofile --norc -p -s -- "$@" <<'__BJG_TRUSTED_BASH__'
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH \
+  GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the clean Git shell environment' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjg_function; do
+  command unset -f -- "$_bjg_function" || {
+    printf '%s\n' 'cannot sanitize the clean Git shell environment' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjg_function
+
+set -uo pipefail
+
+_bjg_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git' >&2
+  exit 1
+}
+_bjg_getconf=$(command -p -v getconf) || {
+  printf '%s\n' 'cannot locate a trusted getconf for clean Git' >&2
+  exit 1
+}
+_bjg_readlink=$(command -p -v readlink) || {
+  printf '%s\n' 'cannot locate a trusted readlink for clean Git' >&2
+  exit 1
+}
+_bjg_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for clean Git' >&2
+  exit 1
+}
+_bjg_mktemp=$(command -p -v mktemp) || {
+  printf '%s\n' 'cannot locate a trusted mktemp for clean Git' >&2
+  exit 1
+}
+_bjg_unlink=$(command -p -v unlink) || {
+  printf '%s\n' 'cannot locate a trusted unlink for clean Git' >&2
+  exit 1
+}
+_bjg_rmdir=$(command -p -v rmdir) || {
+  printf '%s\n' 'cannot locate a trusted rmdir for clean Git' >&2
+  exit 1
+}
+_bjg_chmod=$(command -p -v chmod) || {
+  printf '%s\n' 'cannot locate a trusted chmod for clean Git' >&2
+  exit 1
+}
+_bjg_env=$(command -p -v env) || {
+  printf '%s\n' 'cannot locate a trusted env for clean utilities' >&2
+  exit 1
+}
+_bjg_safe_path=$("$_bjg_getconf" PATH 2>/dev/null) || {
+  printf '%s\n' 'cannot resolve the POSIX utility path for clean Git' >&2
+  exit 1
+}
+[[ -n "$_bjg_safe_path" && "$_bjg_safe_path" != *$'\n'* \
+   && "$_bjg_safe_path" != *$'\r'* ]] || {
+  printf '%s\n' 'cannot validate the POSIX utility path for clean Git' >&2
+  exit 1
+}
+IFS=: read -r -a _bjg_safe_path_entries <<<"$_bjg_safe_path"
+for _bjg_safe_path_entry in "${_bjg_safe_path_entries[@]}"; do
+  [[ "$_bjg_safe_path_entry" == /* ]] || {
+    printf '%s\n' 'cannot validate the POSIX utility path for clean Git' >&2
+    exit 1
+  }
+done
+unset _bjg_safe_path_entry _bjg_safe_path_entries
+
+# `${!GIT@}` includes both the normal GIT_* namespace and exceptions such as
+# GITPERLLIB. Git receives no caller-selected repository, index, object, config,
+# helper, namespace, pathspec, or interpreter state.
+_bjg_git_environment=( "${!GIT@}" )
+for _bjg_git_variable in "${_bjg_git_environment[@]}"; do
+  command unset -- "$_bjg_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment' >&2
+    exit 1
+  }
+done
+unset _bjg_git_variable _bjg_git_environment
+command unset TMPDIR TMP TEMP
+
+_bjg_caller_path=${PATH-}
+PATH=$_bjg_safe_path
+LC_ALL=C
+export PATH LC_ALL
+_bjg_proof_environment=( "$_bjg_env" -i "PATH=$_bjg_safe_path" "LC_ALL=C" )
+
+_bjg_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjg_stat" -c %h "$path" 2>/dev/null) \
+      && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjg_stat" -f %l "$path" 2>/dev/null) \
+      && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
+
+_bjg_prepare_audit_path() {
+  local entry canonical seen
+  local -a entries result
+  _bjg_audit_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+    -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+    rev-parse --show-toplevel 2>/dev/null) || return 1
+  _bjg_audit_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjg_audit_root_raw" 2>/dev/null && pwd -P
+  ) || return 1
+  IFS=: read -r -a entries <<<"$_bjg_safe_path:$_bjg_caller_path"
+  result=()
+  for entry in "${entries[@]}"; do
+    [[ "$entry" == /* && -d "$entry" ]] || continue
+    canonical=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$entry" 2>/dev/null && pwd -P
+    ) || continue
+    if [[ "$_bjg_audit_root" == / || "$canonical" == "$_bjg_audit_root" \
+          || "$canonical" == "$_bjg_audit_root/"* ]]; then
+      continue
+    fi
+    seen=false
+    for entry in "${result[@]}"; do
+      [[ "$entry" != "$canonical" ]] || seen=true
+    done
+    "$seen" || result+=( "$canonical" )
+  done
+  [[ ${#result[@]} -gt 0 ]] || return 1
+  (IFS=:; printf '%s\n' "${result[*]}")
+}
+
+_bjg_external_audit_tool() {
+  local name=$1 path parent leaf link hops link_count
+  [[ "$name" =~ ^[A-Za-z0-9._+-]+$ ]] || return 1
+  _bjg_audit_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+    -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+    rev-parse --show-toplevel 2>/dev/null) || return 1
+  _bjg_audit_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjg_audit_root_raw" 2>/dev/null && pwd -P
+  ) || return 1
+  path=$(
+    PATH=$_bjg_caller_path
+    export PATH
+    type -P -- "$name"
+  ) || return 1
+  [[ "$path" == /* ]] || return 1
+  hops=0
+  while :; do
+    parent=${path%/*}
+    leaf=${path##*/}
+    parent=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$parent" 2>/dev/null && pwd -P
+    ) || return 1
+    path=$parent/$leaf
+    if [[ "$_bjg_audit_root" == / || "$path" == "$_bjg_audit_root" \
+          || "$path" == "$_bjg_audit_root/"* ]]; then
+      return 1
+    fi
+    [[ -L "$path" ]] || break
+    ((hops < 40)) || return 1
+    link=$("$_bjg_readlink" "$path") || return 1
+    case $link in
+      /*) path=$link ;;
+      *) path=$parent/$link ;;
+    esac
+    hops=$((hops + 1))
+  done
+  [[ -f "$path" && -x "$path" ]] || return 1
+  link_count=$(_bjg_regular_link_count "$path") || return 1
+  [[ "$link_count" == 1 ]] || return 1
+  printf '%s\n' "$path"
+}
+
+case ${1-} in
+  copy-file)
+    shift
+    [ "$#" -eq 2 ] || {
+      printf '%s\n' 'usage: git-clean copy-file <source> <destination>' >&2
+      exit 2
+    }
+    [[ "$1" == /* && "$2" == /* ]] || {
+      printf '%s\n' 'clean file copy requires absolute paths' >&2
+      exit 1
+    }
+    _bjg_cp=$(command -p -v cp) || {
+      printf '%s\n' 'cannot locate a trusted cp for clean file copy' >&2
+      exit 1
+    }
+    exec "${_bjg_proof_environment[@]}" "$_bjg_cp" "$1" "$2"
+    ;;
+  diff-files)
+    shift
+    [ "$#" -eq 2 ] || {
+      printf '%s\n' 'usage: git-clean diff-files <before> <after>' >&2
+      exit 2
+    }
+    [[ "$1" == /* && "$2" == /* ]] || {
+      printf '%s\n' 'clean file comparison requires absolute paths' >&2
+      exit 1
+    }
+    _bjg_diff=$(command -p -v diff) || {
+      printf '%s\n' 'cannot locate a trusted diff for clean file comparison' >&2
+      exit 1
+    }
+    exec "${_bjg_proof_environment[@]}" "$_bjg_diff" -u "$1" "$2"
+    ;;
+  worktree-root)
+    shift
+    [ "$#" -eq 0 ] || {
+      printf '%s\n' 'usage: git-clean worktree-root' >&2
+      exit 2
+    }
+    _bjg_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the current Git worktree' >&2
+      exit 1
+    }
+    (
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_root_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the current Git worktree' >&2
+      exit 1
+    }
+    exit 0
+    ;;
+  make-temp-dir)
+    shift
+    [ "$#" -eq 1 ] && [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] || {
+      printf '%s\n' 'usage: git-clean make-temp-dir <safe-prefix>' >&2
+      exit 2
+    }
+    _bjg_temp_dir=$("$_bjg_mktemp" -d "/tmp/$1.XXXXXXXX") || {
+      printf '%s\n' 'cannot create the private audit directory' >&2
+      exit 1
+    }
+    "$_bjg_chmod" 700 "$_bjg_temp_dir" || {
+      "$_bjg_rmdir" "$_bjg_temp_dir" 2>/dev/null || :
+      printf '%s\n' 'cannot protect the private audit directory' >&2
+      exit 1
+    }
+    printf '%s\n' "$_bjg_temp_dir"
+    exit 0
+    ;;
+  make-dir)
+    shift
+    [ "$#" -ge 1 ] || {
+      printf '%s\n' 'usage: git-clean make-dir <absolute-dir>...' >&2
+      exit 2
+    }
+    for _bjg_dir in "$@"; do
+      [[ "$_bjg_dir" == /* ]] || {
+        printf '%s\n' 'clean directory creation requires absolute paths' >&2
+        exit 1
+      }
+    done
+    _bjg_mkdir=$(command -p -v mkdir) || {
+      printf '%s\n' 'cannot locate a trusted mkdir' >&2
+      exit 1
+    }
+    exec "${_bjg_proof_environment[@]}" "$_bjg_mkdir" -p "$@"
+    ;;
+  grep)
+    shift
+    [ "$#" -ge 1 ] || {
+      printf '%s\n' 'usage: git-clean grep <grep-args...>' >&2
+      exit 2
+    }
+    _bjg_grep=$(command -p -v grep) || {
+      printf '%s\n' 'cannot locate a trusted grep' >&2
+      exit 1
+    }
+    exec "${_bjg_proof_environment[@]}" "$_bjg_grep" "$@" <&3
+    ;;
+  run-posix)
+    shift
+    [ "$#" -ge 1 ] || {
+      printf '%s\n' 'usage: git-clean run-posix {awk|sed|tail} <args...>' >&2
+      exit 2
+    }
+    _bjg_utility=$1
+    shift
+    case $_bjg_utility in
+      awk|sed|tail) ;;
+      *)
+        printf '%s\n' 'clean POSIX runner refused an unsupported utility' >&2
+        exit 2
+        ;;
+    esac
+    _bjg_utility_path=$(command -p -v "$_bjg_utility") || {
+      printf '%s\n' 'cannot locate a trusted POSIX utility' >&2
+      exit 1
+    }
+    exec "${_bjg_proof_environment[@]}" "$_bjg_utility_path" "$@" <&3
+    ;;
+  resolve-tool)
+    shift
+    [ "$#" -eq 1 ] || {
+      printf '%s\n' 'usage: git-clean resolve-tool <tool-name>' >&2
+      exit 2
+    }
+    _bjg_audit_path=$(_bjg_prepare_audit_path) || {
+      printf '%s\n' 'cannot construct a clean audit-tool path' >&2
+      exit 1
+    }
+    _bjg_audit_tool=$(_bjg_external_audit_tool "$1") || {
+      printf '%s\n' "$1 is not a trusted outside-worktree audit tool" >&2
+      exit 1
+    }
+    printf '%s\n' "$_bjg_audit_tool"
+    exit 0
+    ;;
+  run-audit-tool)
+    shift
+    [ "$#" -ge 1 ] || {
+      printf '%s\n' 'usage: git-clean run-audit-tool <tool-name> <args...>' >&2
+      exit 2
+    }
+    _bjg_audit_name=$1
+    shift
+    _bjg_audit_path=$(_bjg_prepare_audit_path) || {
+      printf '%s\n' 'cannot construct a clean audit-tool path' >&2
+      exit 1
+    }
+    _bjg_audit_tool=$(_bjg_external_audit_tool "$_bjg_audit_name") || {
+      printf '%s\n' "$_bjg_audit_name is not a trusted outside-worktree audit tool" >&2
+      exit 1
+    }
+    _bjg_audit_environment=( -i "PATH=$_bjg_audit_path" "LC_ALL=C" )
+    for _bjg_audit_variable in HOME USER LOGNAME SHELL TERM COLORTERM NO_COLOR \
+      XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME CODEX_HOME CLAUDE_CONFIG_DIR \
+      OPENAI_API_KEY ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN \
+      HTTPS_PROXY https_proxy ALL_PROXY all_proxy NO_PROXY no_proxy \
+      SSL_CERT_FILE SSL_CERT_DIR NIX_SSL_CERT_FILE SSH_AUTH_SOCK; do
+      if [[ -v $_bjg_audit_variable ]]; then
+        _bjg_audit_environment+=( "$_bjg_audit_variable=${!_bjg_audit_variable}" )
+      fi
+    done
+    for _bjg_audit_variable in "${!BEADS_@}" "${!BR_@}"; do
+      _bjg_audit_environment+=( "$_bjg_audit_variable=${!_bjg_audit_variable}" )
+    done
+    exec "$_bjg_env" "${_bjg_audit_environment[@]}" \
+      "$_bjg_audit_tool" "$@" <&3
+    ;;
+  snapshot-files)
+    shift
+    [ "$#" -ge 5 ] && [ "$4" = -- ] || {
+      printf '%s\n' 'usage: git-clean snapshot-files <manifest> <state> <snapshot-dir> -- <absolute-file>...' >&2
+      exit 2
+    }
+    _bjg_manifest=$1
+    _bjg_state=$2
+    _bjg_snapshot_dir=$3
+    shift 4
+    [[ "$_bjg_manifest" == /* && "$_bjg_state" == /* \
+       && "$_bjg_snapshot_dir" == /* && -d "$_bjg_snapshot_dir" ]] || {
+      printf '%s\n' 'clean source snapshot requires absolute existing destinations' >&2
+      exit 1
+    }
+    _bjg_snapshot_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || exit 1
+    _bjg_snapshot_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_snapshot_root_raw" 2>/dev/null && pwd -P
+    ) || exit 1
+    _bjg_cp=$(command -p -v cp) || {
+      printf '%s\n' 'cannot locate a trusted cp for source snapshot' >&2
+      exit 1
+    }
+    : >"$_bjg_manifest" && : >"$_bjg_state" || {
+      printf '%s\n' 'cannot initialize source snapshot state' >&2
+      exit 1
+    }
+    _bjg_source_n=0
+    for _bjg_source in "$@"; do
+      [[ "$_bjg_source" == /* && -f "$_bjg_source" && ! -L "$_bjg_source" \
+         && "$_bjg_source" != *$'\t'* && "$_bjg_source" != *$'\n'* \
+         && "$_bjg_source" != *$'\r'* ]] || {
+        printf '%s\n' 'source snapshot received an unsafe or missing file' >&2
+        exit 1
+      }
+      _bjg_source_parent=$(
+        CDPATH=
+        export CDPATH
+        cd -P -- "${_bjg_source%/*}" 2>/dev/null && pwd -P
+      ) || exit 1
+      _bjg_source_canonical=$_bjg_source_parent/${_bjg_source##*/}
+      if [[ "$_bjg_snapshot_root" != / \
+            && "$_bjg_source" == "$_bjg_snapshot_root/"* \
+            && "$_bjg_source_canonical" != "$_bjg_snapshot_root/"* ]]; then
+        printf '%s\n' 'worktree source resolves outside the current Git worktree' >&2
+        exit 1
+      fi
+      _bjg_source_n=$((_bjg_source_n + 1))
+      printf -v _bjg_source_prefix '%03d' "$_bjg_source_n"
+      _bjg_copy=$_bjg_snapshot_dir/$_bjg_source_prefix-${_bjg_source##*/}
+      _bjg_before=$("$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        hash-object --no-filters "$_bjg_source") || exit 1
+      "${_bjg_proof_environment[@]}" "$_bjg_cp" \
+        "$_bjg_source" "$_bjg_copy" || exit 1
+      _bjg_after=$("$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        hash-object --no-filters "$_bjg_source") || exit 1
+      _bjg_copy_oid=$("$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        hash-object --no-filters "$_bjg_copy") || exit 1
+      [[ "$_bjg_before" == "$_bjg_after" && "$_bjg_before" == "$_bjg_copy_oid" ]] || {
+        printf '%s\n' "audit source changed while being snapshotted: $_bjg_source" >&2
+        exit 1
+      }
+      printf '%s\t%s\n' "$_bjg_source" "$_bjg_copy" >>"$_bjg_manifest" || exit 1
+      printf '%s\t%s\n' "$_bjg_before" "$_bjg_source" >>"$_bjg_state" || exit 1
+    done
+    exit 0
+    ;;
+  verify-files)
+    shift
+    [ "$#" -ge 4 ] && [ "$3" = -- ] || {
+      printf '%s\n' 'usage: git-clean verify-files <before-state> <after-state> -- <absolute-file>...' >&2
+      exit 2
+    }
+    _bjg_before_state=$1
+    _bjg_after_state=$2
+    shift 3
+    [[ "$_bjg_before_state" == /* && "$_bjg_after_state" == /* ]] || {
+      printf '%s\n' 'clean source verification requires absolute state files' >&2
+      exit 1
+    }
+    _bjg_cmp=$(command -p -v cmp) || {
+      printf '%s\n' 'cannot locate a trusted cmp for source verification' >&2
+      exit 1
+    }
+    : >"$_bjg_after_state" || {
+      printf '%s\n' 'cannot initialize final source state' >&2
+      exit 1
+    }
+    _bjg_verify_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || exit 1
+    _bjg_verify_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_verify_root_raw" 2>/dev/null && pwd -P
+    ) || exit 1
+    for _bjg_source in "$@"; do
+      [[ "$_bjg_source" == /* && -f "$_bjg_source" && ! -L "$_bjg_source" \
+         && "$_bjg_source" != *$'\t'* && "$_bjg_source" != *$'\n'* \
+         && "$_bjg_source" != *$'\r'* ]] || exit 1
+      _bjg_source_parent=$(
+        CDPATH=
+        export CDPATH
+        cd -P -- "${_bjg_source%/*}" 2>/dev/null && pwd -P
+      ) || exit 1
+      _bjg_source_canonical=$_bjg_source_parent/${_bjg_source##*/}
+      if [[ "$_bjg_verify_root" != / \
+            && "$_bjg_source" == "$_bjg_verify_root/"* \
+            && "$_bjg_source_canonical" != "$_bjg_verify_root/"* ]]; then
+        exit 1
+      fi
+      _bjg_after=$("$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        hash-object --no-filters "$_bjg_source") || exit 1
+      printf '%s\t%s\n' "$_bjg_after" "$_bjg_source" >>"$_bjg_after_state" ||
+        exit 1
+    done
+    "${_bjg_proof_environment[@]}" "$_bjg_cmp" \
+      -s "$_bjg_before_state" "$_bjg_after_state"
+    exit $?
+    ;;
+  hash-file)
+    shift
+    [ "$#" -eq 1 ] && [[ "$1" == /* && -f "$1" && ! -L "$1" ]] || {
+      printf '%s\n' 'usage: git-clean hash-file <absolute-regular-file>' >&2
+      exit 2
+    }
+    _bjg_oid=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      hash-object --no-filters "$1") || {
+      printf '%s\n' 'cannot hash the file' >&2
+      exit 1
+    }
+    [[ "$_bjg_oid" =~ ^[0-9a-fA-F]+$ ]] || {
+      printf '%s\n' 'clean file hash returned an invalid object id' >&2
+      exit 1
+    }
+    printf '%s\n' "$_bjg_oid"
+    exit 0
+    ;;
+  head-oid)
+    shift
+    [ "$#" -eq 0 ] || {
+      printf '%s\n' 'usage: git-clean head-oid' >&2
+      exit 2
+    }
+    _bjg_oid=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --verify 'HEAD^{commit}') || {
+      printf '%s\n' 'cannot resolve the current HEAD commit' >&2
+      exit 1
+    }
+    [[ "$_bjg_oid" =~ ^[0-9a-fA-F]+$ ]] || {
+      printf '%s\n' 'clean HEAD resolution returned an invalid object id' >&2
+      exit 1
+    }
+    printf '%s\n' "$_bjg_oid"
+    exit 0
+    ;;
+  commit)
+    shift
+    [ "$#" -eq 8 ] && [ "$1" = --only-reviewed ] \
+      && [ "$3" = --expect-oid ] && [[ "$4" =~ ^[0-9a-fA-F]+$ ]] \
+      && [ "$5" = --expect-head ] && [[ "$6" =~ ^[0-9a-fA-F]+$ ]] \
+      && [ "$7" = -m ] && [ -n "$8" ] || {
+      printf '%s\n' 'usage: git-clean commit --only-reviewed <absolute-file> --expect-oid <oid> --expect-head <commit> -m <message>' >&2
+      exit 2
+    }
+    _bjg_commit_path=$2
+    _bjg_commit_oid=$4
+    _bjg_commit_head=$6
+    _bjg_commit_message=$8
+    [[ "$_bjg_commit_path" == /* ]] || {
+      printf '%s\n' 'clean Git commit requires an absolute reviewed file' >&2
+      exit 1
+    }
+    _bjg_commit_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the current Git worktree for clean commit' >&2
+      exit 1
+    }
+    _bjg_commit_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_commit_root_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the current Git worktree for clean commit' >&2
+      exit 1
+    }
+    _bjg_commit_name=${_bjg_commit_path##*/}
+    _bjg_commit_parent=${_bjg_commit_path%/*}
+    _bjg_commit_parent=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_commit_parent" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the reviewed file for clean commit' >&2
+      exit 1
+    }
+    _bjg_commit_path=$_bjg_commit_parent/$_bjg_commit_name
+    if [[ "$_bjg_commit_root" == / ]]; then
+      _bjg_commit_relative=${_bjg_commit_path#/}
+    elif [[ "$_bjg_commit_path" == "$_bjg_commit_root/"* ]]; then
+      _bjg_commit_relative=${_bjg_commit_path#"$_bjg_commit_root/"}
+    else
+      printf '%s\n' 'clean Git commit file is outside the current worktree' >&2
+      exit 1
+    fi
+
+    _bjg_commit_live_head=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_commit_root" rev-parse --verify 'HEAD^{commit}') || {
+      printf '%s\n' 'cannot resolve HEAD for clean commit' >&2
+      exit 1
+    }
+    [[ "$_bjg_commit_live_head" == "$_bjg_commit_head" ]] || {
+      printf '%s\n' 'HEAD no longer matches the reviewed commit' >&2
+      exit 1
+    }
+
+    _bjg_commit_git_dir_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_commit_root" rev-parse --absolute-git-dir 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the Git administrative directory for clean commit' >&2
+      exit 1
+    }
+    _bjg_commit_git_dir=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_commit_git_dir_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the Git administrative directory for clean commit' >&2
+      exit 1
+    }
+    _bjg_commit_tmp=$("$_bjg_mktemp" -d \
+      "$_bjg_commit_git_dir/beads-jsonl-commit.XXXXXX") || {
+      printf '%s\n' 'cannot create a private isolated-index directory' >&2
+      exit 1
+    }
+    "$_bjg_chmod" 700 "$_bjg_commit_tmp" || {
+      "$_bjg_rmdir" "$_bjg_commit_tmp" 2>/dev/null || :
+      printf '%s\n' 'cannot protect the private isolated-index directory' >&2
+      exit 1
+    }
+    _bjg_commit_index=$_bjg_commit_tmp/index
+    _bjg_commit_cleanup() {
+      local status=$? cleanup_status=0 path
+      trap - EXIT HUP INT QUIT TERM
+      for path in "$_bjg_commit_index.lock" "$_bjg_commit_index"; do
+        if [[ -e "$path" || -L "$path" ]] && ! "$_bjg_unlink" "$path"; then
+          cleanup_status=1
+        fi
+      done
+      if ! "$_bjg_rmdir" "$_bjg_commit_tmp"; then
+        cleanup_status=1
+      fi
+      if [[ $status -eq 0 && $cleanup_status -ne 0 ]]; then
+        printf '%s\n' 'cannot remove the private isolated-index directory' >&2
+        status=1
+      fi
+      exit "$status"
+    }
+    trap _bjg_commit_cleanup EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 131' QUIT
+    trap 'exit 143' TERM
+
+    if ! GIT_INDEX_FILE=$_bjg_commit_index \
+        "$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.splitIndex=false \
+        -c core.hooksPath=/dev/null -C "$_bjg_commit_root" \
+        read-tree "$_bjg_commit_head"; then
+      printf '%s\n' 'cannot initialize the isolated index for clean commit' >&2
+      exit 1
+    fi
+    if ! printf '100644 %s\t%s\0' "$_bjg_commit_oid" "$_bjg_commit_relative" |
+        GIT_INDEX_FILE=$_bjg_commit_index \
+        "$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.splitIndex=false \
+        -c core.hooksPath=/dev/null \
+        -C "$_bjg_commit_root" update-index -z --index-info; then
+      printf '%s\n' 'cannot stage the reviewed object in the isolated index' >&2
+      exit 1
+    fi
+    _bjg_commit_tree=$(GIT_INDEX_FILE=$_bjg_commit_index \
+      "$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.splitIndex=false \
+      -c core.hooksPath=/dev/null -C "$_bjg_commit_root" write-tree) || {
+      printf '%s\n' 'cannot write the isolated reviewed tree' >&2
+      exit 1
+    }
+    _bjg_commit_new=$(
+      printf '%s\n' "$_bjg_commit_message" |
+        "$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        -c commit.gpgSign=false -C "$_bjg_commit_root" \
+        commit-tree "$_bjg_commit_tree" -p "$_bjg_commit_head"
+    ) || {
+      printf '%s\n' 'cannot create the reviewed commit' >&2
+      exit 1
+    }
+    [[ "$_bjg_commit_new" =~ ^[0-9a-fA-F]+$ ]] || {
+      printf '%s\n' 'clean commit returned an invalid object id' >&2
+      exit 1
+    }
+    "$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_commit_root" update-ref \
+      -m 'commit: reviewed Beads JSONL' HEAD \
+      "$_bjg_commit_new" "$_bjg_commit_head" || {
+      printf '%s\n' 'HEAD changed before the reviewed commit could be installed' >&2
+      exit 1
+    }
+    printf '%s\n' "$_bjg_commit_new"
+    exit 0
+    ;;
+  push)
+    shift
+    [ "$#" -eq 6 ] && [ "$1" = --remote ] && [ "$3" = --branch ] \
+      && [ "$5" = --expect-head ] && [[ "$6" =~ ^[0-9a-fA-F]+$ ]] || {
+      printf '%s\n' 'usage: git-clean push --remote <remote-name> --branch <branch-name> --expect-head <commit>' >&2
+      exit 2
+    }
+    _bjg_push_remote=$2
+    _bjg_push_branch=$4
+    _bjg_push_head=$6
+    [[ "$_bjg_push_remote" =~ ^[A-Za-z0-9._-]+$ \
+       && "$_bjg_push_branch" != -* && "$_bjg_push_branch" != refs/* \
+       && "$_bjg_push_branch" != *$'\n'* && "$_bjg_push_branch" != *$'\r'* ]] || {
+      printf '%s\n' 'clean push received an invalid remote or branch' >&2
+      exit 1
+    }
+    "$_bjg_git" check-ref-format "refs/heads/$_bjg_push_branch" >/dev/null || {
+      printf '%s\n' 'clean push received an invalid branch' >&2
+      exit 1
+    }
+    _bjg_push_current_branch=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      symbolic-ref --quiet --short HEAD) || {
+      printf '%s\n' 'clean push requires an attached current branch' >&2
+      exit 1
+    }
+    [[ "$_bjg_push_current_branch" == "$_bjg_push_branch" ]] || {
+      printf '%s\n' 'clean push branch does not match the current branch' >&2
+      exit 1
+    }
+    _bjg_push_live_head=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --verify 'HEAD^{commit}') || {
+      printf '%s\n' 'clean push cannot resolve current HEAD' >&2
+      exit 1
+    }
+    [[ "$_bjg_push_live_head" == "$_bjg_push_head" ]] || {
+      printf '%s\n' 'clean push HEAD no longer matches the reviewed commit' >&2
+      exit 1
+    }
+    _bjg_push_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the current Git worktree for clean push' >&2
+      exit 1
+    }
+    _bjg_push_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_push_root_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the current Git worktree for clean push' >&2
+      exit 1
+    }
+    for _bjg_config_home_name in HOME XDG_CONFIG_HOME; do
+      [[ ! -v $_bjg_config_home_name || -z ${!_bjg_config_home_name} ]] && continue
+      _bjg_config_home_raw=${!_bjg_config_home_name}
+      [[ "$_bjg_config_home_raw" == /* && "$_bjg_config_home_raw" != *$'\n'* \
+         && "$_bjg_config_home_raw" != *$'\r'* ]] || {
+        printf '%s\n' 'cannot canonicalize the Git/SSH config home for clean push' >&2
+        exit 1
+      }
+      if [[ -d "$_bjg_config_home_raw" ]]; then
+        _bjg_config_home=$(
+          CDPATH=
+          export CDPATH
+          cd -P -- "$_bjg_config_home_raw" 2>/dev/null && pwd -P
+        ) || {
+          printf '%s\n' 'cannot canonicalize the Git/SSH config home for clean push' >&2
+          exit 1
+        }
+      elif [[ -e "$_bjg_config_home_raw" || -L "$_bjg_config_home_raw" \
+              || "$_bjg_config_home_raw" == */../* \
+              || "$_bjg_config_home_raw" == */./* \
+              || "$_bjg_config_home_raw" == */.. \
+              || "$_bjg_config_home_raw" == */. ]]; then
+        printf '%s\n' 'cannot canonicalize the Git/SSH config home for clean push' >&2
+        exit 1
+      else
+        # A not-yet-created config directory is normal. Canonicalize its nearest
+        # existing ancestor so a symlinked parent cannot redirect it into the
+        # driven worktree. Keep the absent absolute XDG path: unsetting it
+        # would make Git fall back to a different `$HOME/.config/git/config`.
+        _bjg_config_probe=${_bjg_config_home_raw%/}
+        _bjg_config_suffix=
+        while [[ ! -d "$_bjg_config_probe" ]]; do
+          _bjg_config_leaf=${_bjg_config_probe##*/}
+          _bjg_config_suffix=/$_bjg_config_leaf$_bjg_config_suffix
+          _bjg_config_probe=${_bjg_config_probe%/*}
+          [[ -n "$_bjg_config_probe" ]] || _bjg_config_probe=/
+        done
+        _bjg_config_probe=$(
+          CDPATH=
+          export CDPATH
+          cd -P -- "$_bjg_config_probe" 2>/dev/null && pwd -P
+        ) || {
+          printf '%s\n' 'cannot canonicalize the Git/SSH config home for clean push' >&2
+          exit 1
+        }
+        _bjg_config_home=$_bjg_config_probe$_bjg_config_suffix
+      fi
+      if [[ "$_bjg_push_root" == / || "$_bjg_config_home" == "$_bjg_push_root" \
+            || "$_bjg_config_home" == "$_bjg_push_root/"* ]]; then
+        printf '%s\n' 'Git/SSH config home is inside the current worktree' >&2
+        exit 1
+      fi
+    done
+    unset _bjg_config_home _bjg_config_home_name _bjg_config_home_raw \
+      _bjg_config_leaf _bjg_config_probe _bjg_config_suffix
+
+    _bjg_regular_link_count() {
+      local path=$1 count
+      if count=$("$_bjg_stat" -c %h "$path" 2>/dev/null) \
+          && [[ $count =~ ^[0-9]+$ ]]; then
+        :
+      elif count=$("$_bjg_stat" -f %l "$path" 2>/dev/null) \
+          && [[ $count =~ ^[0-9]+$ ]]; then
+        :
+      else
+        return 1
+      fi
+      printf '%s\n' "$count"
+    }
+    _bjg_external_helper() {
+      local path=$1 diagnostic=$2 parent leaf link hops link_count
+      [[ "$path" == /* ]] || {
+        printf '%s\n' "$diagnostic" >&2
+        return 1
+      }
+      hops=0
+      while :; do
+        parent=${path%/*}
+        leaf=${path##*/}
+        parent=$(
+          CDPATH=
+          export CDPATH
+          cd -P -- "$parent" 2>/dev/null && pwd -P
+        ) || {
+          printf '%s\n' "$diagnostic" >&2
+          return 1
+        }
+        path=$parent/$leaf
+        if [[ "$_bjg_push_root" == / || "$path" == "$_bjg_push_root" \
+              || "$path" == "$_bjg_push_root/"* ]]; then
+          printf '%s\n' 'credential helper resolves inside the current Git worktree' >&2
+          return 1
+        fi
+        [[ -L "$path" ]] || break
+        ((hops < 40)) || {
+          printf '%s\n' "$diagnostic" >&2
+          return 1
+        }
+        link=$("$_bjg_readlink" "$path") || {
+          printf '%s\n' "$diagnostic" >&2
+          return 1
+        }
+        case $link in
+          /*) path=$link ;;
+          *) path=$parent/$link ;;
+        esac
+        hops=$((hops + 1))
+      done
+      [[ -f "$path" && -x "$path" ]] || {
+        printf '%s\n' "$diagnostic" >&2
+        return 1
+      }
+      link_count=$(_bjg_regular_link_count "$path") || {
+        printf '%s\n' "$diagnostic" >&2
+        return 1
+      }
+      [[ "$link_count" == 1 ]] || {
+        printf '%s\n' 'credential helper executable has multiple hard links' >&2
+        return 1
+      }
+      printf '%s\n' "$path"
+    }
+    _bjg_git_exec_path=$("$_bjg_git" --exec-path) || {
+      printf '%s\n' 'cannot resolve the trusted Git helper path' >&2
+      exit 1
+    }
+    _bjg_append_credential_helper() {
+      local key=$1 helper=$2 name program candidate value argument path link_count
+      local -a words
+      [[ "$key" == credential.helper \
+         || ( "$key" == credential.*.helper && "$key" != *$'\n'* \
+              && "$key" != *$'\r'* && "$key" != *=* ) ]] || {
+        printf '%s\n' 'configured credential helper has an invalid scope' >&2
+        return 1
+      }
+      # Empty values deliberately reset helpers accumulated at lower config
+      # precedence. Preserve their position rather than silently skipping them.
+      if [[ -z "$helper" ]]; then
+        _bjg_credential_config+=( -c "$key=" )
+        return 0
+      fi
+      read -r -a words <<<"$helper"
+      name=${words[0]-}
+      [[ "$name" =~ ^[A-Za-z0-9._+-]+$ ]] || {
+        printf '%s\n' 'configured credential helper is not a simple named helper' >&2
+        return 1
+      }
+
+      # Support the argument-bearing forms of Git's standard cache/store
+      # helpers without admitting a shell grammar. Other named helpers remain
+      # supported with no arguments.
+      case $name:${#words[@]} in
+        cache:1) ;;
+        store:1)
+          printf '%s\n' 'credential store requires an explicit --file path' >&2
+          return 1
+          ;;
+        *:1) ;;
+        cache:2)
+          [[ "${words[1]}" =~ ^--timeout=[0-9]+$ \
+             || "${words[1]}" == --socket=/* ]] || {
+            printf '%s\n' 'configured credential helper has unsupported arguments' >&2
+            return 1
+          }
+          ;;
+        cache:3)
+          [[ ( "${words[1]}" == --timeout && "${words[2]}" =~ ^[0-9]+$ ) \
+             || ( "${words[1]}" == --socket && "${words[2]}" == /* ) ]] || {
+            printf '%s\n' 'configured credential helper has unsupported arguments' >&2
+            return 1
+          }
+          ;;
+        store:2)
+          [[ "${words[1]}" == --file=/* ]] || {
+            printf '%s\n' 'configured credential helper has unsupported arguments' >&2
+            return 1
+          }
+          ;;
+        store:3)
+          [[ "${words[1]}" == --file && "${words[2]}" == /* ]] || {
+            printf '%s\n' 'configured credential helper has unsupported arguments' >&2
+            return 1
+          }
+          ;;
+        *)
+          printf '%s\n' 'configured credential helper has unsupported arguments' >&2
+          return 1
+          ;;
+      esac
+      for argument in "${words[@]:1}"; do
+        [[ "$argument" =~ ^[A-Za-z0-9_./+:=@%,-]+$ ]] || {
+          printf '%s\n' 'configured credential helper has unsafe arguments' >&2
+          return 1
+        }
+        case $argument in
+          --socket=/*|--file=/*) path=${argument#*=} ;;
+          /*) path=$argument ;;
+          *) continue ;;
+        esac
+        [[ "$path" != */../* && "$path" != */./* && "$path" != */.. \
+           && "$path" != */. && ! -L "$path" ]] || {
+          printf '%s\n' 'configured credential helper path is unsafe' >&2
+          return 1
+        }
+        candidate=${path%/*}
+        candidate=$(
+          CDPATH=
+          export CDPATH
+          cd -P -- "$candidate" 2>/dev/null && pwd -P
+        ) || {
+          printf '%s\n' 'cannot canonicalize the configured credential helper path' >&2
+          return 1
+        }
+        if [[ "$_bjg_push_root" == / || "$candidate" == "$_bjg_push_root" \
+              || "$candidate" == "$_bjg_push_root/"* ]]; then
+          printf '%s\n' 'credential helper path resolves inside the current Git worktree' >&2
+          return 1
+        fi
+        if [[ "$name" == store && ( -e "$path" || -L "$path" ) ]]; then
+          [[ -f "$path" && ! -L "$path" ]] || {
+            printf '%s\n' 'credential store path is not a non-symlink regular file' >&2
+            return 1
+          }
+          link_count=$(_bjg_regular_link_count "$path") || {
+            printf '%s\n' 'cannot inspect the credential store hard-link count' >&2
+            return 1
+          }
+          [[ "$link_count" == 1 ]] || {
+            printf '%s\n' 'credential store has multiple hard links' >&2
+            return 1
+          }
+        fi
+      done
+
+      program=git-credential-$name
+      if [[ -x "$_bjg_git_exec_path/$program" ]]; then
+        candidate=$_bjg_git_exec_path/$program
+      else
+        candidate=$(
+          PATH=$_bjg_caller_path
+          export PATH
+          type -P -- "$program"
+        ) || {
+          printf '%s\n' 'cannot resolve the configured credential helper' >&2
+          return 1
+        }
+      fi
+      candidate=$(_bjg_external_helper \
+        "$candidate" 'cannot validate the configured credential helper') ||
+        return 1
+      [[ "$candidate" =~ ^[A-Za-z0-9_./+,:=@%-]+$ ]] || {
+        printf '%s\n' 'configured credential helper executable has an unsafe pathname' >&2
+        return 1
+      }
+      value=$candidate
+      for argument in "${words[@]:1}"; do
+        value+=" $argument"
+      done
+      _bjg_credential_config+=( -c "$key=$value" )
+    }
+    _bjg_credential_config=( -c credential.helper= )
+    while IFS=' ' read -r _bjg_credential_key _bjg_credential_helper; do
+      _bjg_append_credential_helper "$_bjg_credential_key" "$_bjg_credential_helper" ||
+        exit 1
+    done < <("$_bjg_git" config --system --get-regexp \
+      '^credential\.(.*\.)?helper$' 2>/dev/null)
+    while IFS=' ' read -r _bjg_credential_key _bjg_credential_helper; do
+      _bjg_append_credential_helper "$_bjg_credential_key" "$_bjg_credential_helper" ||
+        exit 1
+    done < <("$_bjg_git" config --global --get-regexp \
+      '^credential\.(.*\.)?helper$' 2>/dev/null)
+    unset _bjg_credential_helper _bjg_credential_key _bjg_git_exec_path
+    _bjg_transport_config=()
+    if _bjg_ssh=$(command -p -v ssh); then
+      _bjg_ssh_command="$_bjg_ssh -F /dev/null -o ProxyCommand=none -o PermitLocalCommand=no -o BatchMode=yes"
+      _bjg_transport_config+=( -c protocol.ssh.allow=always \
+        -c "core.sshCommand=$_bjg_ssh_command" )
+    else
+      _bjg_transport_config+=( -c protocol.ssh.allow=never )
+    fi
+    command unset SSH_ASKPASS SSH_ASKPASS_REQUIRE DISPLAY WAYLAND_DISPLAY
+    GIT_TERMINAL_PROMPT=0
+    export GIT_TERMINAL_PROMPT
+    exec "$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -c push.gpgSign=false -c core.askPass= \
+      -c push.default=nothing -c push.followTags=false \
+      -c "remote.$_bjg_push_remote.mirror=false" \
+      -c protocol.allow=never \
+      -c protocol.https.allow=always -c protocol.http.allow=never \
+      "${_bjg_credential_config[@]}" "${_bjg_transport_config[@]}" \
+      push "$_bjg_push_remote" "$_bjg_push_head:refs/heads/$_bjg_push_branch"
+    ;;
+esac
+[ "$#" -ge 2 ] && [ "$1" = --literal-pathspecs ] || {
+  printf '%s\n' 'usage: git-clean {copy-file|diff-files|hash-file|head-oid|worktree-root|make-temp-dir|make-dir|grep|run-posix|resolve-tool|run-audit-tool|snapshot-files|verify-files|commit|push|--literal-pathspecs {diff|add}} ...' >&2
+  exit 2
+}
+shift
+_bjg_subcommand=$1
+shift
+case $_bjg_subcommand in
+  diff)
+    exec "$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      --literal-pathspecs diff --no-ext-diff --no-textconv --text "$@"
+    ;;
+  add)
+    [ "$#" -eq 4 ] && [ "$1" = --expect-oid ] && [ "$3" = -- ] \
+      && [[ "$2" =~ ^[0-9a-fA-F]+$ ]] || {
+      printf '%s\n' 'usage: git-clean --literal-pathspecs add --expect-oid <oid> -- <absolute-file>' >&2
+      exit 2
+    }
+    _bjg_expected_oid=$2
+    _bjg_path=$4
+    case $_bjg_path in
+      /*) ;;
+      *)
+        printf '%s\n' 'clean Git add requires an absolute file' >&2
+        exit 1
+        ;;
+    esac
+    _bjg_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the current Git worktree for clean add' >&2
+      exit 1
+    }
+    _bjg_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_root_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the current Git worktree for clean add' >&2
+      exit 1
+    }
+    _bjg_name=${_bjg_path##*/}
+    _bjg_parent=${_bjg_path%/*}
+    _bjg_parent=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_parent" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the file for clean add' >&2
+      exit 1
+    }
+    _bjg_path=$_bjg_parent/$_bjg_name
+    if [[ "$_bjg_root" == / ]]; then
+      _bjg_relative=${_bjg_path#/}
+    elif [[ "$_bjg_path" == "$_bjg_root/"* ]]; then
+      _bjg_relative=${_bjg_path#"$_bjg_root/"}
+    else
+      printf '%s\n' 'clean Git add file is outside the current worktree' >&2
+      exit 1
+    fi
+    [[ -n "$_bjg_relative" && -f "$_bjg_path" && ! -L "$_bjg_path" ]] || {
+      printf '%s\n' 'clean Git add file is not a non-symlink regular file' >&2
+      exit 1
+    }
+    _bjg_oid=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_root" hash-object -w --no-filters "$_bjg_path") || {
+      printf '%s\n' 'cannot hash the file for clean add' >&2
+      exit 1
+    }
+    [[ "$_bjg_oid" =~ ^[0-9a-fA-F]+$ ]] || {
+      printf '%s\n' 'clean Git add returned an invalid object id' >&2
+      exit 1
+    }
+    [[ "$_bjg_oid" == "$_bjg_expected_oid" ]] || {
+      printf '%s\n' 'clean Git add file no longer matches the reviewed object id' >&2
+      exit 1
+    }
+    printf '100644 %s\t%s\0' "$_bjg_oid" "$_bjg_relative" |
+      "$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        -C "$_bjg_root" update-index -z --index-info
+    ;;
+  *)
+    printf '%s\n' 'usage: git-clean {copy-file|diff-files|commit|push|--literal-pathspecs {diff|add}} ...' >&2
+    exit 2
+    ;;
+esac
+__BJG_TRUSTED_BASH__

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -1139,9 +1139,64 @@ case $_bjg_subcommand in
       printf '%s\n' 'clean Git add file is not a non-symlink regular file' >&2
       exit 1
     }
+    _bjg_add_git_dir_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_root" rev-parse --absolute-git-dir 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the Git administrative directory for clean add' >&2
+      exit 1
+    }
+    _bjg_add_git_dir=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_add_git_dir_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the Git administrative directory for clean add' >&2
+      exit 1
+    }
+    _bjg_add_tmp=$("$_bjg_mktemp" -d \
+      "$_bjg_add_git_dir/beads-jsonl-add.XXXXXX") || {
+      printf '%s\n' 'cannot create a private clean-add directory' >&2
+      exit 1
+    }
+    "$_bjg_chmod" 700 "$_bjg_add_tmp" || {
+      "$_bjg_rmdir" "$_bjg_add_tmp" 2>/dev/null || :
+      printf '%s\n' 'cannot protect the private clean-add directory' >&2
+      exit 1
+    }
+    _bjg_add_snapshot=$_bjg_add_tmp/reviewed
+    _bjg_add_cleanup() {
+      local status=$? cleanup_status=0
+      trap - EXIT HUP INT QUIT TERM
+      if [[ -e "$_bjg_add_snapshot" || -L "$_bjg_add_snapshot" ]] \
+          && ! "$_bjg_unlink" "$_bjg_add_snapshot"; then
+        cleanup_status=1
+      fi
+      if ! "$_bjg_rmdir" "$_bjg_add_tmp"; then
+        cleanup_status=1
+      fi
+      if [[ $status -eq 0 && $cleanup_status -ne 0 ]]; then
+        printf '%s\n' 'cannot remove the private clean-add directory' >&2
+        status=1
+      fi
+      exit "$status"
+    }
+    trap _bjg_add_cleanup EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 131' QUIT
+    trap 'exit 143' TERM
+    _bjg_add_cp=$(command -p -v cp) || {
+      printf '%s\n' 'cannot locate a trusted cp for clean add' >&2
+      exit 1
+    }
+    "${_bjg_proof_environment[@]}" "$_bjg_add_cp" \
+      "$_bjg_path" "$_bjg_add_snapshot" || {
+      printf '%s\n' 'cannot snapshot the file for clean add' >&2
+      exit 1
+    }
     _bjg_oid=$("$_bjg_git" --no-pager --no-replace-objects \
       -c core.fsmonitor=false -c core.hooksPath=/dev/null \
-      -C "$_bjg_root" hash-object -w --no-filters "$_bjg_path") || {
+      -C "$_bjg_root" hash-object --no-filters "$_bjg_add_snapshot") || {
       printf '%s\n' 'cannot hash the file for clean add' >&2
       exit 1
     }
@@ -1153,10 +1208,21 @@ case $_bjg_subcommand in
       printf '%s\n' 'clean Git add file no longer matches the reviewed object id' >&2
       exit 1
     }
+    _bjg_written_oid=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_root" hash-object -w --no-filters "$_bjg_add_snapshot") || {
+      printf '%s\n' 'cannot persist the reviewed object for clean add' >&2
+      exit 1
+    }
+    [[ "$_bjg_written_oid" == "$_bjg_expected_oid" ]] || {
+      printf '%s\n' 'persisted clean-add object does not match the reviewed object id' >&2
+      exit 1
+    }
     printf '100644 %s\t%s\0' "$_bjg_oid" "$_bjg_relative" |
       "$_bjg_git" --no-pager --no-replace-objects \
         -c core.fsmonitor=false -c core.hooksPath=/dev/null \
         -C "$_bjg_root" update-index -z --index-info
+    exit $?
     ;;
   *)
     printf '%s\n' 'usage: git-clean {copy-file|diff-files|commit|push|--literal-pathspecs {diff|add}} ...' >&2

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Run one Git command through a clean, non-repository-controlled environment.
+# The documented caller-shell locator clears loader injection before this
+# shebang starts; repeat the cleanup here so it cannot reach later execs.
 POSIXLY_CORRECT=y
 export POSIXLY_CORRECT
 \unset -f command builtin exec unset 2>/dev/null || :
@@ -7,7 +9,11 @@ _bjg_bash=$(command -p -v bash) || {
   printf '%s\n' 'cannot locate a trusted Bash for clean Git' >&2
   exit 1
 }
-unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE \
+  LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH
 \exec 3<&0
 \exec "$_bjg_bash" --noprofile --norc -p -s -- "$@" <<'__BJG_TRUSTED_BASH__'
 command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH \

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -799,19 +799,57 @@ case ${1-} in
     printf '%s\n' "$_bjg_oid"
     exit 0
     ;;
+  head-branch)
+    shift
+    [ "$#" -eq 0 ] || {
+      printf '%s\n' 'usage: git-clean head-branch' >&2
+      exit 2
+    }
+    _bjg_branch_ref=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      symbolic-ref --quiet --no-recurse HEAD) || {
+      printf '%s\n' 'cannot resolve the current attached branch' >&2
+      exit 1
+    }
+    case $_bjg_branch_ref in
+      refs/heads/?*) _bjg_branch=${_bjg_branch_ref#refs/heads/} ;;
+      *)
+        printf '%s\n' 'clean branch resolution returned a non-branch ref' >&2
+        exit 1
+        ;;
+    esac
+    [[ -n "$_bjg_branch" && "$_bjg_branch" != *$'\n'* \
+       && "$_bjg_branch" != *$'\r'* ]] \
+      && "$_bjg_git" check-ref-format "refs/heads/$_bjg_branch" >/dev/null || {
+      printf '%s\n' 'clean branch resolution returned an invalid branch' >&2
+      exit 1
+    }
+    printf '%s\n' "$_bjg_branch"
+    exit 0
+    ;;
   commit)
     shift
-    [ "$#" -eq 8 ] && [ "$1" = --only-reviewed ] \
+    [ "$#" -eq 10 ] && [ "$1" = --only-reviewed ] \
       && [ "$3" = --expect-oid ] && [[ "$4" =~ ^[0-9a-fA-F]+$ ]] \
       && [ "$5" = --expect-head ] && [[ "$6" =~ ^[0-9a-fA-F]+$ ]] \
-      && [ "$7" = -m ] && [ -n "$8" ] || {
-      printf '%s\n' 'usage: git-clean commit --only-reviewed <absolute-file> --expect-oid <oid> --expect-head <commit> -m <message>' >&2
+      && [ "$7" = --expect-branch ] && [ -n "$8" ] \
+      && [ "$9" = -m ] && [ -n "${10}" ] || {
+      printf '%s\n' 'usage: git-clean commit --only-reviewed <absolute-file> --expect-oid <oid> --expect-head <commit> --expect-branch <branch> -m <message>' >&2
       exit 2
     }
     _bjg_commit_path=$2
     _bjg_commit_oid=$4
     _bjg_commit_head=$6
-    _bjg_commit_message=$8
+    _bjg_commit_branch=$8
+    _bjg_commit_message=${10}
+    [[ "$_bjg_commit_branch" != *$'\n'* \
+       && "$_bjg_commit_branch" != *$'\r'* ]] \
+      && "$_bjg_git" check-ref-format \
+        "refs/heads/$_bjg_commit_branch" >/dev/null || {
+      printf '%s\n' 'clean Git commit received an invalid reviewed branch' >&2
+      exit 1
+    }
+    _bjg_commit_ref=refs/heads/$_bjg_commit_branch
     [[ "$_bjg_commit_path" == /* ]] || {
       printf '%s\n' 'clean Git commit requires an absolute reviewed file' >&2
       exit 1
@@ -858,6 +896,43 @@ case ${1-} in
     }
     [[ "$_bjg_commit_live_head" == "$_bjg_commit_head" ]] || {
       printf '%s\n' 'HEAD no longer matches the reviewed commit' >&2
+      exit 1
+    }
+    _bjg_commit_live_ref=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_commit_root" symbolic-ref --quiet --no-recurse HEAD) || {
+      printf '%s\n' 'clean commit requires the reviewed attached branch' >&2
+      exit 1
+    }
+    case $_bjg_commit_live_ref in
+      refs/heads/?*)
+        _bjg_commit_live_branch=${_bjg_commit_live_ref#refs/heads/}
+        ;;
+      *)
+        printf '%s\n' 'clean commit HEAD is not attached to a branch ref' >&2
+        exit 1
+        ;;
+    esac
+    [[ "$_bjg_commit_live_branch" == "$_bjg_commit_branch" ]] || {
+      printf '%s\n' 'current branch no longer matches the reviewed branch' >&2
+      exit 1
+    }
+    if "$_bjg_git" --no-pager --no-replace-objects \
+        -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+        -C "$_bjg_commit_root" symbolic-ref --quiet --no-recurse \
+        "$_bjg_commit_ref" >/dev/null; then
+      printf '%s\n' 'reviewed branch ref is unexpectedly symbolic' >&2
+      exit 1
+    fi
+    _bjg_commit_branch_head=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -C "$_bjg_commit_root" rev-parse --verify \
+      "$_bjg_commit_ref^{commit}") || {
+      printf '%s\n' 'cannot resolve the reviewed branch for clean commit' >&2
+      exit 1
+    }
+    [[ "$_bjg_commit_branch_head" == "$_bjg_commit_head" ]] || {
+      printf '%s\n' 'reviewed branch no longer matches the reviewed commit' >&2
       exit 1
     }
 
@@ -948,11 +1023,11 @@ case ${1-} in
       exit 1
     }
     "$_bjg_git" --no-pager --no-replace-objects \
-      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
-      -C "$_bjg_commit_root" update-ref \
-      -m 'commit: reviewed Beads JSONL' HEAD \
+       -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+       -C "$_bjg_commit_root" update-ref \
+      --no-deref -m 'commit: reviewed Beads JSONL' "$_bjg_commit_ref" \
       "$_bjg_commit_new" "$_bjg_commit_head" || {
-      printf '%s\n' 'HEAD changed before the reviewed commit could be installed' >&2
+      printf '%s\n' 'reviewed branch changed before the commit could be installed' >&2
       exit 1
     }
     printf '%s\n' "$_bjg_commit_new"
@@ -969,8 +1044,8 @@ case ${1-} in
     _bjg_push_branch=$4
     _bjg_push_head=$6
     [[ "$_bjg_push_remote" =~ ^[A-Za-z0-9._-]+$ \
-       && "$_bjg_push_branch" != -* && "$_bjg_push_branch" != refs/* \
-       && "$_bjg_push_branch" != *$'\n'* && "$_bjg_push_branch" != *$'\r'* ]] || {
+       && "$_bjg_push_branch" != *$'\n'* \
+       && "$_bjg_push_branch" != *$'\r'* ]] || {
       printf '%s\n' 'clean push received an invalid remote or branch' >&2
       exit 1
     }
@@ -978,12 +1053,21 @@ case ${1-} in
       printf '%s\n' 'clean push received an invalid branch' >&2
       exit 1
     }
-    _bjg_push_current_branch=$("$_bjg_git" --no-pager --no-replace-objects \
+    _bjg_push_current_ref=$("$_bjg_git" --no-pager --no-replace-objects \
       -c core.fsmonitor=false -c core.hooksPath=/dev/null \
-      symbolic-ref --quiet --short HEAD) || {
+      symbolic-ref --quiet --no-recurse HEAD) || {
       printf '%s\n' 'clean push requires an attached current branch' >&2
       exit 1
     }
+    case $_bjg_push_current_ref in
+      refs/heads/?*)
+        _bjg_push_current_branch=${_bjg_push_current_ref#refs/heads/}
+        ;;
+      *)
+        printf '%s\n' 'clean push HEAD is not attached to a branch ref' >&2
+        exit 1
+        ;;
+    esac
     [[ "$_bjg_push_current_branch" == "$_bjg_push_branch" ]] || {
       printf '%s\n' 'clean push branch does not match the current branch' >&2
       exit 1
@@ -1399,7 +1483,7 @@ case ${1-} in
     ;;
 esac
 [ "$#" -ge 2 ] && [ "$1" = --literal-pathspecs ] || {
-  printf '%s\n' 'usage: git-clean {copy-file|diff-files|hash-file|head-oid|worktree-root|make-temp-dir|make-dir|grep|run-posix|resolve-tool|run-audit-tool|snapshot-files|verify-files|commit|push|--literal-pathspecs {diff|add}} ...' >&2
+  printf '%s\n' 'usage: git-clean {copy-file|diff-files|hash-file|head-oid|head-branch|worktree-root|make-temp-dir|make-dir|grep|run-posix|resolve-tool|run-audit-tool|snapshot-files|verify-files|commit|push|--literal-pathspecs {diff|add}} ...' >&2
   exit 2
 }
 shift

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -130,6 +130,60 @@ _bjg_regular_link_count() {
   printf '%s\n' "$count"
 }
 
+_bjg_regular_inode_number() {
+  local path=$1 inode
+  if inode=$("$_bjg_stat" -c %i "$path" 2>/dev/null) \
+      && [[ $inode =~ ^[0-9]+$ ]]; then
+    :
+  elif inode=$("$_bjg_stat" -f %i "$path" 2>/dev/null) \
+      && [[ $inode =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$inode"
+}
+
+_bjg_regular_device_number() {
+  local path=$1 device
+  if device=$("$_bjg_stat" -c %d "$path" 2>/dev/null) \
+      && [[ $device =~ ^[0-9]+$ ]]; then
+    :
+  elif device=$("$_bjg_stat" -f %d "$path" 2>/dev/null) \
+      && [[ $device =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$device"
+}
+
+_bjg_count_matching_device_records() {
+  local expected_device=$1 count _bjg_counted_path device
+  count=0
+  while IFS= read -r -d '' _bjg_counted_path; do
+    device=$(_bjg_regular_device_number "$_bjg_counted_path") || return 1
+    [[ "$device" == "$expected_device" ]] || continue
+    count=$((count + 1))
+    ((count <= 1024)) || return 1
+  done
+  printf '%s\n' "$count"
+}
+
+_bjg_multiple_links_are_colocated() {
+  local path=$1 expected=$2 parent inode device found
+  parent=${path%/*}
+  inode=$(_bjg_regular_inode_number "$path") || return 1
+  device=$(_bjg_regular_device_number "$path") || return 1
+  found=$(
+    "$_bjg_find" "$parent/." ! -name . -prune -inum "$inode" \
+      -exec "$_bjg_sh" -c \
+        'for path do printf "%s\0" "$path"; done' sh '{}' + |
+      _bjg_count_matching_device_records "$device"
+  ) || return 1
+  [[ "$found" == "$expected" ]]
+}
+
 _bjg_canonicalize_directory() {
   local encoded
   encoded=$(
@@ -170,7 +224,7 @@ _bjg_validate_audit_directory_stream() {
   entry_count=0
   while IFS= read -r -d '' candidate; do
     entry_count=$((entry_count + 1))
-    ((entry_count <= entry_limit)) || return 1
+    ((entry_count <= entry_limit)) || return 2
     [[ -x "$candidate" && ! -d "$candidate" ]] || continue
     _bjg_validate_audit_executable "$candidate" >/dev/null || return 1
   done
@@ -179,7 +233,7 @@ _bjg_validate_audit_directory_stream() {
 
 _bjg_prepare_audit_path() {
   local entry canonical seen audited_directories audited_entries
-  local directory_entry_count remaining_entries
+  local directory_entry_count remaining_entries stream_rc
   local -a entries result
   _bjg_load_audit_root || return 1
   result=()
@@ -229,7 +283,14 @@ _bjg_prepare_audit_path() {
         -exec "$_bjg_sh" -c \
           'for path do printf "%s\0" "$path"; done' sh '{}' + |
         _bjg_validate_audit_directory_stream "$remaining_entries"
-    ) || return 1
+    )
+    stream_rc=$?
+    if ((stream_rc != 0)); then
+      ((stream_rc != 2)) || return 1
+      # Omit an unrelated directory containing an unprovable executable. The
+      # selected top-level tool is resolved only from this admitted result below.
+      continue
+    fi
     [[ "$directory_entry_count" =~ ^[0-9]+$ ]] || return 1
     audited_entries=$((audited_entries + directory_entry_count))
     result+=( "$canonical" )
@@ -239,7 +300,10 @@ _bjg_prepare_audit_path() {
 }
 
 _bjg_validate_audit_executable() {
-  local selected=$1 path=$1 parent leaf link hops link_count
+  local selected=$1 path=$1 depth=${2:-0}
+  local parent leaf link hops link_count first_line shebang interpreter argument
+  local interpreter_final safe_entry safe_env_final env_identity
+  local -a safe_entries
   _bjg_load_audit_root || return 1
   [[ "$path" == /* ]] || return 1
   hops=0
@@ -266,18 +330,77 @@ _bjg_validate_audit_executable() {
   done
   [[ -f "$path" && -x "$path" ]] || return 1
   link_count=$(_bjg_regular_link_count "$path") || return 1
-  [[ "$link_count" == 1 ]] || return 1
+  if [[ "$link_count" != 1 ]]; then
+    _bjg_multiple_links_are_colocated "$path" "$link_count" || return 1
+  fi
+
+  # Validate absolute kernel-selected script interpreters recursively. Permit
+  # `/usr/bin/env name` only when `name` is a plain PATH token; the runtime PATH
+  # itself is the fully admitted set assembled above.
+  first_line=
+  if ! IFS= command builtin read -r -n 513 first_line 2>/dev/null <"$path"; then
+    [[ -r "$path" ]] || return 1
+  fi
+  if [[ "$first_line" == '#!'* ]]; then
+    ((${#first_line} <= 512 && depth < 4)) || return 1
+    shebang=${first_line#\#!}
+    while [[ "$shebang" == ' '* || "$shebang" == $'\t'* ]]; do
+      shebang=${shebang#?}
+    done
+    # Linux shebang parsing separates only on space/tab. Treating CR/VT/FF as
+    # shell whitespace would validate a different pathname than the kernel.
+    interpreter=${shebang%%[$' \t']*}
+    [[ "$interpreter" == /* && "$interpreter" != *[$'\r\v\f']* ]] || return 1
+    argument=${shebang#"$interpreter"}
+    while [[ "$argument" == ' '* || "$argument" == $'\t'* ]]; do
+      argument=${argument#?}
+    done
+    # A missing interpreter makes this entry unlaunchable and therefore unable
+    # to execute worktree bytes; do not reject an otherwise unrelated PATH dir.
+    if [[ -e "$interpreter" || -L "$interpreter" ]]; then
+      _bjg_validate_audit_executable "$interpreter" "$((depth + 1))" \
+        >/dev/null || return 1
+      interpreter_final=$_bjg_validated_executable_final
+      if [[ -n "$argument" ]]; then
+        env_identity=false
+        IFS=: read -r -a safe_entries <<<"$_bjg_safe_path"
+        for safe_entry in "${safe_entries[@]}"; do
+          [[ -x "$safe_entry/env" ]] || continue
+          if _bjg_validate_audit_executable "$safe_entry/env" \
+              "$((depth + 1))" >/dev/null; then
+            safe_env_final=$_bjg_validated_executable_final
+            [[ "$interpreter_final" != "$safe_env_final" ]] ||
+              env_identity=true
+          fi
+        done
+        if [[ "$env_identity" == true ]]; then
+          [[ "$argument" =~ ^[A-Za-z0-9._+-]+$ ]] || return 1
+          # Safe-path commands are trusted, and every command in each additional
+          # runtime PATH directory is validated by the enclosing admission scan.
+        else
+          return 1
+        fi
+      fi
+    fi
+  fi
+  _bjg_validated_executable_final=$path
   printf '%s\n' "$selected"
 }
 
 _bjg_external_audit_tool() {
-  local name=$1 selected
+  local name=$1 selected selected_parent
   [[ "$name" =~ ^[A-Za-z0-9._+-]+$ ]] || return 1
   selected=$(
     PATH=$_bjg_caller_path
     export PATH
     type -P -- "$name"
   ) || return 1
+  _bjg_canonicalize_directory "${selected%/*}" || return 1
+  selected_parent=$_bjg_canonical_directory_result
+  case :$_bjg_audit_path: in
+    *:"$selected_parent":*) ;;
+    *) return 1 ;;
+  esac
   _bjg_validate_audit_executable "$selected"
 }
 

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -67,6 +67,14 @@ _bjg_env=$(command -p -v env) || {
   printf '%s\n' 'cannot locate a trusted env for clean utilities' >&2
   exit 1
 }
+_bjg_sh=$(command -p -v sh) || {
+  printf '%s\n' 'cannot locate a trusted shell for clean path enumeration' >&2
+  exit 1
+}
+_bjg_find=$(command -p -v find) || {
+  printf '%s\n' 'cannot locate a trusted find for clean audit-tool paths' >&2
+  exit 1
+}
 _bjg_safe_path=$("$_bjg_getconf" PATH 2>/dev/null) || {
   printf '%s\n' 'cannot resolve the POSIX utility path for clean Git' >&2
   exit 1
@@ -103,6 +111,10 @@ PATH=$_bjg_safe_path
 LC_ALL=C
 export PATH LC_ALL
 _bjg_proof_environment=( "$_bjg_env" -i "PATH=$_bjg_safe_path" "LC_ALL=C" )
+# Never honor caller-exported values for the private root-discovery cache.
+command unset _bjg_audit_root _bjg_audit_root_raw \
+  _bjg_audit_root_loaded _bjg_canonical_directory_result
+_bjg_audit_root_loaded=false
 
 _bjg_regular_link_count() {
   local path=$1 count
@@ -118,26 +130,83 @@ _bjg_regular_link_count() {
   printf '%s\n' "$count"
 }
 
-_bjg_prepare_audit_path() {
-  local entry canonical seen
-  local -a entries result
-  _bjg_audit_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
-    -c core.fsmonitor=false -c core.hooksPath=/dev/null \
-    rev-parse --show-toplevel 2>/dev/null) || return 1
-  _bjg_audit_root=$(
+_bjg_canonicalize_directory() {
+  local encoded
+  encoded=$(
     CDPATH=
     export CDPATH
-    cd -P -- "$_bjg_audit_root_raw" 2>/dev/null && pwd -P
+    cd -P -- "$1" 2>/dev/null && {
+      pwd -P
+      # Keep command substitution from stripping pathname-significant trailing
+      # newlines; remove this sentinel and pwd's one record separator below.
+      printf '/.'
+    }
   ) || return 1
-  IFS=: read -r -a entries <<<"$_bjg_safe_path:$_bjg_caller_path"
+  encoded=${encoded%/.}
+  [[ "$encoded" == *$'\n' ]] || return 1
+  _bjg_canonical_directory_result=${encoded%$'\n'}
+}
+
+_bjg_load_audit_root() {
+  local encoded
+  [[ ${_bjg_audit_root_loaded-} == true ]] && return 0
+  encoded=$(
+    "$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null && printf '/.'
+  ) || return 1
+  encoded=${encoded%/.}
+  [[ "$encoded" == *$'\n' ]] || return 1
+  _bjg_audit_root_raw=${encoded%$'\n'}
+  _bjg_canonicalize_directory "$_bjg_audit_root_raw" || return 1
+  _bjg_audit_root=$_bjg_canonical_directory_result
+  [[ "$_bjg_audit_root" != *:* && "$_bjg_audit_root" != *$'\n'* \
+     && "$_bjg_audit_root" != *$'\r'* ]] || return 1
+  _bjg_audit_root_loaded=true
+}
+
+_bjg_validate_audit_directory_stream() {
+  local entry_limit=$1 candidate entry_count
+  entry_count=0
+  while IFS= read -r -d '' candidate; do
+    entry_count=$((entry_count + 1))
+    ((entry_count <= entry_limit)) || return 1
+    [[ -x "$candidate" && ! -d "$candidate" ]] || continue
+    _bjg_validate_audit_executable "$candidate" >/dev/null || return 1
+  done
+  printf '%s\n' "$entry_count"
+}
+
+_bjg_prepare_audit_path() {
+  local entry canonical seen audited_directories audited_entries
+  local directory_entry_count remaining_entries
+  local -a entries result
+  _bjg_load_audit_root || return 1
   result=()
+  audited_directories=0
+  audited_entries=0
+  IFS=: read -r -a entries <<<"$_bjg_safe_path"
   for entry in "${entries[@]}"; do
     [[ "$entry" == /* && -d "$entry" ]] || continue
-    canonical=$(
-      CDPATH=
-      export CDPATH
-      cd -P -- "$entry" 2>/dev/null && pwd -P
-    ) || continue
+    _bjg_canonicalize_directory "$entry" || continue
+    canonical=$_bjg_canonical_directory_result
+    [[ "$canonical" != *:* && "$canonical" != *$'\n'* \
+       && "$canonical" != *$'\r'* ]] || return 1
+    seen=false
+    for entry in "${result[@]}"; do
+      [[ "$entry" != "$canonical" ]] || seen=true
+    done
+    "$seen" || result+=( "$canonical" )
+  done
+  IFS=: read -r -a entries <<<"$_bjg_caller_path"
+  for entry in "${entries[@]}"; do
+    [[ "$entry" == /* && -d "$entry" ]] || continue
+    _bjg_canonicalize_directory "$entry" || continue
+    canonical=$_bjg_canonical_directory_result
+    # This value is serialized back into one colon-delimited PATH. An otherwise
+    # valid delimiter/control byte would inject or disguise runtime entries.
+    [[ "$canonical" != *:* && "$canonical" != *$'\n'* \
+       && "$canonical" != *$'\r'* ]] || return 1
     if [[ "$_bjg_audit_root" == / || "$canonical" == "$_bjg_audit_root" \
           || "$canonical" == "$_bjg_audit_root/"* ]]; then
       continue
@@ -146,38 +215,41 @@ _bjg_prepare_audit_path() {
     for entry in "${result[@]}"; do
       [[ "$entry" != "$canonical" ]] || seen=true
     done
-    "$seen" || result+=( "$canonical" )
+    "$seen" && continue
+    audited_directories=$((audited_directories + 1))
+    ((audited_directories <= 64)) || return 1
+    # A child launched by a validated top-level tool can select any executable
+    # name from this directory. POSIX find prunes each child after one level and
+    # a trusted shell emits NUL records, so Bash 3.2 can stream arbitrary names
+    # without materializing an attacker-sized glob. Pipefail also refuses a
+    # search-only directory that find cannot enumerate completely.
+    remaining_entries=$((1024 - audited_entries))
+    directory_entry_count=$(
+      "$_bjg_find" "$canonical/." ! -name . -prune \
+        -exec "$_bjg_sh" -c \
+          'for path do printf "%s\0" "$path"; done' sh '{}' + |
+        _bjg_validate_audit_directory_stream "$remaining_entries"
+    ) || return 1
+    [[ "$directory_entry_count" =~ ^[0-9]+$ ]] || return 1
+    audited_entries=$((audited_entries + directory_entry_count))
+    result+=( "$canonical" )
   done
   [[ ${#result[@]} -gt 0 ]] || return 1
   (IFS=:; printf '%s\n' "${result[*]}")
 }
 
-_bjg_external_audit_tool() {
-  local name=$1 path parent leaf link hops link_count
-  [[ "$name" =~ ^[A-Za-z0-9._+-]+$ ]] || return 1
-  _bjg_audit_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
-    -c core.fsmonitor=false -c core.hooksPath=/dev/null \
-    rev-parse --show-toplevel 2>/dev/null) || return 1
-  _bjg_audit_root=$(
-    CDPATH=
-    export CDPATH
-    cd -P -- "$_bjg_audit_root_raw" 2>/dev/null && pwd -P
-  ) || return 1
-  path=$(
-    PATH=$_bjg_caller_path
-    export PATH
-    type -P -- "$name"
-  ) || return 1
+_bjg_validate_audit_executable() {
+  local selected=$1 path=$1 parent leaf link hops link_count
+  _bjg_load_audit_root || return 1
   [[ "$path" == /* ]] || return 1
   hops=0
   while :; do
     parent=${path%/*}
     leaf=${path##*/}
-    parent=$(
-      CDPATH=
-      export CDPATH
-      cd -P -- "$parent" 2>/dev/null && pwd -P
-    ) || return 1
+    _bjg_canonicalize_directory "$parent" || return 1
+    parent=$_bjg_canonical_directory_result
+    [[ "$parent" != *:* && "$parent" != *$'\n'* \
+       && "$parent" != *$'\r'* ]] || return 1
     path=$parent/$leaf
     if [[ "$_bjg_audit_root" == / || "$path" == "$_bjg_audit_root" \
           || "$path" == "$_bjg_audit_root/"* ]]; then
@@ -195,7 +267,18 @@ _bjg_external_audit_tool() {
   [[ -f "$path" && -x "$path" ]] || return 1
   link_count=$(_bjg_regular_link_count "$path") || return 1
   [[ "$link_count" == 1 ]] || return 1
-  printf '%s\n' "$path"
+  printf '%s\n' "$selected"
+}
+
+_bjg_external_audit_tool() {
+  local name=$1 selected
+  [[ "$name" =~ ^[A-Za-z0-9._+-]+$ ]] || return 1
+  selected=$(
+    PATH=$_bjg_caller_path
+    export PATH
+    type -P -- "$name"
+  ) || return 1
+  _bjg_validate_audit_executable "$selected"
 }
 
 case ${1-} in
@@ -372,7 +455,10 @@ case ${1-} in
     # read-only flags take effect. Preserve only existing canonical directories
     # proven outside the driven worktree.
     for _bjg_audit_variable in HOME CODEX_HOME CLAUDE_CONFIG_DIR; do
-      [[ ! -v $_bjg_audit_variable || -z ${!_bjg_audit_variable} ]] && continue
+      if ! command builtin declare -p "$_bjg_audit_variable" >/dev/null 2>&1 \
+          || [[ -z ${!_bjg_audit_variable} ]]; then
+        continue
+      fi
       _bjg_audit_config_raw=${!_bjg_audit_variable}
       [[ "$_bjg_audit_config_raw" == /* && -d "$_bjg_audit_config_raw" \
          && "$_bjg_audit_config_raw" != *$'\n'* \
@@ -397,7 +483,7 @@ case ${1-} in
       OPENAI_API_KEY ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN \
       HTTPS_PROXY https_proxy ALL_PROXY all_proxy NO_PROXY no_proxy \
       SSL_CERT_FILE SSL_CERT_DIR NIX_SSL_CERT_FILE SSH_AUTH_SOCK; do
-      if [[ -v $_bjg_audit_variable ]]; then
+      if command builtin declare -p "$_bjg_audit_variable" >/dev/null 2>&1; then
         _bjg_audit_environment+=( "$_bjg_audit_variable=${!_bjg_audit_variable}" )
       fi
     done
@@ -787,7 +873,10 @@ case ${1-} in
       exit 1
     }
     for _bjg_config_home_name in HOME XDG_CONFIG_HOME; do
-      [[ ! -v $_bjg_config_home_name || -z ${!_bjg_config_home_name} ]] && continue
+      if ! command builtin declare -p "$_bjg_config_home_name" >/dev/null 2>&1 \
+          || [[ -z ${!_bjg_config_home_name} ]]; then
+        continue
+      fi
       _bjg_config_home_raw=${!_bjg_config_home_name}
       [[ "$_bjg_config_home_raw" == /* && "$_bjg_config_home_raw" != *$'\n'* \
          && "$_bjg_config_home_raw" != *$'\r'* ]] || {

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -349,9 +349,45 @@ case ${1-} in
       printf '%s\n' "$_bjg_audit_name is not a trusted outside-worktree audit tool" >&2
       exit 1
     }
-    _bjg_audit_environment=( -i "PATH=$_bjg_audit_path" "LC_ALL=C" )
-    for _bjg_audit_variable in HOME USER LOGNAME SHELL TERM COLORTERM NO_COLOR \
-      XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME CODEX_HOME CLAUDE_CONFIG_DIR \
+    _bjg_audit_root_raw=$("$_bjg_git" --no-pager --no-replace-objects \
+      -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      rev-parse --show-toplevel 2>/dev/null) || exit 1
+    _bjg_audit_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjg_audit_root_raw" 2>/dev/null && pwd -P
+    ) || exit 1
+    _bjg_audit_environment=(
+      -i "PATH=$_bjg_audit_path" "LC_ALL=C"
+      "PYTHONNOUSERSITE=1" "PYTHONSAFEPATH=1"
+    )
+    # Auth/config homes are needed by the real model CLIs, but a repository-
+    # selected HOME can activate interpreter user sites or tool hooks before
+    # read-only flags take effect. Preserve only existing canonical directories
+    # proven outside the driven worktree.
+    for _bjg_audit_variable in HOME CODEX_HOME CLAUDE_CONFIG_DIR; do
+      [[ ! -v $_bjg_audit_variable || -z ${!_bjg_audit_variable} ]] && continue
+      _bjg_audit_config_raw=${!_bjg_audit_variable}
+      [[ "$_bjg_audit_config_raw" == /* && -d "$_bjg_audit_config_raw" \
+         && "$_bjg_audit_config_raw" != *$'\n'* \
+         && "$_bjg_audit_config_raw" != *$'\r'* ]] || {
+        printf '%s\n' 'audit-tool config home is not a valid absolute directory' >&2
+        exit 1
+      }
+      _bjg_audit_config=$(
+        CDPATH=
+        export CDPATH
+        cd -P -- "$_bjg_audit_config_raw" 2>/dev/null && pwd -P
+      ) || exit 1
+      if [[ "$_bjg_audit_root" == / \
+            || "$_bjg_audit_config" == "$_bjg_audit_root" \
+            || "$_bjg_audit_config" == "$_bjg_audit_root/"* ]]; then
+        printf '%s\n' 'audit-tool config home resolves inside the current worktree' >&2
+        exit 1
+      fi
+      _bjg_audit_environment+=( "$_bjg_audit_variable=$_bjg_audit_config" )
+    done
+    for _bjg_audit_variable in USER LOGNAME SHELL TERM COLORTERM NO_COLOR \
       OPENAI_API_KEY ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN \
       HTTPS_PROXY https_proxy ALL_PROXY all_proxy NO_PROXY no_proxy \
       SSL_CERT_FILE SSL_CERT_DIR NIX_SSL_CERT_FILE SSH_AUTH_SOCK; do

--- a/skills/beads-jsonl-path/scripts/git-clean
+++ b/skills/beads-jsonl-path/scripts/git-clean
@@ -47,6 +47,10 @@ _bjg_stat=$(command -p -v stat) || {
   printf '%s\n' 'cannot locate a trusted stat for clean Git' >&2
   exit 1
 }
+_bjg_od=$(command -p -v od) || {
+  printf '%s\n' 'cannot locate a trusted od for executable inspection' >&2
+  exit 1
+}
 _bjg_mktemp=$(command -p -v mktemp) || {
   printf '%s\n' 'cannot locate a trusted mktemp for clean Git' >&2
   exit 1
@@ -184,6 +188,16 @@ _bjg_multiple_links_are_colocated() {
   [[ "$found" == "$expected" ]]
 }
 
+_bjg_hex_shebang_has_nul() {
+  local bytes=$1 token
+  local IFS=$' \t\n'
+  for token in $bytes; do
+    [[ "$token" != 0a ]] || return 1
+    [[ "$token" != 00 ]] || return 0
+  done
+  return 1
+}
+
 _bjg_canonicalize_directory() {
   local encoded
   encoded=$(
@@ -302,7 +316,7 @@ _bjg_prepare_audit_path() {
 _bjg_validate_audit_executable() {
   local selected=$1 path=$1 depth=${2:-0}
   local parent leaf link hops link_count first_line shebang interpreter argument
-  local interpreter_final safe_entry safe_env_final env_identity
+  local interpreter_final safe_entry safe_env_final env_identity shebang_bytes
   local -a safe_entries
   _bjg_load_audit_root || return 1
   [[ "$path" == /* ]] || return 1
@@ -342,6 +356,9 @@ _bjg_validate_audit_executable() {
     [[ -r "$path" ]] || return 1
   fi
   if [[ "$first_line" == '#!'* ]]; then
+    shebang_bytes=$("$_bjg_od" -An -v -N 513 -t x1 "$path" 2>/dev/null) ||
+      return 1
+    _bjg_hex_shebang_has_nul "$shebang_bytes" && return 1
     ((${#first_line} <= 512 && depth < 4)) || return 1
     shebang=${first_line#\#!}
     while [[ "$shebang" == ' '* || "$shebang" == $'\t'* ]]; do
@@ -995,7 +1012,8 @@ case ${1-} in
       printf '%s\n' 'cannot canonicalize the current Git worktree for clean push' >&2
       exit 1
     }
-    for _bjg_config_home_name in HOME XDG_CONFIG_HOME; do
+    for _bjg_config_home_name in HOME XDG_CONFIG_HOME XDG_CACHE_HOME \
+      XDG_DATA_HOME XDG_STATE_HOME; do
       if ! command builtin declare -p "$_bjg_config_home_name" >/dev/null 2>&1 \
           || [[ -z ${!_bjg_config_home_name} ]]; then
         continue
@@ -1050,6 +1068,8 @@ case ${1-} in
         printf '%s\n' 'Git/SSH config home is inside the current worktree' >&2
         exit 1
       fi
+      printf -v "$_bjg_config_home_name" '%s' "$_bjg_config_home"
+      export "$_bjg_config_home_name"
     done
     unset _bjg_config_home _bjg_config_home_name _bjg_config_home_raw \
       _bjg_config_leaf _bjg_config_probe _bjg_config_suffix
@@ -1068,7 +1088,10 @@ case ${1-} in
       printf '%s\n' "$count"
     }
     _bjg_external_helper() {
-      local path=$1 diagnostic=$2 parent leaf link hops link_count
+      local path=$1 diagnostic=$2 depth=${3:-0}
+      local parent leaf link hops link_count first_line shebang interpreter argument
+      local interpreter_final safe_entry safe_env_final env_identity env_tool shebang_bytes
+      local -a safe_entries
       [[ "$path" == /* ]] || {
         printf '%s\n' "$diagnostic" >&2
         return 1
@@ -1118,6 +1141,75 @@ case ${1-} in
         printf '%s\n' 'credential helper executable has multiple hard links' >&2
         return 1
       }
+
+      first_line=
+      if ! IFS= command builtin read -r -n 513 first_line 2>/dev/null <"$path"; then
+        [[ -r "$path" ]] || {
+          printf '%s\n' 'credential helper executable cannot be inspected safely' >&2
+          return 1
+        }
+      fi
+      if [[ "$first_line" == '#!'* ]]; then
+        shebang_bytes=$("$_bjg_od" -An -v -N 513 -t x1 "$path" 2>/dev/null) || {
+          printf '%s\n' "$diagnostic" >&2
+          return 1
+        }
+        if _bjg_hex_shebang_has_nul "$shebang_bytes"; then
+          printf '%s\n' 'credential helper has a NUL-bearing script interpreter' >&2
+          return 1
+        fi
+        ((${#first_line} <= 512 && depth < 4)) || {
+          printf '%s\n' "$diagnostic" >&2
+          return 1
+        }
+        shebang=${first_line#\#!}
+        while [[ "$shebang" == ' '* || "$shebang" == $'\t'* ]]; do
+          shebang=${shebang#?}
+        done
+        interpreter=${shebang%%[$' \t']*}
+        [[ "$interpreter" == /* && "$interpreter" != *[$'\r\v\f']* ]] || {
+          printf '%s\n' 'credential helper has an unsafe script interpreter' >&2
+          return 1
+        }
+        argument=${shebang#"$interpreter"}
+        while [[ "$argument" == ' '* || "$argument" == $'\t'* ]]; do
+          argument=${argument#?}
+        done
+        if [[ -e "$interpreter" || -L "$interpreter" ]]; then
+          interpreter_final=$(_bjg_external_helper "$interpreter" "$diagnostic" \
+            "$((depth + 1))") || return 1
+          if [[ -n "$argument" ]]; then
+            env_identity=false
+            IFS=: read -r -a safe_entries <<<"$_bjg_safe_path"
+            for safe_entry in "${safe_entries[@]}"; do
+              [[ -x "$safe_entry/env" ]] || continue
+              safe_env_final=$(_bjg_external_helper "$safe_entry/env" \
+                "$diagnostic" "$((depth + 1))") || continue
+              [[ "$interpreter_final" != "$safe_env_final" ]] ||
+                env_identity=true
+            done
+            if [[ "$env_identity" == true ]]; then
+              [[ "$argument" =~ ^[A-Za-z0-9._+-]+$ ]] || {
+                printf '%s\n' 'credential helper has an unsafe env interpreter argument' >&2
+                return 1
+              }
+              env_tool=$(
+                PATH=$_bjg_safe_path
+                export PATH
+                type -P -- "$argument"
+              ) || {
+                printf '%s\n' 'credential helper env target is unavailable' >&2
+                return 1
+              }
+              _bjg_external_helper "$env_tool" "$diagnostic" \
+                "$((depth + 1))" >/dev/null || return 1
+            else
+              printf '%s\n' 'credential helper has an unsupported script interpreter argument' >&2
+              return 1
+            fi
+          fi
+        fi
+      fi
       printf '%s\n' "$path"
     }
     _bjg_git_exec_path=$("$_bjg_git" --exec-path) || {
@@ -1278,10 +1370,24 @@ case ${1-} in
     else
       _bjg_transport_config+=( -c protocol.ssh.allow=never )
     fi
-    command unset SSH_ASKPASS SSH_ASKPASS_REQUIRE DISPLAY WAYLAND_DISPLAY
-    GIT_TERMINAL_PROMPT=0
-    export GIT_TERMINAL_PROMPT
-    exec "$_bjg_git" --no-pager --no-replace-objects \
+    _bjg_push_environment=(
+      "$_bjg_env" -i "PATH=$_bjg_safe_path" "LC_ALL=C"
+      "GIT_TERMINAL_PROMPT=0" "PYTHONNOUSERSITE=1" "PYTHONSAFEPATH=1"
+    )
+    for _bjg_push_variable in HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME \
+      XDG_STATE_HOME USER LOGNAME SHELL TERM \
+      COLORTERM NO_COLOR GH_TOKEN GITHUB_TOKEN \
+      HTTPS_PROXY https_proxy HTTP_PROXY http_proxy ALL_PROXY all_proxy \
+      NO_PROXY no_proxy SSL_CERT_FILE SSL_CERT_DIR NIX_SSL_CERT_FILE \
+      SSH_AUTH_SOCK DBUS_SESSION_BUS_ADDRESS GCM_CREDENTIAL_STORE; do
+      if command builtin declare -p "$_bjg_push_variable" >/dev/null 2>&1; then
+        _bjg_push_environment+=(
+          "$_bjg_push_variable=${!_bjg_push_variable}"
+        )
+      fi
+    done
+    exec "${_bjg_push_environment[@]}" "$_bjg_git" \
+      --no-pager --no-replace-objects \
       -c core.fsmonitor=false -c core.hooksPath=/dev/null \
       -c push.gpgSign=false -c core.askPass= \
       -c push.default=nothing -c push.followTags=false \

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -1,4 +1,7 @@
 #!/bin/sh
+# A shebang cannot defend its own interpreter against LD_PRELOAD/DYLD injection.
+# Invoke through the documented caller-shell locator, which clears loader state
+# before this process starts; this cleanup prevents it from reaching later execs.
 # Enter the implementation through a known Bash, not through `/usr/bin/env` and
 # the worktree-controlled PATH.  The inherited POSIX mode makes the cleanup
 # below use the real special builtins even if an exported Bash function tries to
@@ -10,7 +13,11 @@ _bj_bash=$(command -p -v bash) || {
   printf '%s\n' 'cannot locate a trusted Bash for the beads resolver' >&2
   exit 1
 }
-unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE \
+  LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH
 \exec 3<&0
 \exec "$_bj_bash" --noprofile --norc -p -s -- "$@" <<'__BJ_TRUSTED_BASH__'
 # Privileged Bash ignores BASH_ENV and inherited functions. Clear the remaining

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -1,0 +1,478 @@
+#!/bin/sh
+# Enter the implementation through a known Bash, not through `/usr/bin/env` and
+# the worktree-controlled PATH.  The inherited POSIX mode makes the cleanup
+# below use the real special builtins even if an exported Bash function tries to
+# claim one of their names.
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset -f command builtin exec unset 2>/dev/null || :
+_bj_bash=$(command -p -v bash) || {
+  printf '%s\n' 'cannot locate a trusted Bash for the beads resolver' >&2
+  exit 1
+}
+unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+exec "$_bj_bash" --noprofile --norc -p -s -- "$@" <<'__BJ_TRUSTED_BASH__'
+# Privileged Bash ignores BASH_ENV and inherited functions. Clear the remaining
+# startup controls before resolving `br` or Git as a defense in depth.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH \
+  GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads resolver shell environment' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bj_function; do
+  command unset -f -- "$_bj_function" || {
+    printf '%s\n' 'cannot sanitize the beads resolver shell environment' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bj_function
+
+set -uo pipefail
+
+die() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+_bj_mode=clean
+case $# in
+  0) ;;
+  1)
+    case $1 in
+      --allow-dirty) _bj_mode=allow-dirty ;;
+      --recovery) _bj_mode=recovery ;;
+      *) die 'usage: resolve-beads-jsonl [--allow-dirty|--recovery]' ;;
+    esac
+    ;;
+  *) die 'usage: resolve-beads-jsonl [--allow-dirty|--recovery]' ;;
+esac
+
+_bj_git=$(command -p -v git) ||
+  die 'cannot locate a trusted Git for the beads resolver'
+_bj_cmp=$(command -p -v cmp) ||
+  die 'cannot locate a trusted cmp for the beads resolver'
+_bj_od=$(command -p -v od) ||
+  die 'cannot locate a trusted od for the beads resolver'
+_bj_grep=$(command -p -v grep) ||
+  die 'cannot locate a trusted grep for the beads resolver'
+_bj_mktemp=$(command -p -v mktemp) ||
+  die 'cannot locate a trusted mktemp for the beads resolver'
+_bj_unlink=$(command -p -v unlink) ||
+  die 'cannot locate a trusted unlink for the beads resolver'
+_bj_rmdir=$(command -p -v rmdir) ||
+  die 'cannot locate a trusted rmdir for the beads resolver'
+_bj_readlink=$(command -p -v readlink) ||
+  die 'cannot locate a trusted readlink for the beads resolver'
+
+_bj_tmp=$("$_bj_mktemp" -d) || die 'cannot create beads resolver workspace'
+_bj_files=(
+  "$_bj_tmp/where.json"
+  "$_bj_tmp/where.hex"
+  "$_bj_tmp/index.records"
+  "$_bj_tmp/flags.records"
+  "$_bj_tmp/head.records"
+  "$_bj_tmp/head.blob"
+  "$_bj_tmp/index.blob"
+  "$_bj_tmp/intent.records"
+  "$_bj_tmp/fsmonitor.records"
+  "$_bj_tmp/mode.records"
+)
+
+_bj_cleanup() {
+  local path cleanup_rc=0
+  for path in "${_bj_files[@]}"; do
+    if [[ -e "$path" ]] && ! "$_bj_unlink" "$path"; then
+      cleanup_rc=1
+    fi
+  done
+  if ! "$_bj_rmdir" "$_bj_tmp"; then
+    cleanup_rc=1
+  fi
+  return "$cleanup_rc"
+}
+
+_bj_on_exit() {
+  local status=$?
+  if ! _bj_cleanup; then
+    printf '%s\n' 'cannot remove beads resolver workspace' >&2
+    [[ $status -ne 0 ]] || status=1
+  fi
+  trap - EXIT
+  exit "$status"
+}
+trap _bj_on_exit EXIT
+
+_bj_finish() {
+  if ! _bj_cleanup; then
+    trap - EXIT
+    die 'cannot remove beads resolver workspace'
+  fi
+  trap - EXIT
+  printf '%s\n' "$BEADS_JSONL"
+}
+
+_bj_root_raw=$("$_bj_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) \
+  || die 'cannot resolve the current Git worktree'
+_bj_root=$(
+  CDPATH=
+  export CDPATH
+  cd -P -- "$_bj_root_raw" 2>/dev/null && pwd -P
+) || die 'cannot canonicalize the current Git worktree'
+
+# `br` and `jq` are not both guaranteed to exist in Bash's implementation-defined
+# POSIX utility path, so find executables rather than accepting aliases/functions.
+# Reject an executable selected from the driven worktree: otherwise a repository
+# could plant a proof tool in (for example) `$PWD/bin` and put it first in PATH.
+_bj_external_tool() {
+  local name=$1 diagnostic=$2 path parent leaf link hops
+  path=$(type -P -- "$name") || die "$diagnostic"
+  case $path in
+    /*) ;;
+    *) die "$diagnostic" ;;
+  esac
+
+  # Canonicalize every directory component and the complete final symlink chain.
+  # Reject at each hop, not just at the end: an out-of-worktree symlink whose
+  # target is a worktree-controlled symlink is itself an unstable proof tool.
+  hops=0
+  while :; do
+    parent=${path%/*}
+    leaf=${path##*/}
+    parent=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$parent" 2>/dev/null && pwd -P
+    ) || die "$diagnostic"
+    path=$parent/$leaf
+    if [[ "$_bj_root" == / || "$path" == "$_bj_root" || "$path" == "$_bj_root/"* ]]; then
+      die "$name resolves inside the current Git worktree"
+    fi
+    [[ -L "$path" ]] || break
+    ((hops < 40)) || die "$diagnostic"
+    link=$("$_bj_readlink" "$path") || die "$diagnostic"
+    case $link in
+      /*) path=$link ;;
+      *) path=$parent/$link ;;
+    esac
+    hops=$((hops + 1))
+  done
+  [[ -f "$path" && -x "$path" ]] || die "$diagnostic"
+  printf '%s\n' "$path"
+}
+
+_bj_br=$(_bj_external_tool br 'br is required to resolve the beads JSONL') ||
+  die 'br is required to resolve the beads JSONL'
+_bj_jq=$(_bj_external_tool jq 'jq is required to resolve the beads JSONL') ||
+  die 'jq is required to resolve the beads JSONL'
+
+if ! "$_bj_br" --no-auto-flush --no-auto-import where --json >"${_bj_files[0]}"; then
+  die 'cannot resolve the beads workspace'
+fi
+if ! LC_ALL=C "$_bj_od" -An -v -t x1 "${_bj_files[0]}" >"${_bj_files[1]}"; then
+  die 'cannot scan beads workspace JSON'
+fi
+if "$_bj_grep" -Eq '(^|[[:space:]])00([[:space:]]|$)' "${_bj_files[1]}"; then
+  die 'beads workspace JSON contains a raw NUL byte'
+else
+  _bj_grep_rc=$?
+  [[ $_bj_grep_rc -eq 1 ]] || die 'cannot inspect beads workspace JSON'
+fi
+
+BEADS_JSONL=$(
+  "$_bj_jq" -ers '
+    if length == 1 and
+      ((.[0] | type) == "object") and
+      ((.[0].jsonl_path | type) == "string") and
+      ((.[0].jsonl_path | length) > 0) and
+      (.[0].jsonl_path | startswith("/")) and
+      ((.[0].jsonl_path | contains("\u0000")) | not) and
+      ((.[0].jsonl_path | test("[\r\n]")) | not)
+    then .[0].jsonl_path
+    else error("expected exactly one non-empty string jsonl_path")
+    end
+  ' <"${_bj_files[0]}"
+) || die 'cannot resolve exactly one beads JSONL'
+
+_bj_name=${BEADS_JSONL##*/}
+[[ -n "$_bj_name" ]] || die 'beads JSONL path has no final component'
+case $_bj_name in
+  .|..) die 'beads JSONL path has an unsafe final component' ;;
+esac
+if [[ "$BEADS_JSONL" == */* ]]; then
+  _bj_parent=${BEADS_JSONL%/*}
+  [[ -n "$_bj_parent" ]] || _bj_parent=/
+else
+  _bj_parent=.
+fi
+_bj_parent=$(
+  CDPATH=
+  export CDPATH
+  cd -P -- "$_bj_parent" 2>/dev/null && pwd -P
+) || die 'cannot canonicalize the beads JSONL parent'
+if [[ "$_bj_parent" == / ]]; then
+  _bj_absolute="/$_bj_name"
+else
+  _bj_absolute="$_bj_parent/$_bj_name"
+fi
+
+if [[ "$_bj_root" == / ]]; then
+  BEADS_JSONL_REL=${_bj_absolute#/}
+elif [[ "$_bj_absolute" == "$_bj_root/"* ]]; then
+  BEADS_JSONL_REL=${_bj_absolute#"$_bj_root/"}
+else
+  die 'beads JSONL is outside the current worktree'
+fi
+[[ -n "$BEADS_JSONL_REL" ]] || die 'beads JSONL does not name a worktree file'
+BEADS_JSONL=$_bj_absolute
+
+# Recovery intentionally permits the missing export, but never a Git administrative
+# file.  `--git-dir` can be a relative `.git` path (or a worktree's gitdir file
+# target), and `--git-common-dir` can name the shared administration directory, so
+# canonicalize both actual locations before comparing them with the already
+# canonical final JSONL pathname.
+if [[ $_bj_mode == recovery ]]; then
+  _bj_git_dir_raw=$("$_bj_git" --no-replace-objects rev-parse --git-dir 2>/dev/null) \
+    || die 'cannot resolve the current Git administrative directory'
+  _bj_git_common_dir_raw=$("$_bj_git" --no-replace-objects rev-parse --git-common-dir 2>/dev/null) \
+    || die 'cannot resolve the current Git common directory'
+  _bj_git_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bj_git_dir_raw" 2>/dev/null && pwd -P
+  ) || die 'cannot canonicalize the current Git administrative directory'
+  _bj_git_common_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bj_git_common_dir_raw" 2>/dev/null && pwd -P
+  ) || die 'cannot canonicalize the current Git common directory'
+  if [[ "$BEADS_JSONL" == "$_bj_root/.git" \
+        || "$BEADS_JSONL" == "$_bj_root/.git/"* \
+        || "$_bj_git_dir" == / || "$BEADS_JSONL" == "$_bj_git_dir" \
+        || "$BEADS_JSONL" == "$_bj_git_dir/"* \
+        || "$_bj_git_common_dir" == / || "$BEADS_JSONL" == "$_bj_git_common_dir" \
+        || "$BEADS_JSONL" == "$_bj_git_common_dir/"* ]]; then
+    die 'beads JSONL is inside the Git administrative directory'
+  fi
+fi
+
+# Recovery stops here: it must name the deleted artifact that restoration will recreate,
+# so tracked/index/HEAD state cannot be a precondition. All writing gates and dirty audit
+# handoffs continue below through the structural proof.
+if [[ $_bj_mode == recovery ]]; then
+  # A missing final path is useful to recovery, but anything else occupying it is not the
+  # export: a symlink escapes the containment proof when a recovery command writes through
+  # the resolved name, and a FIFO or directory breaks the `cp` and byte diff consumers run
+  # against it — a FIFO by blocking that read indefinitely rather than failing. The
+  # default mode proves the same thing below, after the index and HEAD records have had
+  # their chance to name the more specific fault.
+  #
+  # Scope of the symlink half, since `br` resolves before this check sees anything.
+  # Measured on br 0.2.19, streams separated by redirection, with `.beads/issues.jsonl` a
+  # symlink: `where --json` printed the canonical *target* whenever that target existed
+  # (`../unrelated.jsonl` came back as `<repo>/unrelated.jsonl`) and the symlink pathname
+  # itself only when it dangled. So what this clause refuses is the dangling link and a
+  # path swapped for a link after `br` answered; a live link is inspected as its target,
+  # which is the same file `br` writes through it, and one leaving the worktree was already
+  # refused by containment above.
+  if [[ -L "$BEADS_JSONL" || ( -e "$BEADS_JSONL" && ! -f "$BEADS_JSONL" ) ]]; then
+    die 'beads JSONL worktree path is not a non-symlink regular file'
+  fi
+  _bj_finish
+  _bj_finish_rc=$?
+  exit "$_bj_finish_rc"
+fi
+
+# `--literal-pathspecs` on every lookup below: `br where` may name a tracked file whose
+# bytes read as pathspec magic (`:(literal)graph.beads.jsonl`) or as a wildmatch pattern,
+# and either one asks Git about a different set of paths than the resolved one.
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-files --stage -z -- "$BEADS_JSONL_REL" \
+  >"${_bj_files[2]}"; then
+  die 'cannot inspect the beads JSONL index entry'
+fi
+_bj_index_count=0
+_bj_index_record=
+while IFS= read -r -d '' _bj_record; do
+  _bj_index_count=$((_bj_index_count + 1))
+  _bj_index_record=$_bj_record
+done <"${_bj_files[2]}"
+
+_bj_index_mode=
+_bj_index_oid=
+_bj_index_stage=
+_bj_index_extra=
+_bj_index_path=
+if [[ $_bj_index_count -eq 1 && "$_bj_index_record" == *$'\t'* ]]; then
+  _bj_index_meta=${_bj_index_record%%$'\t'*}
+  _bj_index_path=${_bj_index_record#*$'\t'}
+  IFS=' ' read -r _bj_index_mode _bj_index_oid _bj_index_stage _bj_index_extra \
+    <<<"$_bj_index_meta"
+fi
+if [[ $_bj_index_count -ne 1 || "$_bj_index_mode" != 100644 \
+      || "$_bj_index_stage" != 0 || -n "$_bj_index_extra" \
+      || "$_bj_index_path" != "$BEADS_JSONL_REL" ]]; then
+  die 'beads JSONL index entry is not one stage-0 regular file'
+fi
+
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-files -v -z -- "$BEADS_JSONL_REL" \
+  >"${_bj_files[3]}"; then
+  die 'cannot inspect the beads JSONL index flags'
+fi
+_bj_flag_count=0
+_bj_flag_record=
+while IFS= read -r -d '' _bj_record; do
+  _bj_flag_count=$((_bj_flag_count + 1))
+  _bj_flag_record=$_bj_record
+done <"${_bj_files[3]}"
+if [[ $_bj_flag_count -ne 1 || "$_bj_flag_record" != "H $BEADS_JSONL_REL" ]]; then
+  die 'beads JSONL has hidden index flags or an ambiguous index record'
+fi
+
+# `git add -N`, on its own or after `git rm --cached`, leaves a record every check above
+# accepts — one stage-0 `100644` entry tagged `H` — whose OID is the empty blob rather than
+# the file's content. The index holds no bytes for such a path, Git reports it as `DA`, and
+# byte identity below therefore only holds when the tracked file is empty; `--allow-dirty`
+# drops that comparison entirely. `diff-files` is where the flag surfaces: with exactly one
+# stage-0 entry already proven, an `A` against the worktree means the file is absent from
+# the index, which only intent-to-add produces. Measured on git 2.53.0 with the streams
+# separated by redirection: after `rm --cached` plus `add -N`, this exact command wrote
+# `.beads/issues.jsonl\0` to stdout at exit 0 with empty stderr, and `--raw` showed the
+# `:000000 100644` source mode behind it. Unmeasured on other versions — a git that
+# reported the entry differently would leave `--allow-dirty` accepting an index that holds
+# no bytes for the path, so the fixture below is what pins this to the git in use.
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs diff-files --diff-filter=A --name-only -z \
+  -- "$BEADS_JSONL_REL" >"${_bj_files[7]}"; then
+  die 'cannot inspect the beads JSONL intent-to-add state'
+fi
+if [[ -s "${_bj_files[7]}" ]]; then
+  die 'beads JSONL index entry is intent-to-add'
+fi
+
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-tree -z HEAD -- "$BEADS_JSONL_REL" \
+  >"${_bj_files[4]}"; then
+  die 'cannot inspect the beads JSONL HEAD entry'
+fi
+_bj_head_count=0
+_bj_head_record=
+while IFS= read -r -d '' _bj_record; do
+  _bj_head_count=$((_bj_head_count + 1))
+  _bj_head_record=$_bj_record
+done <"${_bj_files[4]}"
+
+_bj_head_mode=
+_bj_head_type=
+_bj_head_oid=
+_bj_head_extra=
+_bj_head_path=
+if [[ $_bj_head_count -eq 1 && "$_bj_head_record" == *$'\t'* ]]; then
+  _bj_head_meta=${_bj_head_record%%$'\t'*}
+  _bj_head_path=${_bj_head_record#*$'\t'}
+  IFS=' ' read -r _bj_head_mode _bj_head_type _bj_head_oid _bj_head_extra \
+    <<<"$_bj_head_meta"
+fi
+if [[ $_bj_head_count -ne 1 || "$_bj_head_mode" != 100644 \
+      || "$_bj_head_type" != blob || -n "$_bj_head_extra" \
+      || "$_bj_head_path" != "$BEADS_JSONL_REL" ]]; then
+  die 'beads JSONL HEAD entry is not one regular file'
+fi
+
+if [[ ! -f "$BEADS_JSONL" || -L "$BEADS_JSONL" ]]; then
+  die 'beads JSONL worktree path is not a non-symlink regular file'
+fi
+# The mode a tracked file has is Git's answer, not the invoking user's access rights. Git
+# reads the owner-exec bit and honors `core.filemode`; bash `[[ -x ]]` is an `access(2)`
+# probe that does neither, so it diverges in both directions — refusing forever on the
+# filesystems that carry no executable bit and configure `core.filemode=false`, and
+# accepting a file another user owns at 0744 that Git already calls `100755`. Measured on
+# git 2.53.0 with the streams separated by redirection: after `core.filemode=false` and
+# `chmod +x`, `diff-files --raw -z` and `git status --porcelain` each wrote 0 bytes to
+# stdout at exit 0 with empty stderr while `[[ -x ]]` was true; under `core.filemode=true`
+# the same chmod wrote `:100644 100755 …`. So ask Git. No record means the worktree agrees
+# with the stage-0 entry proven `100644` above; a record carries the worktree mode Git sees
+# in its second field, and a content-only difference leaves `100644` there for the byte
+# comparison below — or, deliberately, for `--allow-dirty` — to judge instead.
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" -c core.fsmonitor=false \
+  --literal-pathspecs diff-files --raw -z -- "$BEADS_JSONL_REL" \
+  >"${_bj_files[9]}"; then
+  die 'cannot inspect the beads JSONL worktree mode'
+fi
+if [[ -s "${_bj_files[9]}" ]]; then
+  if ! IFS= read -r -d '' _bj_mode_record <"${_bj_files[9]}"; then
+    die 'cannot inspect the beads JSONL worktree mode'
+  fi
+  _bj_worktree_mode=
+  IFS=' ' read -r _ _bj_worktree_mode _ <<<"${_bj_mode_record#:}"
+  if [[ "$_bj_worktree_mode" != 100644 ]]; then
+    die 'beads JSONL worktree mode is not 100644'
+  fi
+fi
+
+# A post-write diff or flushed-but-uncommitted audit handoff expects content to differ,
+# but it still needs the path-ownership proof above before another `br` write can run.
+# Skip only the byte-identity requirement; retain stage, mode, flag, HEAD, and worktree
+# structure checks so hidden, untracked, unmerged, missing, and wrong-type states refuse.
+if [[ $_bj_mode == allow-dirty ]]; then
+  # One hidden flag survives every check above: `ls-files -v` prints `H` for an entry whose
+  # fsmonitor-valid bit is set, and only `ls-files -f` lowercases it. That bit means Git
+  # answered from the file system monitor's cache rather than the filesystem, so a write
+  # the monitor missed is invisible to the `git status` and `git diff HEAD` this mode's
+  # consumers read before flushing. Byte identity is what catches that in the default
+  # mode, and this mode drops it. The bit itself is normal — every entry in a monitored
+  # repository carries it whenever Git last saw the file match the index, including the
+  # staged JSONL these consumers expect — so refuse only when the cached answer and the
+  # bytes actually disagree, which is exactly when the review ahead would be a lie.
+  if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-files -f -z -- "$BEADS_JSONL_REL" \
+    >"${_bj_files[8]}"; then
+    die 'cannot inspect the beads JSONL fsmonitor state'
+  fi
+  _bj_fsmonitor_count=0
+  _bj_fsmonitor_record=
+  while IFS= read -r -d '' _bj_record; do
+    _bj_fsmonitor_count=$((_bj_fsmonitor_count + 1))
+    _bj_fsmonitor_record=$_bj_record
+  done <"${_bj_files[8]}"
+  if [[ $_bj_fsmonitor_count -ne 1 \
+        || ( "$_bj_fsmonitor_record" != "H $BEADS_JSONL_REL" \
+             && "$_bj_fsmonitor_record" != "h $BEADS_JSONL_REL" ) ]]; then
+    die 'beads JSONL has an unreadable or ambiguous fsmonitor record'
+  fi
+  if [[ "$_bj_fsmonitor_record" == "h $BEADS_JSONL_REL" ]]; then
+    if ! "$_bj_git" --no-replace-objects -C "$_bj_root" cat-file blob "$_bj_index_oid" >"${_bj_files[6]}"; then
+      die 'cannot read the beads JSONL index blob'
+    fi
+    "$_bj_cmp" -s "${_bj_files[6]}" "$BEADS_JSONL"
+    _bj_cmp_rc=$?
+    if [[ $_bj_cmp_rc -eq 1 ]]; then
+      die 'beads JSONL modification is hidden by the fsmonitor cache'
+    elif [[ $_bj_cmp_rc -ne 0 ]]; then
+      die 'cannot compare the beads JSONL index and worktree bytes'
+    fi
+  fi
+  _bj_finish
+  _bj_finish_rc=$?
+  exit "$_bj_finish_rc"
+fi
+
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" cat-file blob "$_bj_head_oid" >"${_bj_files[5]}"; then
+  die 'cannot read the beads JSONL HEAD blob'
+fi
+if ! "$_bj_git" --no-replace-objects -C "$_bj_root" cat-file blob "$_bj_index_oid" >"${_bj_files[6]}"; then
+  die 'cannot read the beads JSONL index blob'
+fi
+
+"$_bj_cmp" -s "${_bj_files[5]}" "${_bj_files[6]}"
+_bj_cmp_rc=$?
+if [[ $_bj_cmp_rc -eq 1 ]]; then
+  die 'beads JSONL differs among HEAD, index, and worktree'
+elif [[ $_bj_cmp_rc -ne 0 ]]; then
+  die 'cannot compare the beads JSONL HEAD and index bytes'
+fi
+"$_bj_cmp" -s "${_bj_files[6]}" "$BEADS_JSONL"
+_bj_cmp_rc=$?
+if [[ $_bj_cmp_rc -eq 1 ]]; then
+  die 'beads JSONL differs among HEAD, index, and worktree'
+elif [[ $_bj_cmp_rc -ne 0 ]]; then
+  die 'cannot compare the beads JSONL index and worktree bytes'
+fi
+
+_bj_finish
+__BJ_TRUSTED_BASH__

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -63,6 +63,8 @@ _bj_rmdir=$(command -p -v rmdir) ||
   die 'cannot locate a trusted rmdir for the beads resolver'
 _bj_readlink=$(command -p -v readlink) ||
   die 'cannot locate a trusted readlink for the beads resolver'
+_bj_stat=$(command -p -v stat) ||
+  die 'cannot locate a trusted stat for the beads resolver'
 
 # Git's repository, worktree, index, object store, config, namespace, and pathspec
 # behavior can all be redirected through inherited GIT_* variables. This fact owner
@@ -264,6 +266,23 @@ if [[ $_bj_mode == recovery ]]; then
         || "$BEADS_JSONL" == "$_bj_git_common_dir/"* ]]; then
     die 'beads JSONL is inside the Git administrative directory'
   fi
+fi
+
+# Path containment cannot see inode aliases. A regular occupant with another
+# hard link could alias Git administrative state or any same-filesystem file, so
+# a later recovery copy or Beads write through this path would modify both.
+if [[ -f "$BEADS_JSONL" && ! -L "$BEADS_JSONL" ]]; then
+  if _bj_link_count=$("$_bj_stat" -c %h "$BEADS_JSONL" 2>/dev/null) \
+      && [[ $_bj_link_count =~ ^[0-9]+$ ]]; then
+    :
+  elif _bj_link_count=$("$_bj_stat" -f %l "$BEADS_JSONL" 2>/dev/null) \
+      && [[ $_bj_link_count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    die 'cannot inspect the beads JSONL hard-link count'
+  fi
+  [[ "$_bj_link_count" == 1 ]] ||
+    die 'beads JSONL worktree path has multiple hard links'
 fi
 
 # Recovery stops here: it must name the deleted artifact that restoration will recreate,

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -11,7 +11,8 @@ _bj_bash=$(command -p -v bash) || {
   exit 1
 }
 unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
-exec "$_bj_bash" --noprofile --norc -p -s -- "$@" <<'__BJ_TRUSTED_BASH__'
+\exec 3<&0
+\exec "$_bj_bash" --noprofile --norc -p -s -- "$@" <<'__BJ_TRUSTED_BASH__'
 # Privileged Bash ignores BASH_ENV and inherited functions. Clear the remaining
 # startup controls before resolving `br` or Git as a defense in depth.
 command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH \
@@ -35,17 +36,29 @@ die() {
 }
 
 _bj_mode=clean
-case $# in
-  0) ;;
-  1)
+_bj_run_br_arguments=()
+_bj_run_jq_arguments=()
+if [[ $# -ge 2 && $1 == --run-br ]]; then
+  _bj_mode=run-br
+  shift
+  _bj_run_br_arguments=( "$@" )
+elif [[ $# -ge 2 && $1 == --run-jq ]]; then
+  _bj_mode=run-jq
+  shift
+  _bj_run_jq_arguments=( "$@" )
+else
+  case $# in
+    0) ;;
+    1)
     case $1 in
       --allow-dirty) _bj_mode=allow-dirty ;;
       --recovery) _bj_mode=recovery ;;
-      *) die 'usage: resolve-beads-jsonl [--allow-dirty|--recovery]' ;;
+      *) die 'usage: resolve-beads-jsonl [--allow-dirty|--recovery] | --run-{br|jq} <args...>' ;;
     esac
     ;;
-  *) die 'usage: resolve-beads-jsonl [--allow-dirty|--recovery]' ;;
-esac
+    *) die 'usage: resolve-beads-jsonl [--allow-dirty|--recovery] | --run-{br|jq} <args...>' ;;
+  esac
+fi
 
 _bj_git=$(command -p -v git) ||
   die 'cannot locate a trusted Git for the beads resolver'
@@ -67,6 +80,8 @@ _bj_stat=$(command -p -v stat) ||
   die 'cannot locate a trusted stat for the beads resolver'
 _bj_getconf=$(command -p -v getconf) ||
   die 'cannot locate a trusted getconf for the beads resolver'
+_bj_env=$(command -p -v env) ||
+  die 'cannot locate a trusted env for the beads resolver'
 
 _bj_safe_path=$("$_bj_getconf" PATH 2>/dev/null) ||
   die 'cannot resolve the POSIX utility path for proof tools'
@@ -79,6 +94,27 @@ for _bj_safe_path_entry in "${_bj_safe_path_entries[@]}"; do
     die 'cannot validate the POSIX utility path for proof tools'
 done
 unset _bj_safe_path_entry _bj_safe_path_entries
+
+# Do not let a script-based proof tool import caller-selected language modules,
+# loader shims, or interpreter startup files. `br` retains only the location
+# inputs it needs to discover the same workspace as the caller; jq needs none.
+_bj_br_environment=(
+  -i "PATH=$_bj_safe_path" "LC_ALL=C"
+  "PYTHONNOUSERSITE=1" "PYTHONSAFEPATH=1"
+)
+for _bj_proof_variable in HOME XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME; do
+  if [[ -v $_bj_proof_variable ]]; then
+    _bj_br_environment+=( "$_bj_proof_variable=${!_bj_proof_variable}" )
+  fi
+done
+for _bj_proof_variable in "${!BEADS_@}" "${!BR_@}"; do
+  _bj_br_environment+=( "$_bj_proof_variable=${!_bj_proof_variable}" )
+done
+_bj_jq_environment=(
+  -i "PATH=$_bj_safe_path" "LC_ALL=C"
+  "PYTHONNOUSERSITE=1" "PYTHONSAFEPATH=1"
+)
+unset _bj_proof_variable
 
 _bj_regular_link_count() {
   local path=$1 count
@@ -99,7 +135,7 @@ _bj_regular_link_count() {
 # is about the repository discovered from the current directory, so remove the
 # entire Git environment namespace before its first Git invocation rather than
 # attempting an inevitably incomplete allowlist.
-_bj_git_environment=( "${!GIT_@}" )
+_bj_git_environment=( "${!GIT@}" )
 for _bj_git_variable in "${_bj_git_environment[@]}"; do
   command unset -- "$_bj_git_variable" ||
     die 'cannot sanitize the Git environment for the beads resolver'
@@ -205,12 +241,25 @@ _bj_external_tool() {
   printf '%s\n' "$path"
 }
 
+if [[ $_bj_mode == run-jq ]]; then
+  _bj_jq=$(_bj_external_tool jq 'jq is required to inspect Beads data') ||
+    die 'jq is required to inspect Beads data'
+  "$_bj_env" "${_bj_jq_environment[@]}" "$_bj_jq" "${_bj_run_jq_arguments[@]}" <&3
+  _bj_run_jq_rc=$?
+  exit "$_bj_run_jq_rc"
+fi
 _bj_br=$(_bj_external_tool br 'br is required to resolve the beads JSONL') ||
   die 'br is required to resolve the beads JSONL'
+if [[ $_bj_mode == run-br ]]; then
+  "$_bj_env" "${_bj_br_environment[@]}" "$_bj_br" "${_bj_run_br_arguments[@]}"
+  _bj_run_br_rc=$?
+  exit "$_bj_run_br_rc"
+fi
 _bj_jq=$(_bj_external_tool jq 'jq is required to resolve the beads JSONL') ||
   die 'jq is required to resolve the beads JSONL'
 
-if ! PATH="$_bj_safe_path" "$_bj_br" --no-auto-flush --no-auto-import where --json \
+if ! "$_bj_env" "${_bj_br_environment[@]}" \
+  "$_bj_br" --no-auto-flush --no-auto-import where --json \
   >"${_bj_files[0]}"; then
   die 'cannot resolve the beads workspace'
 fi
@@ -225,7 +274,7 @@ else
 fi
 
 BEADS_JSONL=$(
-  PATH="$_bj_safe_path" "$_bj_jq" -ers '
+  "$_bj_env" "${_bj_jq_environment[@]}" "$_bj_jq" -ers '
     if length == 1 and
       ((.[0] | type) == "object") and
       ((.[0].jsonl_path | type) == "string") and

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -65,6 +65,20 @@ _bj_readlink=$(command -p -v readlink) ||
   die 'cannot locate a trusted readlink for the beads resolver'
 _bj_stat=$(command -p -v stat) ||
   die 'cannot locate a trusted stat for the beads resolver'
+_bj_getconf=$(command -p -v getconf) ||
+  die 'cannot locate a trusted getconf for the beads resolver'
+
+_bj_safe_path=$("$_bj_getconf" PATH 2>/dev/null) ||
+  die 'cannot resolve the POSIX utility path for proof tools'
+[[ -n "$_bj_safe_path" && "$_bj_safe_path" != *$'\n'* \
+   && "$_bj_safe_path" != *$'\r'* ]] ||
+  die 'cannot validate the POSIX utility path for proof tools'
+IFS=: read -r -a _bj_safe_path_entries <<<"$_bj_safe_path"
+for _bj_safe_path_entry in "${_bj_safe_path_entries[@]}"; do
+  [[ "$_bj_safe_path_entry" == /* ]] ||
+    die 'cannot validate the POSIX utility path for proof tools'
+done
+unset _bj_safe_path_entry _bj_safe_path_entries
 
 _bj_regular_link_count() {
   local path=$1 count
@@ -196,7 +210,8 @@ _bj_br=$(_bj_external_tool br 'br is required to resolve the beads JSONL') ||
 _bj_jq=$(_bj_external_tool jq 'jq is required to resolve the beads JSONL') ||
   die 'jq is required to resolve the beads JSONL'
 
-if ! "$_bj_br" --no-auto-flush --no-auto-import where --json >"${_bj_files[0]}"; then
+if ! PATH="$_bj_safe_path" "$_bj_br" --no-auto-flush --no-auto-import where --json \
+  >"${_bj_files[0]}"; then
   die 'cannot resolve the beads workspace'
 fi
 if ! LC_ALL=C "$_bj_od" -An -v -t x1 "${_bj_files[0]}" >"${_bj_files[1]}"; then
@@ -210,7 +225,7 @@ else
 fi
 
 BEADS_JSONL=$(
-  "$_bj_jq" -ers '
+  PATH="$_bj_safe_path" "$_bj_jq" -ers '
     if length == 1 and
       ((.[0] | type) == "object") and
       ((.[0].jsonl_path | type) == "string") and

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -86,7 +86,6 @@ _bj_files=(
   "$_bj_tmp/head.blob"
   "$_bj_tmp/index.blob"
   "$_bj_tmp/intent.records"
-  "$_bj_tmp/fsmonitor.records"
   "$_bj_tmp/mode.records"
 )
 
@@ -123,7 +122,7 @@ _bj_finish() {
   printf '%s\n' "$BEADS_JSONL"
 }
 
-_bj_root_raw=$("$_bj_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) \
+_bj_root_raw=$("$_bj_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) \
   || die 'cannot resolve the current Git worktree'
 _bj_root=$(
   CDPATH=
@@ -243,9 +242,9 @@ BEADS_JSONL=$_bj_absolute
 # canonicalize both actual locations before comparing them with the already
 # canonical final JSONL pathname.
 if [[ $_bj_mode == recovery ]]; then
-  _bj_git_dir_raw=$("$_bj_git" --no-replace-objects rev-parse --git-dir 2>/dev/null) \
+  _bj_git_dir_raw=$("$_bj_git" --no-replace-objects -c core.fsmonitor=false rev-parse --git-dir 2>/dev/null) \
     || die 'cannot resolve the current Git administrative directory'
-  _bj_git_common_dir_raw=$("$_bj_git" --no-replace-objects rev-parse --git-common-dir 2>/dev/null) \
+  _bj_git_common_dir_raw=$("$_bj_git" --no-replace-objects -c core.fsmonitor=false rev-parse --git-common-dir 2>/dev/null) \
     || die 'cannot resolve the current Git common directory'
   _bj_git_dir=$(
     CDPATH=
@@ -297,7 +296,7 @@ fi
 # `--literal-pathspecs` on every lookup below: `br where` may name a tracked file whose
 # bytes read as pathspec magic (`:(literal)graph.beads.jsonl`) or as a wildmatch pattern,
 # and either one asks Git about a different set of paths than the resolved one.
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-files --stage -z -- "$BEADS_JSONL_REL" \
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" --literal-pathspecs ls-files --stage -z -- "$BEADS_JSONL_REL" \
   >"${_bj_files[2]}"; then
   die 'cannot inspect the beads JSONL index entry'
 fi
@@ -325,7 +324,7 @@ if [[ $_bj_index_count -ne 1 || "$_bj_index_mode" != 100644 \
   die 'beads JSONL index entry is not one stage-0 regular file'
 fi
 
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-files -v -z -- "$BEADS_JSONL_REL" \
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" --literal-pathspecs ls-files -v -z -- "$BEADS_JSONL_REL" \
   >"${_bj_files[3]}"; then
   die 'cannot inspect the beads JSONL index flags'
 fi
@@ -351,7 +350,7 @@ fi
 # `:000000 100644` source mode behind it. Unmeasured on other versions — a git that
 # reported the entry differently would leave `--allow-dirty` accepting an index that holds
 # no bytes for the path, so the fixture below is what pins this to the git in use.
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs diff-files --diff-filter=A --name-only -z \
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" --literal-pathspecs diff-files --diff-filter=A --name-only -z \
   -- "$BEADS_JSONL_REL" >"${_bj_files[7]}"; then
   die 'cannot inspect the beads JSONL intent-to-add state'
 fi
@@ -359,7 +358,7 @@ if [[ -s "${_bj_files[7]}" ]]; then
   die 'beads JSONL index entry is intent-to-add'
 fi
 
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-tree -z HEAD -- "$BEADS_JSONL_REL" \
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" --literal-pathspecs ls-tree -z HEAD -- "$BEADS_JSONL_REL" \
   >"${_bj_files[4]}"; then
   die 'cannot inspect the beads JSONL HEAD entry'
 fi
@@ -402,13 +401,13 @@ fi
 # with the stage-0 entry proven `100644` above; a record carries the worktree mode Git sees
 # in its second field, and a content-only difference leaves `100644` there for the byte
 # comparison below — or, deliberately, for `--allow-dirty` — to judge instead.
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" -c core.fsmonitor=false \
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" \
   --literal-pathspecs diff-files --raw -z -- "$BEADS_JSONL_REL" \
-  >"${_bj_files[9]}"; then
+  >"${_bj_files[8]}"; then
   die 'cannot inspect the beads JSONL worktree mode'
 fi
-if [[ -s "${_bj_files[9]}" ]]; then
-  if ! IFS= read -r -d '' _bj_mode_record <"${_bj_files[9]}"; then
+if [[ -s "${_bj_files[8]}" ]]; then
+  if ! IFS= read -r -d '' _bj_mode_record <"${_bj_files[8]}"; then
     die 'cannot inspect the beads JSONL worktree mode'
   fi
   _bj_worktree_mode=
@@ -423,51 +422,17 @@ fi
 # Skip only the byte-identity requirement; retain stage, mode, flag, HEAD, and worktree
 # structure checks so hidden, untracked, unmerged, missing, and wrong-type states refuse.
 if [[ $_bj_mode == allow-dirty ]]; then
-  # One hidden flag survives every check above: `ls-files -v` prints `H` for an entry whose
-  # fsmonitor-valid bit is set, and only `ls-files -f` lowercases it. That bit means Git
-  # answered from the file system monitor's cache rather than the filesystem, so a write
-  # the monitor missed is invisible to the `git status` and `git diff HEAD` this mode's
-  # consumers read before flushing. Byte identity is what catches that in the default
-  # mode, and this mode drops it. The bit itself is normal — every entry in a monitored
-  # repository carries it whenever Git last saw the file match the index, including the
-  # staged JSONL these consumers expect — so refuse only when the cached answer and the
-  # bytes actually disagree, which is exactly when the review ahead would be a lie.
-  if ! "$_bj_git" --no-replace-objects -C "$_bj_root" --literal-pathspecs ls-files -f -z -- "$BEADS_JSONL_REL" \
-    >"${_bj_files[8]}"; then
-    die 'cannot inspect the beads JSONL fsmonitor state'
-  fi
-  _bj_fsmonitor_count=0
-  _bj_fsmonitor_record=
-  while IFS= read -r -d '' _bj_record; do
-    _bj_fsmonitor_count=$((_bj_fsmonitor_count + 1))
-    _bj_fsmonitor_record=$_bj_record
-  done <"${_bj_files[8]}"
-  if [[ $_bj_fsmonitor_count -ne 1 \
-        || ( "$_bj_fsmonitor_record" != "H $BEADS_JSONL_REL" \
-             && "$_bj_fsmonitor_record" != "h $BEADS_JSONL_REL" ) ]]; then
-    die 'beads JSONL has an unreadable or ambiguous fsmonitor record'
-  fi
-  if [[ "$_bj_fsmonitor_record" == "h $BEADS_JSONL_REL" ]]; then
-    if ! "$_bj_git" --no-replace-objects -C "$_bj_root" cat-file blob "$_bj_index_oid" >"${_bj_files[6]}"; then
-      die 'cannot read the beads JSONL index blob'
-    fi
-    "$_bj_cmp" -s "${_bj_files[6]}" "$BEADS_JSONL"
-    _bj_cmp_rc=$?
-    if [[ $_bj_cmp_rc -eq 1 ]]; then
-      die 'beads JSONL modification is hidden by the fsmonitor cache'
-    elif [[ $_bj_cmp_rc -ne 0 ]]; then
-      die 'cannot compare the beads JSONL index and worktree bytes'
-    fi
-  fi
+  # All resolver and documented consumer Git commands force core.fsmonitor=false,
+  # so a stale monitor cache cannot hide the content difference this mode permits.
   _bj_finish
   _bj_finish_rc=$?
   exit "$_bj_finish_rc"
 fi
 
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" cat-file blob "$_bj_head_oid" >"${_bj_files[5]}"; then
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" cat-file blob "$_bj_head_oid" >"${_bj_files[5]}"; then
   die 'cannot read the beads JSONL HEAD blob'
 fi
-if ! "$_bj_git" --no-replace-objects -C "$_bj_root" cat-file blob "$_bj_index_oid" >"${_bj_files[6]}"; then
+if ! "$_bj_git" --no-replace-objects -c core.fsmonitor=false -C "$_bj_root" cat-file blob "$_bj_index_oid" >"${_bj_files[6]}"; then
   die 'cannot read the beads JSONL index blob'
 fi
 

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -207,14 +207,11 @@ _bj_root=$(
 # POSIX utility path, so find executables rather than accepting aliases/functions.
 # Reject an executable selected from the driven worktree: otherwise a repository
 # could plant a proof tool in (for example) `$PWD/bin` and put it first in PATH.
-_bj_external_tool() {
-  local name=$1 diagnostic=$2 path parent leaf link hops link_count
-  path=$(type -P -- "$name") || die "$diagnostic"
-  case $path in
-    /*) ;;
-    *) die "$diagnostic" ;;
-  esac
-
+_bj_validate_executable_path() {
+  local name=$1 diagnostic=$2 path=$3 depth=${4:-0}
+  local parent leaf link hops link_count first_line shebang interpreter argument
+  local env_tool interpreter_final safe_entry safe_env_final env_identity
+  local -a safe_entries
   # Canonicalize every directory component and the complete final symlink chain.
   # Reject at each hop, not just at the end: an out-of-worktree symlink whose
   # target is a worktree-controlled symlink is itself an unstable proof tool.
@@ -245,7 +242,73 @@ _bj_external_tool() {
     die "cannot inspect the $name executable hard-link count"
   [[ "$link_count" == 1 ]] ||
     die "$name executable has multiple hard links"
+
+  # The kernel follows an absolute shebang interpreter without consulting the
+  # sanitized PATH. Validate that second executable chain too; otherwise an
+  # outside br/jq script can name a worktree-controlled interpreter directly.
+  first_line=
+  if ! IFS= command builtin read -r -n 513 first_line 2>/dev/null <"$path"; then
+    [[ -r "$path" ]] || die "$name executable cannot be inspected safely"
+  fi
+  if [[ "$first_line" == '#!'* ]]; then
+    ((${#first_line} <= 512 && depth < 4)) || die "$diagnostic"
+    shebang=${first_line#\#!}
+    while [[ "$shebang" == ' '* || "$shebang" == $'\t'* ]]; do
+      shebang=${shebang#?}
+    done
+    interpreter=${shebang%%[$' \t']*}
+    [[ "$interpreter" == /* && "$interpreter" != *[$'\r\v\f']* ]] ||
+      die "$name has an unsafe script interpreter"
+    argument=${shebang#"$interpreter"}
+    while [[ "$argument" == ' '* || "$argument" == $'\t'* ]]; do
+      argument=${argument#?}
+    done
+    # A missing interpreter makes this script unlaunchable; execution will fail
+    # closed without running any worktree bytes.
+    if [[ -e "$interpreter" || -L "$interpreter" ]]; then
+      interpreter_final=$(
+        _bj_validate_executable_path "$name interpreter" "$diagnostic" \
+          "$interpreter" "$((depth + 1))"
+      ) || die "$diagnostic"
+      if [[ -n "$argument" ]]; then
+        env_identity=false
+        IFS=: read -r -a safe_entries <<<"$_bj_safe_path"
+        for safe_entry in "${safe_entries[@]}"; do
+          [[ -x "$safe_entry/env" ]] || continue
+          safe_env_final=$(
+            _bj_validate_executable_path "$name env interpreter" "$diagnostic" \
+              "$safe_entry/env" "$((depth + 1))"
+          ) || continue
+          [[ "$interpreter_final" != "$safe_env_final" ]] ||
+            env_identity=true
+        done
+        if [[ "$env_identity" == true ]]; then
+          [[ "$argument" =~ ^[A-Za-z0-9._+-]+$ ]] ||
+            die "$name has an unsafe env interpreter argument"
+          env_tool=$(
+            PATH=$_bj_safe_path
+            export PATH
+            type -P -- "$argument"
+          ) || die "$name env interpreter target is unavailable"
+          _bj_validate_executable_path "$name env target" "$diagnostic" \
+            "$env_tool" "$((depth + 1))" >/dev/null
+        else
+          die "$name has an unsupported script interpreter argument"
+        fi
+      fi
+    fi
+  fi
   printf '%s\n' "$path"
+}
+
+_bj_external_tool() {
+  local name=$1 diagnostic=$2 path
+  path=$(type -P -- "$name") || die "$diagnostic"
+  case $path in
+    /*) ;;
+    *) die "$diagnostic" ;;
+  esac
+  _bj_validate_executable_path "$name" "$diagnostic" "$path" 0
 }
 
 if [[ $_bj_mode == run-jq ]]; then

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -137,6 +137,16 @@ _bj_regular_link_count() {
   printf '%s\n' "$count"
 }
 
+_bj_hex_shebang_has_nul() {
+  local bytes=$1 token
+  local IFS=$' \t\n'
+  for token in $bytes; do
+    [[ "$token" != 0a ]] || return 1
+    [[ "$token" != 00 ]] || return 0
+  done
+  return 1
+}
+
 # Git's repository, worktree, index, object store, config, namespace, and pathspec
 # behavior can all be redirected through inherited GIT_* variables. This fact owner
 # is about the repository discovered from the current directory, so remove the
@@ -210,7 +220,7 @@ _bj_root=$(
 _bj_validate_executable_path() {
   local name=$1 diagnostic=$2 path=$3 depth=${4:-0}
   local parent leaf link hops link_count first_line shebang interpreter argument
-  local env_tool interpreter_final safe_entry safe_env_final env_identity
+  local env_tool interpreter_final safe_entry safe_env_final env_identity shebang_bytes
   local -a safe_entries
   # Canonicalize every directory component and the complete final symlink chain.
   # Reject at each hop, not just at the end: an out-of-worktree symlink whose
@@ -251,6 +261,10 @@ _bj_validate_executable_path() {
     [[ -r "$path" ]] || die "$name executable cannot be inspected safely"
   fi
   if [[ "$first_line" == '#!'* ]]; then
+    shebang_bytes=$("$_bj_od" -An -v -N 513 -t x1 "$path" 2>/dev/null) ||
+      die "$diagnostic"
+    ! _bj_hex_shebang_has_nul "$shebang_bytes" ||
+      die "$name has a NUL-bearing script interpreter"
     ((${#first_line} <= 512 && depth < 4)) || die "$diagnostic"
     shebang=${first_line#\#!}
     while [[ "$shebang" == ' '* || "$shebang" == $'\t'* ]]; do

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -66,6 +66,20 @@ _bj_readlink=$(command -p -v readlink) ||
 _bj_stat=$(command -p -v stat) ||
   die 'cannot locate a trusted stat for the beads resolver'
 
+_bj_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bj_stat" -c %h "$path" 2>/dev/null) \
+      && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bj_stat" -f %l "$path" 2>/dev/null) \
+      && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
+
 # Git's repository, worktree, index, object store, config, namespace, and pathspec
 # behavior can all be redirected through inherited GIT_* variables. This fact owner
 # is about the repository discovered from the current directory, so remove the
@@ -137,7 +151,7 @@ _bj_root=$(
 # Reject an executable selected from the driven worktree: otherwise a repository
 # could plant a proof tool in (for example) `$PWD/bin` and put it first in PATH.
 _bj_external_tool() {
-  local name=$1 diagnostic=$2 path parent leaf link hops
+  local name=$1 diagnostic=$2 path parent leaf link hops link_count
   path=$(type -P -- "$name") || die "$diagnostic"
   case $path in
     /*) ;;
@@ -170,6 +184,10 @@ _bj_external_tool() {
     hops=$((hops + 1))
   done
   [[ -f "$path" && -x "$path" ]] || die "$diagnostic"
+  link_count=$(_bj_regular_link_count "$path") ||
+    die "cannot inspect the $name executable hard-link count"
+  [[ "$link_count" == 1 ]] ||
+    die "$name executable has multiple hard links"
   printf '%s\n' "$path"
 }
 
@@ -272,13 +290,7 @@ fi
 # hard link could alias Git administrative state or any same-filesystem file, so
 # a later recovery copy or Beads write through this path would modify both.
 if [[ -f "$BEADS_JSONL" && ! -L "$BEADS_JSONL" ]]; then
-  if _bj_link_count=$("$_bj_stat" -c %h "$BEADS_JSONL" 2>/dev/null) \
-      && [[ $_bj_link_count =~ ^[0-9]+$ ]]; then
-    :
-  elif _bj_link_count=$("$_bj_stat" -f %l "$BEADS_JSONL" 2>/dev/null) \
-      && [[ $_bj_link_count =~ ^[0-9]+$ ]]; then
-    :
-  else
+  if ! _bj_link_count=$(_bj_regular_link_count "$BEADS_JSONL"); then
     die 'cannot inspect the beads JSONL hard-link count'
   fi
   [[ "$_bj_link_count" == 1 ]] ||

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl
@@ -64,6 +64,18 @@ _bj_rmdir=$(command -p -v rmdir) ||
 _bj_readlink=$(command -p -v readlink) ||
   die 'cannot locate a trusted readlink for the beads resolver'
 
+# Git's repository, worktree, index, object store, config, namespace, and pathspec
+# behavior can all be redirected through inherited GIT_* variables. This fact owner
+# is about the repository discovered from the current directory, so remove the
+# entire Git environment namespace before its first Git invocation rather than
+# attempting an inevitably incomplete allowlist.
+_bj_git_environment=( "${!GIT_@}" )
+for _bj_git_variable in "${_bj_git_environment[@]}"; do
+  command unset -- "$_bj_git_variable" ||
+    die 'cannot sanitize the Git environment for the beads resolver'
+done
+unset _bj_git_variable _bj_git_environment
+
 _bj_tmp=$("$_bj_mktemp" -d) || die 'cannot create beads resolver workspace'
 _bj_files=(
   "$_bj_tmp/where.json"

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -354,6 +354,45 @@ if [[ -e "$b/worktree-tool-ran" ]]; then
   fail 'a worktree-controlled jq executable is refused' 'the refused jq shim executed'
 fi
 
+# An outside pathname can still name a worktree-controlled inode through a hard
+# link. Reject multiply linked br/jq executables before either proof tool runs.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+command cat >"$b/repo/evil-br" <<'WORKTREE_BR_HARDLINK'
+#!/bin/sh
+printf '%s\n' ran >"$WORKTREE_TOOL_RAN"
+cat "$BR_OUTPUT"
+WORKTREE_BR_HARDLINK
+chmod +x "$b/repo/evil-br"
+ln "$b/repo/evil-br" "$b/outside-bin/br"
+WORKTREE_TOOL_RAN="$b/worktree-tool-ran"
+export WORKTREE_TOOL_RAN
+assert_refused 'an outside br hard link to a worktree executable is refused' "$b" \
+  'br executable has multiple hard links' "$b/outside-bin:$SYSTEM_PATH"
+unset WORKTREE_TOOL_RAN
+if [[ -e "$b/worktree-tool-ran" ]]; then
+  fail 'an outside br hard link to a worktree executable is refused' 'the refused br executable ran'
+fi
+
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+trusted_jq=$(command -v jq)
+command cat >"$b/repo/evil-jq" <<WORKTREE_JQ_HARDLINK
+#!/bin/sh
+printf '%s\n' ran >"\$WORKTREE_TOOL_RAN"
+exec "$trusted_jq" "\$@"
+WORKTREE_JQ_HARDLINK
+chmod +x "$b/repo/evil-jq"
+ln "$b/repo/evil-jq" "$b/outside-bin/jq"
+WORKTREE_TOOL_RAN="$b/worktree-tool-ran"
+export WORKTREE_TOOL_RAN
+assert_refused 'an outside jq hard link to a worktree executable is refused' "$b" \
+  'jq executable has multiple hard links' "$b/outside-bin:$b/bin:$SYSTEM_PATH"
+unset WORKTREE_TOOL_RAN
+if [[ -e "$b/worktree-tool-ran" ]]; then
+  fail 'an outside jq hard link to a worktree executable is refused' 'the refused jq executable ran'
+fi
+
 # Repository selectors inherited from a caller must not redirect the proof away
 # from the repository containing the current directory. A bare Git directory
 # paired with `/` as its worktree would otherwise make rev-parse report `/`.

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -264,7 +264,7 @@ fi
 # the otherwise hardened implementation ran the `git` and `cmp` sentinels.
 b=$(new_fixture)
 mkdir "$b/repo/evil"
-for utility in bash git cmp od grep mktemp unlink rmdir readlink stat; do
+for utility in bash git cmp od grep mktemp unlink rmdir readlink stat getconf; do
   trusted_utility=$(command -p -v "$utility") || {
     fail 'hostile startup fixture setup' "cannot locate $utility in the POSIX utility path"
     continue
@@ -277,7 +277,7 @@ HOSTILE_UTILITY
   chmod +x "$b/repo/evil/$utility"
 done
 command cat >"$b/bin/br" <<'SAFE_BR'
-#!/bin/sh
+#!/usr/bin/env bash
 printf '%s\n' "$*" >>"$BR_CALLS"
 if [ "$*" != '--no-auto-flush --no-auto-import where --json' ]; then
   : >"$BR_MUTATION"
@@ -286,6 +286,12 @@ cat "$BR_OUTPUT"
 exit "${BR_EXIT:-0}"
 SAFE_BR
 chmod +x "$b/bin/br"
+trusted_jq=$(command -v jq)
+command cat >"$b/bin/jq" <<SAFE_JQ
+#!/usr/bin/env bash
+exec "$trusted_jq" "\$@"
+SAFE_JQ
+chmod +x "$b/bin/jq"
 printf '%s\n' ': >"$HOSTILE_BASH_ENV_RAN"' >"$b/bash-env"
 snapshot_fixture "$b" "$b/before"
 br() {

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -418,7 +418,38 @@ chmod +x "$b/repo/.git/hooks/pre-commit"
 printf '%s\n' unrelated >"$b/repo/unrelated"
 git -C "$b/repo" add -- unrelated
 real_before=$(git -C "$b/repo" rev-parse HEAD)
+real_branch=$(git -C "$b/repo" symbolic-ref --short HEAD)
 forged_before=$(git -C "$b/forged" rev-parse HEAD)
+
+# `symbolic-ref --short` becomes `heads/<name>` when a tag makes the shortened
+# spelling ambiguous. Read and strip the exact direct refs/heads/ target instead.
+git -C "$b/repo" tag "$real_branch" "$real_before"
+if runner_branch=$(cd "$b/repo" && "$GIT_RUNNER" head-branch); then rc=0; else rc=$?; fi
+t='clean Git runner returns an unambiguous direct branch name'
+if [[ $rc -ne 0 || "$runner_branch" != "$real_branch" ]]; then
+  fail "$t" "branch resolution returned '${runner_branch-}' at exit $rc"
+else
+  pass "$t"
+fi
+git -C "$b/repo" tag -d "$real_branch" >/dev/null
+
+# A valid branch may itself begin with `refs/`; only the full refs/heads/ prefix
+# has structural meaning here.
+nested_branch=refs/topic
+git -C "$b/repo" switch -q -c "$nested_branch" "$real_before"
+if nested_runner_branch=$(cd "$b/repo" && "$GIT_RUNNER" head-branch); then
+  rc=0
+else
+  rc=$?
+fi
+t='clean Git runner accepts a valid nested refs branch name'
+if [[ $rc -ne 0 || "$nested_runner_branch" != "$nested_branch" ]]; then
+  fail "$t" "nested branch resolution returned '${nested_runner_branch-}' at exit $rc"
+else
+  pass "$t"
+fi
+git -C "$b/repo" switch -q "$real_branch"
+git -C "$b/repo" branch -D "$nested_branch" >/dev/null
 
 # The reviewed parent is part of the proof. A concurrent ref update must make
 # the commit fail without overwriting the intervening HEAD.
@@ -430,6 +461,7 @@ if (
   cd "$b/repo" || exit 98
   "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
     --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+    --expect-branch "$real_branch" \
     -m 'must refuse stale HEAD' \
     >"$b/stale-head.stdout" 2>"$b/stale-head.stderr"
 ); then rc=0; else rc=$?; fi
@@ -446,6 +478,62 @@ else
 fi
 git -C "$b/repo" update-ref HEAD "$real_before" "$intervening"
 
+# The reviewed commit OID is not a branch identity. Switching to another branch
+# at the same OID must not advance that newly checked-out ref.
+other_branch=review-other
+git -C "$b/repo" branch "$other_branch" "$real_before"
+git -C "$b/repo" switch -q "$other_branch"
+if (
+  cd "$b/repo" || exit 98
+  "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
+    --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+    --expect-branch "$real_branch" \
+    -m 'must refuse switched branch' \
+    >"$b/switched-branch.stdout" 2>"$b/switched-branch.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses a branch switched after review'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner committed to a different branch at the reviewed OID'
+elif [[ $(git -C "$b/repo" rev-parse "$real_branch") != "$real_before" \
+        || $(git -C "$b/repo" rev-parse "$other_branch") != "$real_before" ]]; then
+  fail "$t" 'runner advanced a branch after the reviewed branch changed'
+elif ! grep -Fq 'current branch no longer matches the reviewed branch' \
+    "$b/switched-branch.stderr"; then
+  fail "$t" "runner did not diagnose switched branch: $(<"$b/switched-branch.stderr")"
+else
+  pass "$t"
+fi
+git -C "$b/repo" switch -q "$real_branch"
+git -C "$b/repo" branch -D "$other_branch" >/dev/null
+
+# A branch ref can itself be symbolic. Updating without --no-deref would follow it
+# and advance the target branch even though the reviewed ref name was explicit.
+symref_target=review-symref-target
+git -C "$b/repo" branch "$symref_target" "$real_before"
+git -C "$b/repo" symbolic-ref "refs/heads/$real_branch" \
+  "refs/heads/$symref_target"
+if (
+  cd "$b/repo" || exit 98
+  "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
+    --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+    --expect-branch "$real_branch" \
+    -m 'must refuse symbolic reviewed ref' \
+    >"$b/symbolic-branch.stdout" 2>"$b/symbolic-branch.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner does not dereference a symbolic reviewed branch'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner followed and advanced the symbolic branch target'
+elif [[ $(git -C "$b/repo" rev-parse "$symref_target") != "$real_before" ]]; then
+  fail "$t" 'runner mutated the symbolic branch target'
+elif ! grep -Fq 'reviewed branch ref is unexpectedly symbolic' \
+    "$b/symbolic-branch.stderr"; then
+  fail "$t" "runner did not diagnose symbolic branch CAS: $(<"$b/symbolic-branch.stderr")"
+else
+  pass "$t"
+fi
+git -C "$b/repo" update-ref --no-deref "refs/heads/$real_branch" "$real_before"
+git -C "$b/repo" branch -D "$symref_target" >/dev/null
+
 # Temp-index state lives only in the Git administrative directory, ignores a
 # worktree TMPDIR, and is removed even when commit-tree fails after creation.
 mkdir "$b/repo/hostile-tmp" "$b/identity-home"
@@ -456,6 +544,7 @@ if (
   HOME="$b/identity-home" TMPDIR="$b/repo/hostile-tmp" \
     "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
       --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+      --expect-branch "$real_branch" \
       -m 'forced identity failure' \
       >"$b/failed-commit.stdout" 2>"$b/failed-commit.stderr"
 ); then rc=0; else rc=$?; fi
@@ -480,6 +569,7 @@ for unsafe_commit_arg in -a --all --amend -S unrelated; do
     cd "$b/repo" || exit 98
     "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
       --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+      --expect-branch "$real_branch" \
       "$unsafe_commit_arg" unsafe >/dev/null 2>&1
   ); then
     unsafe_commit_accepted=true
@@ -496,6 +586,7 @@ if (
   GIT_DIR="$b/forged/.git" GIT_WORK_TREE="$b/repo" \
     "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
       --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+      --expect-branch "$real_branch" \
       -m 'stage exact JSONL' \
     >"$b/commit.stdout" 2>"$b/commit.stderr"
 ); then rc=0; else rc=$?; fi

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -123,11 +123,26 @@ safe_br_calls_only() {
 # every assert_* clears them.
 RESOLVER_ARGS=()
 RESOLVER_CWD=
+RESOLVER_GIT_DIR=
+RESOLVER_GIT_WORK_TREE=
+RESOLVER_GIT_INDEX_FILE=
 
 run_resolver() {
   local base=$1 runtime_path=$2
   (
     cd "${RESOLVER_CWD:-$base/repo}" || exit 98
+    if [[ -n "$RESOLVER_GIT_DIR" ]]; then
+      GIT_DIR=$RESOLVER_GIT_DIR
+      export GIT_DIR
+    fi
+    if [[ -n "$RESOLVER_GIT_WORK_TREE" ]]; then
+      GIT_WORK_TREE=$RESOLVER_GIT_WORK_TREE
+      export GIT_WORK_TREE
+    fi
+    if [[ -n "$RESOLVER_GIT_INDEX_FILE" ]]; then
+      GIT_INDEX_FILE=$RESOLVER_GIT_INDEX_FILE
+      export GIT_INDEX_FILE
+    fi
     BR_CALLS="$base/br.calls" BR_MUTATION="$base/br.mutation" \
       BR_OUTPUT="$base/where.out" BR_EXIT="${BR_EXIT:-0}" \
       PATH="$runtime_path" "$RESOLVER" ${RESOLVER_ARGS+"${RESOLVER_ARGS[@]}"} \
@@ -142,6 +157,9 @@ assert_refused() {
   if run_resolver "$base" "$runtime_path"; then rc=0; else rc=$?; fi
   RESOLVER_ARGS=()
   RESOLVER_CWD=
+  RESOLVER_GIT_DIR=
+  RESOLVER_GIT_WORK_TREE=
+  RESOLVER_GIT_INDEX_FILE=
   snapshot_fixture "$base" "$base/after"
   if [[ $rc -eq 0 ]]; then
     fail "$name" 'resolver accepted unsafe state'
@@ -166,6 +184,9 @@ assert_success() {
   if run_resolver "$base" "$base/bin:$SYSTEM_PATH"; then rc=0; else rc=$?; fi
   RESOLVER_ARGS=()
   RESOLVER_CWD=
+  RESOLVER_GIT_DIR=
+  RESOLVER_GIT_WORK_TREE=
+  RESOLVER_GIT_INDEX_FILE=
   snapshot_fixture "$base" "$base/after"
   printf '%s\n' "$expected" >"$base/expected"
   if [[ $rc -ne 0 ]]; then
@@ -313,33 +334,14 @@ if [[ -e "$b/worktree-tool-ran" ]]; then
   fail 'a worktree-controlled jq executable is refused' 'the refused jq shim executed'
 fi
 
-# A Git worktree rooted at `/` contains every absolute PATH executable. The
-# containment special case must therefore refuse before invoking even an
-# otherwise external-looking stub.
+# Repository selectors inherited from a caller must not redirect the proof away
+# from the repository containing the current directory. A bare Git directory
+# paired with `/` as its worktree would otherwise make rev-parse report `/`.
 b=$(new_fixture)
 git init -q --bare "$b/root-admin"
-snapshot_fixture "$b" "$b/before"
-if (
-  cd "$b/repo" || exit 98
-  GIT_DIR="$b/root-admin" GIT_WORK_TREE=/ \
-    BR_CALLS="$b/br.calls" BR_MUTATION="$b/br.mutation" BR_OUTPUT="$b/where.out" \
-    PATH="$b/bin:$SYSTEM_PATH" "$RESOLVER" >"$b/stdout" 2>"$b/stderr"
-); then rc=0; else rc=$?; fi
-snapshot_fixture "$b" "$b/after"
-t='a root worktree refuses every PATH-selected proof executable'
-if [[ $rc -eq 0 ]]; then
-  fail "$t" 'resolver accepted a proof executable contained by the root worktree'
-elif [[ -s "$b/stdout" ]]; then
-  fail "$t" 'resolver printed a path while refusing the root worktree'
-elif ! grep -Fq -- 'br resolves inside the current Git worktree' "$b/stderr"; then
-  fail "$t" "missing root-worktree diagnostic: $(<"$b/stderr")"
-elif [[ -e "$b/br.calls" || -e "$b/br.mutation" ]]; then
-  fail "$t" 'resolver invoked br before refusing the root worktree'
-elif ! cmp -s "$b/before" "$b/after"; then
-  fail "$t" 'root-worktree refusal changed the fixture'
-else
-  pass "$t"
-fi
+RESOLVER_GIT_DIR="$b/root-admin"
+RESOLVER_GIT_WORK_TREE=/
+assert_success 'inherited Git repository selectors are cleared' "$b" "$(<"$b/jsonl-path")"
 
 # Canonicalizing only an executable's parent is insufficient: a PATH directory
 # outside the checkout can contain a final symlink back to checkout-controlled
@@ -503,6 +505,20 @@ b=$(new_fixture)
 printf '%s\n' staged >>"$(<"$b/jsonl-path")"
 git -C "$b/repo" add -- .beads/issues.jsonl
 assert_refused 'staged-only content is refused' "$b" \
+  'beads JSONL differs among HEAD, index, and worktree'
+
+# An inherited alternate index can hide the actual repository's staged bytes
+# from every ls-files/diff-files/cat-file proof. Populate it from HEAD, then
+# diverge the real index while restoring only the worktree copy.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+alternate_index="$b/alternate.index"
+GIT_INDEX_FILE="$alternate_index" git -C "$b/repo" read-tree HEAD
+printf '%s\n' staged-through-real-index >>"$jsonl"
+git -C "$b/repo" add -- .beads/issues.jsonl
+git -C "$b/repo" show HEAD:.beads/issues.jsonl >"$jsonl"
+RESOLVER_GIT_INDEX_FILE="$alternate_index"
+assert_refused 'an inherited alternate Git index cannot hide staged content' "$b" \
   'beads JSONL differs among HEAD, index, and worktree'
 
 b=$(new_fixture)

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -1024,6 +1024,55 @@ else
   pass "$t"
 fi
 
+# A model/config HOME selected from the driven repository is refused before the
+# validated tool starts.
+rm -f "$b/audit-probe-ran"
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/repo" PATH="$b/outside-audit-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-probe exact argument \
+    >"$b/worktree-home.stdout" 2>"$b/worktree-home.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner refuses a worktree-selected HOME'
+if [[ $rc -eq 0 || -e "$b/audit-probe-ran" ]]; then
+  fail "$t" 'runner executed an audit tool with worktree HOME'
+elif ! grep -Fq 'config home resolves inside the current worktree' \
+    "$b/worktree-home.stderr"; then
+  fail "$t" "runner did not diagnose worktree HOME: $(<"$b/worktree-home.stderr")"
+else
+  pass "$t"
+fi
+
+# An allowed outside HOME still cannot activate Python's user-site .pth startup.
+python_path=$(command -p -v python3)
+mkdir "$b/python-audit-home"
+python_user_site=$(HOME="$b/python-audit-home" "$python_path" -c \
+  'import site; print(site.getusersitepackages())')
+mkdir -p "$python_user_site"
+printf '%s\n' \
+  "import pathlib; pathlib.Path('$b/python-user-site-ran').write_text('ran')" \
+  >"$python_user_site/worktree-startup.pth"
+command cat >"$b/outside-audit-bin/python-audit" <<PYTHON_AUDIT
+#!$python_path
+from pathlib import Path
+Path('$b/python-audit-ran').write_text('clean')
+PYTHON_AUDIT
+chmod +x "$b/outside-audit-bin/python-audit"
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/python-audit-home" PATH="$b/outside-audit-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool python-audit \
+    >"$b/python-audit.stdout" 2>"$b/python-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner disables Python user-site startup'
+if [[ $rc -ne 0 || ! -e "$b/python-audit-ran" ]]; then
+  fail "$t" "Python audit tool exit $rc: $(<"$b/python-audit.stderr")"
+elif [[ -e "$b/python-user-site-ran" ]]; then
+  fail "$t" 'Python audit tool loaded a user-site .pth file'
+else
+  pass "$t"
+fi
+
 # Index-reading Git commands must not execute a repository-configured fsmonitor
 # hook. Prime the hook once, erase its marker, then keep the fixture snapshots
 # on their own explicit hook-disabled path so only the resolver is measured.

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -1055,6 +1055,62 @@ else
   pass "$t"
 fi
 
+# An unsafe executable in an unrelated caller directory omits only that directory;
+# a later valid selected tool still runs. The selected tool's own directory must
+# remain admitted (the hard-linked-child fixture immediately below is the negative
+# sharing-one-directory control).
+mkdir "$b/unrelated-invalid-bin" "$b/later-valid-bin"
+command cat >"$b/unrelated-invalid-bin/unrelated-xonly" <<UNRELATED_XONLY
+#!$b/repo/audit-worktree-interpreter
+exit 0
+UNRELATED_XONLY
+chmod 111 "$b/unrelated-invalid-bin/unrelated-xonly"
+command cat >"$b/later-valid-bin/audit-later-valid" <<LATER_VALID_AUDIT
+#!/bin/sh
+printf '%s\n' valid >'$b/later-valid-audit-ran'
+LATER_VALID_AUDIT
+chmod +x "$b/later-valid-bin/audit-later-valid"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/unrelated-invalid-bin:$b/later-valid-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-later-valid \
+    >"$b/later-valid.stdout" 2>"$b/later-valid.stderr"
+); then rc=0; else rc=$?; fi
+chmod 755 "$b/unrelated-invalid-bin/unrelated-xonly"
+t='clean audit-tool PATH omits an invalid unrelated directory'
+if [[ $rc -ne 0 || ! -e "$b/later-valid-audit-ran" ]]; then
+  fail "$t" "later valid audit tool exit $rc: $(<"$b/later-valid.stderr")"
+else
+  pass "$t"
+fi
+
+# Conversely, do not execute a valid selected tool by absolute path after its own
+# directory was omitted because a sibling executable was unprovable.
+mkdir "$b/mixed-invalid-bin"
+command cat >"$b/mixed-invalid-bin/audit-mixed-valid" <<MIXED_VALID_AUDIT
+#!/bin/sh
+printf '%s\n' valid >'$b/mixed-valid-audit-ran'
+MIXED_VALID_AUDIT
+command cat >"$b/mixed-invalid-bin/unrelated-xonly" <<'MIXED_XONLY'
+#!/missing/interpreter
+exit 0
+MIXED_XONLY
+chmod +x "$b/mixed-invalid-bin/audit-mixed-valid"
+chmod 111 "$b/mixed-invalid-bin/unrelated-xonly"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/mixed-invalid-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-mixed-valid \
+    >"$b/mixed-valid.stdout" 2>"$b/mixed-valid.stderr"
+); then rc=0; else rc=$?; fi
+chmod 755 "$b/mixed-invalid-bin/unrelated-xonly"
+t='clean audit-tool runner requires the selected parent to remain admitted'
+if [[ $rc -eq 0 || -e "$b/mixed-valid-audit-ran" ]]; then
+  fail "$t" 'runner executed a selected tool from an omitted mixed directory'
+else
+  pass "$t"
+fi
+
 # The clean descendant PATH must not expose a nominally outside command whose
 # inode is also repository-controlled through a hard link.
 mkdir "$b/outside-hardlink-bin"
@@ -1082,6 +1138,169 @@ if [[ $rc -eq 0 ]]; then
 elif [[ -e "$b/hardlinked-audit-child-ran" \
         || -e "$b/hardlinked-audit-parent-ran" ]]; then
   fail "$t" 'runner executed through a hard-linked audit descendant'
+else
+  pass "$t"
+fi
+
+# Multiple names for one outside inode are compatible when every hard link is
+# accounted for in the same admitted directory and none can live in the worktree.
+mkdir "$b/outside-hardlink-shims" "$b/outside-hardlink-wrapper"
+command cat >"$b/outside-hardlink-shims/audit-shim-1" <<HARDLINKED_AUDIT_SHIM
+#!/bin/sh
+printf '%s\n' shim >'$b/outside-hardlink-shim-ran'
+HARDLINKED_AUDIT_SHIM
+chmod +x "$b/outside-hardlink-shims/audit-shim-1"
+for hardlink_shim in 2 3 4 5 6 7 8 9 10; do
+  ln "$b/outside-hardlink-shims/audit-shim-1" \
+    "$b/outside-hardlink-shims/audit-shim-$hardlink_shim"
+done
+command cat >"$b/outside-hardlink-wrapper/audit-hardlink-parent" <<HARDLINK_PARENT
+#!/bin/sh
+audit-shim-1
+printf '%s\n' parent >'$b/outside-hardlink-parent-ran'
+HARDLINK_PARENT
+chmod +x "$b/outside-hardlink-wrapper/audit-hardlink-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-hardlink-wrapper:$b/outside-hardlink-shims:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-hardlink-parent \
+    >"$b/outside-hardlinks.stdout" 2>"$b/outside-hardlinks.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH admits fully accounted outside hard-link shims'
+if [[ $rc -ne 0 || ! -e "$b/outside-hardlink-shim-ran" \
+      || ! -e "$b/outside-hardlink-parent-ran" ]]; then
+  fail "$t" "accounted hard-link shim fixture exit $rc: $(<"$b/outside-hardlinks.stderr")"
+else
+  pass "$t"
+fi
+
+# Exercise the exact production identity counter with a stubbed cross-device inode
+# collision: only the matching st_dev record may contribute.
+device_counter_function=$(awk '
+  /^_bjg_count_matching_device_records\(\) \{/ { capture=1 }
+  capture { print }
+  capture && /^}$/ { exit }
+' "$GIT_RUNNER")
+if (
+  eval "$device_counter_function"
+  _bjg_regular_device_number() {
+    case $1 in
+      */same-device) printf '%s\n' 11 ;;
+      */other-device) printf '%s\n' 22 ;;
+      *) return 1 ;;
+    esac
+  }
+  counted=$(
+    printf '%s\0' /fixture/same-device /fixture/other-device |
+      _bjg_count_matching_device_records 11
+  )
+  [[ "$counted" == 1 ]]
+); then rc=0; else rc=$?; fi
+t='hard-link co-location counts matching device and inode together'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" 'cross-device inode collision contributed to co-location'
+else
+  pass "$t"
+fi
+
+# A validated outside script must not hand execution to an absolute shebang
+# interpreter selected from the worktree.
+command cat >"$b/repo/audit-worktree-interpreter" <<AUDIT_WORKTREE_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/audit-worktree-interpreter-ran'
+exec /bin/sh "\$@"
+AUDIT_WORKTREE_INTERPRETER
+chmod +x "$b/repo/audit-worktree-interpreter"
+mkdir "$b/outside-shebang-bin"
+command cat >"$b/outside-shebang-bin/audit-shebang-parent" <<AUDIT_SHEBANG_PARENT
+#!$b/repo/audit-worktree-interpreter
+printf '%s\n' parent >'$b/audit-shebang-parent-ran'
+AUDIT_SHEBANG_PARENT
+chmod +x "$b/outside-shebang-bin/audit-shebang-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-shebang-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-shebang-parent \
+    >"$b/audit-shebang.stdout" 2>"$b/audit-shebang.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner refuses a worktree shebang interpreter'
+if [[ $rc -eq 0 || -e "$b/audit-worktree-interpreter-ran" \
+      || -e "$b/audit-shebang-parent-ran" ]]; then
+  fail "$t" 'runner executed through a worktree-selected shebang interpreter'
+else
+  pass "$t"
+fi
+
+# Execute-only scripts are omitted because their kernel shebang cannot be
+# inspected safely from the caller identity.
+mkdir "$b/outside-xonly-shebang-bin"
+command cat >"$b/outside-xonly-shebang-bin/audit-xonly-parent" <<AUDIT_XONLY_PARENT
+#!$b/repo/audit-worktree-interpreter
+printf '%s\n' parent >'$b/audit-xonly-parent-ran'
+AUDIT_XONLY_PARENT
+chmod 111 "$b/outside-xonly-shebang-bin/audit-xonly-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-xonly-shebang-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-xonly-parent \
+    >"$b/audit-xonly.stdout" 2>"$b/audit-xonly.stderr"
+); then rc=0; else rc=$?; fi
+chmod 755 "$b/outside-xonly-shebang-bin/audit-xonly-parent"
+t='clean audit-tool runner refuses an execute-only script before its shebang'
+if [[ $rc -eq 0 || -e "$b/audit-worktree-interpreter-ran" \
+      || -e "$b/audit-xonly-parent-ran" ]]; then
+  fail "$t" 'execute-only audit script reached its worktree interpreter'
+else
+  pass "$t"
+fi
+
+# A symlink merely named env cannot grant env argument semantics to another
+# interpreter.
+mkdir "$b/outside-env-spoof-bin"
+trusted_python=$(command -p -v python3)
+ln -s "$trusted_python" "$b/outside-env-spoof-bin/env"
+printf '%s\n' \
+  "open('$b/audit-env-name-spoof-ran', 'w').write('ran')" >"$b/repo/python3"
+command cat >"$b/outside-env-spoof-bin/audit-env-spoof-parent" <<AUDIT_ENV_SPOOF
+#!$b/outside-env-spoof-bin/env python3
+raise SystemExit(0)
+AUDIT_ENV_SPOOF
+chmod +x "$b/outside-env-spoof-bin/audit-env-spoof-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-env-spoof-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-env-spoof-parent \
+    >"$b/audit-env-spoof.stdout" 2>"$b/audit-env-spoof.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner authenticates env by resolved executable identity'
+if [[ $rc -eq 0 || -e "$b/audit-env-name-spoof-ran" ]]; then
+  fail "$t" 'non-env interpreter executed a worktree-relative shebang argument'
+else
+  pass "$t"
+fi
+
+# CR remains pathname data to the kernel and cannot be dropped by shell
+# whitespace parsing.
+audit_cr_interpreter="$b/repo/audit-cr-only-interpreter"$'\r'
+command cat >"$audit_cr_interpreter" <<AUDIT_CR_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/audit-cr-interpreter-ran'
+exec /bin/sh "\$@"
+AUDIT_CR_INTERPRETER
+chmod +x "$audit_cr_interpreter"
+mkdir "$b/outside-cr-shebang-bin"
+printf '#!%s\nexit 0\n' "$audit_cr_interpreter" \
+  >"$b/outside-cr-shebang-bin/audit-cr-parent"
+chmod +x "$b/outside-cr-shebang-bin/audit-cr-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-cr-shebang-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-cr-parent \
+    >"$b/audit-cr.stdout" 2>"$b/audit-cr.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner refuses a CR-bearing worktree interpreter'
+if [[ $rc -eq 0 || -e "$b/audit-cr-interpreter-ran" ]]; then
+  fail "$t" 'CR-bearing worktree shebang interpreter executed'
 else
   pass "$t"
 fi
@@ -1458,6 +1677,92 @@ WORKTREE_BR
 chmod +x "$b/repo/bin/br"
 assert_refused 'a worktree-controlled br executable is refused' "$b" \
   'br resolves inside the current Git worktree' "$b/repo/bin:$SYSTEM_PATH"
+
+# An outside script pathname is still unsafe when its kernel-selected absolute
+# shebang interpreter comes from the driven worktree.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+command cat >"$b/repo/worktree-interpreter" <<WORKTREE_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/worktree-interpreter-ran'
+exec /bin/sh "\$@"
+WORKTREE_INTERPRETER
+chmod +x "$b/repo/worktree-interpreter"
+command cat >"$b/outside-bin/br" <<OUTSIDE_BR_WORKTREE_INTERPRETER
+#!$b/repo/worktree-interpreter
+cat "\$BR_OUTPUT"
+OUTSIDE_BR_WORKTREE_INTERPRETER
+chmod +x "$b/outside-bin/br"
+assert_refused 'an outside br with a worktree shebang interpreter is refused' "$b" \
+  'br interpreter resolves inside the current Git worktree' \
+  "$b/outside-bin:$SYSTEM_PATH"
+if [[ -e "$b/worktree-interpreter-ran" ]]; then
+  fail 'an outside br with a worktree shebang interpreter is refused' \
+    'the worktree-controlled interpreter executed'
+fi
+
+# Execute permission does not make an unreadable script safe: the kernel can
+# still consume its shebang. Refuse rather than infer its format.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+command cat >"$b/repo/worktree-interpreter" <<WORKTREE_XONLY_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/worktree-interpreter-ran'
+exec /bin/sh "\$@"
+WORKTREE_XONLY_INTERPRETER
+chmod +x "$b/repo/worktree-interpreter"
+command cat >"$b/outside-bin/br" <<OUTSIDE_XONLY_BR
+#!$b/repo/worktree-interpreter
+cat "\$BR_OUTPUT"
+OUTSIDE_XONLY_BR
+chmod 111 "$b/outside-bin/br"
+assert_refused 'an execute-only outside br script is refused before its shebang' "$b" \
+  'br executable cannot be inspected safely' "$b/outside-bin:$SYSTEM_PATH"
+chmod 755 "$b/outside-bin/br"
+if [[ -e "$b/worktree-interpreter-ran" ]]; then
+  fail 'an execute-only outside br script is refused before its shebang' \
+    'the execute-only script reached its worktree interpreter'
+fi
+
+# A pathname lexically named `env` is not the env executable. Python would treat
+# the shebang argument as a worktree-relative script and execute it.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+trusted_python=$(command -p -v python3)
+ln -s "$trusted_python" "$b/outside-bin/env"
+printf '%s\n' \
+  "open('$b/env-name-spoof-ran', 'w').write('ran')" >"$b/repo/python3"
+command cat >"$b/outside-bin/br" <<OUTSIDE_ENV_NAME_SPOOF
+#!$b/outside-bin/env python3
+raise SystemExit(0)
+OUTSIDE_ENV_NAME_SPOOF
+chmod +x "$b/outside-bin/br"
+assert_refused 'a non-env interpreter named env cannot gain env semantics' "$b" \
+  'br has an unsupported script interpreter argument' \
+  "$b/outside-bin:$b/bin:$SYSTEM_PATH"
+if [[ -e "$b/env-name-spoof-ran" ]]; then
+  fail 'a non-env interpreter named env cannot gain env semantics' \
+    'the spoofed interpreter executed a worktree-relative script'
+fi
+
+# Linux treats CR as interpreter pathname data, not as a shebang separator.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+cr_interpreter="$b/repo/worktree-interpreter"$'\r'
+command cat >"$cr_interpreter" <<WORKTREE_CR_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/worktree-cr-interpreter-ran'
+exec /bin/sh "\$@"
+WORKTREE_CR_INTERPRETER
+chmod +x "$cr_interpreter"
+printf '#!%s\ncat \"$BR_OUTPUT\"\n' "$cr_interpreter" >"$b/outside-bin/br"
+chmod +x "$b/outside-bin/br"
+assert_refused 'a CR-bearing worktree shebang interpreter is refused' "$b" \
+  'br has an unsafe script interpreter' "$b/outside-bin:$SYSTEM_PATH"
+if [[ -e "$b/worktree-cr-interpreter-ran" ]]; then
+  fail 'a CR-bearing worktree shebang interpreter is refused' \
+    'the CR-bearing worktree interpreter executed'
+fi
 
 b=$(new_fixture)
 mkdir "$b/repo/bin"

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -1,0 +1,905 @@
+#!/usr/bin/env bash
+# Isolated regression fixtures for resolve-beads-jsonl. Every fixture uses a
+# scratch repository and a stubbed br; the real Beads store is never queried or
+# mutated.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+RESOLVER="$HERE/resolve-beads-jsonl"
+SYSTEM_PATH=$PATH
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL %s\n         %s\n' "$1" "$2"; }
+
+set_where_path() {
+  local base=$1 path=$2
+  printf '%s' "$path" >"$base/where-path" || return
+  jq -n --arg path "$path" '{jsonl_path: $path}' >"$base/where.out" || return
+}
+
+new_fixture() {
+  local base repo jsonl
+  base=$(mktemp -d "$WORK/fixture.XXXXXX") || return
+  repo="$base/repo"
+  jsonl="$repo/.beads/issues.jsonl"
+  mkdir -p "$repo/.beads" "$base/bin" || return
+  git init -q "$repo" || return
+  git -C "$repo" symbolic-ref --short HEAD >"$base/initial-branch" || return
+  git -C "$repo" config user.name 'Resolver Test' || return
+  git -C "$repo" config user.email resolver@example.invalid || return
+  printf '%s\n' '{"id":"fixture"}' >"$jsonl" || return
+  git -C "$repo" add -- .beads/issues.jsonl || return
+  git -C "$repo" commit -qm baseline || return
+  printf '%s' "$jsonl" >"$base/jsonl-path" || return
+  set_where_path "$base" "$jsonl" || return
+  command cat >"$base/bin/br" <<'BR_STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BR_CALLS"
+if [[ "$*" != '--no-auto-flush --no-auto-import where --json' ]]; then
+  : >"$BR_MUTATION"
+fi
+command cat "$BR_OUTPUT"
+exit "${BR_EXIT:-0}"
+BR_STUB
+  chmod +x "$base/bin/br" || return
+  printf '%s' "$base"
+}
+
+# Marks the fixture's JSONL entry fsmonitor-valid and proves it landed. Git sets that bit
+# for entries a configured file system monitor did not report as changed, and then answers
+# from the bit instead of the filesystem. The stub reports no changed paths at all, so
+# whatever happens to the file after this call stays hidden from Git. `ls-files -v` cannot
+# see the bit — it prints `H` — which is why the caller checks `ls-files -f`.
+mark_fsmonitor_valid() {
+  local base=$1 hook flags
+  hook="$base/fsmonitor-stub"
+  command cat >"$hook" <<'FSMONITOR_STUB'
+#!/bin/sh
+printf 'resolver-fixture-token\0'
+FSMONITOR_STUB
+  chmod +x "$hook" || return 1
+  git -C "$base/repo" config core.fsmonitor "$hook" || return 1
+  # Sets the bit while the worktree still matches the index; Git keeps that cached answer
+  # until the monitor names the path, which this stub never does.
+  git -C "$base/repo" status --porcelain >/dev/null || return 1
+  flags=$(git -C "$base/repo" ls-files -f -- .beads/issues.jsonl) || return 1
+  [[ "$flags" == 'h '* ]]
+}
+
+snapshot_one_path() {
+  local label=$1 path=$2
+  printf '\nPATH %s\n' "$label"
+  if [[ -L "$path" ]]; then
+    printf 'symlink\n'
+    readlink "$path"
+  elif [[ -f "$path" ]]; then
+    printf 'regular\n'
+    git hash-object --no-filters --stdin <"$path"
+    if [[ -x "$path" ]]; then printf 'executable\n'; else printf 'non-executable\n'; fi
+  elif [[ -d "$path" ]]; then
+    printf 'directory\n'
+  elif [[ -p "$path" ]]; then
+    printf 'fifo\n'
+  elif [[ -e "$path" ]]; then
+    printf 'other\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+snapshot_fixture() {
+  local base=$1 output=$2 repo actual resolved
+  repo="$base/repo"
+  actual=$(<"$base/jsonl-path")
+  resolved=$(<"$base/where-path")
+  {
+    printf 'STATUS\n'
+    git -C "$repo" status --porcelain=v2 -z --untracked-files=all
+    printf '\nSTAGE\n'
+    git -C "$repo" ls-files --stage -z
+    printf '\nFLAGS\n'
+    git -C "$repo" ls-files -v -z
+    snapshot_one_path actual "$actual"
+    if [[ "$resolved" != "$actual" ]]; then
+      snapshot_one_path resolved "$resolved"
+    fi
+  } >"$output"
+}
+
+safe_br_calls_only() {
+  local calls=$1 call
+  [[ -e "$calls" ]] || return 0
+  while IFS= read -r call; do
+    [[ "$call" == '--no-auto-flush --no-auto-import where --json' ]] || return 1
+  done <"$calls"
+}
+
+# Extra resolver arguments and invocation worktree for the next assertion only;
+# every assert_* clears them.
+RESOLVER_ARGS=()
+RESOLVER_CWD=
+
+run_resolver() {
+  local base=$1 runtime_path=$2
+  (
+    cd "${RESOLVER_CWD:-$base/repo}" || exit 98
+    BR_CALLS="$base/br.calls" BR_MUTATION="$base/br.mutation" \
+      BR_OUTPUT="$base/where.out" BR_EXIT="${BR_EXIT:-0}" \
+      PATH="$runtime_path" "$RESOLVER" ${RESOLVER_ARGS+"${RESOLVER_ARGS[@]}"} \
+      >"$base/stdout" 2>"$base/stderr"
+  )
+}
+
+assert_refused() {
+  local name=$1 base=$2 diagnostic=$3 runtime_path rc
+  runtime_path=${4:-"$base/bin:$SYSTEM_PATH"}
+  snapshot_fixture "$base" "$base/before"
+  if run_resolver "$base" "$runtime_path"; then rc=0; else rc=$?; fi
+  RESOLVER_ARGS=()
+  RESOLVER_CWD=
+  snapshot_fixture "$base" "$base/after"
+  if [[ $rc -eq 0 ]]; then
+    fail "$name" 'resolver accepted unsafe state'
+  elif [[ -s "$base/stdout" ]]; then
+    fail "$name" 'resolver printed a path while refusing'
+  elif ! grep -Fq -- "$diagnostic" "$base/stderr"; then
+    fail "$name" "missing diagnostic '$diagnostic': $(<"$base/stderr")"
+  elif ! cmp -s "$base/before" "$base/after"; then
+    fail "$name" 'repository or resolved-path state changed'
+  elif [[ -e "$base/br.mutation" ]]; then
+    fail "$name" 'br observed a mutation or flush-shaped invocation'
+  elif ! safe_br_calls_only "$base/br.calls"; then
+    fail "$name" 'br received something other than the exact read-only where invocation'
+  else
+    pass "$name"
+  fi
+}
+
+assert_success() {
+  local name=$1 base=$2 expected=$3 rc
+  snapshot_fixture "$base" "$base/before"
+  if run_resolver "$base" "$base/bin:$SYSTEM_PATH"; then rc=0; else rc=$?; fi
+  RESOLVER_ARGS=()
+  RESOLVER_CWD=
+  snapshot_fixture "$base" "$base/after"
+  printf '%s\n' "$expected" >"$base/expected"
+  if [[ $rc -ne 0 ]]; then
+    fail "$name" "exit $rc: $(<"$base/stderr")"
+  elif ! cmp -s "$base/expected" "$base/stdout"; then
+    fail "$name" 'stdout was not exactly the absolute JSONL path'
+  elif [[ -s "$base/stderr" ]]; then
+    fail "$name" "unexpected stderr: $(<"$base/stderr")"
+  elif ! cmp -s "$base/before" "$base/after"; then
+    fail "$name" 'successful inspection changed repository state'
+  elif [[ -e "$base/br.mutation" ]] || ! safe_br_calls_only "$base/br.calls"; then
+    fail "$name" 'success invoked a Beads mutation or flush'
+  else
+    pass "$name"
+  fi
+}
+
+assert_stdout_failure() {
+  local name=$1 base=$2 rc
+  snapshot_fixture "$base" "$base/before"
+  set +e
+  (
+    cd "$base/repo" || exit 98
+    trap '' PIPE
+    BR_CALLS="$base/br.calls" BR_MUTATION="$base/br.mutation" \
+      BR_OUTPUT="$base/where.out" BR_EXIT=0 PATH="$base/bin:$SYSTEM_PATH" \
+      "$RESOLVER" --allow-dirty 2>"$base/stderr"
+  ) | :
+  rc=${PIPESTATUS[0]}
+  set -e
+  snapshot_fixture "$base" "$base/after"
+  if [[ $rc -eq 0 ]]; then
+    fail "$name" 'resolver masked the failed stdout write'
+  elif [[ ! -s "$base/stderr" ]]; then
+    fail "$name" 'stdout failed without a diagnostic'
+  elif ! cmp -s "$base/before" "$base/after"; then
+    fail "$name" 'failed output changed repository state'
+  elif [[ -e "$base/br.mutation" ]]; then
+    fail "$name" 'failed output invoked a Beads mutation or flush'
+  elif [[ ! -e "$base/br.calls" ]] || ! safe_br_calls_only "$base/br.calls"; then
+    fail "$name" 'failed output did not use only the exact read-only where invocation'
+  else
+    pass "$name"
+  fi
+}
+
+printf '%s\n' 'resolve-beads-jsonl fixtures'
+
+b=$(new_fixture)
+assert_success 'clean tracked JSONL resolves' "$b" "$(<"$b/jsonl-path")"
+
+# Neither the outer launcher nor the proof may pick up checkout-controlled
+# standard utilities from PATH, a BASH_ENV startup file, or exported functions.
+# Before the launcher existed the `bash` sentinel ran; before proof-tool pinning,
+# the otherwise hardened implementation ran the `git` and `cmp` sentinels.
+b=$(new_fixture)
+mkdir "$b/repo/evil"
+for utility in bash git cmp od grep mktemp unlink rmdir; do
+  trusted_utility=$(command -p -v "$utility") || {
+    fail 'hostile startup fixture setup' "cannot locate $utility in the POSIX utility path"
+    continue
+  }
+  command cat >"$b/repo/evil/$utility" <<HOSTILE_UTILITY
+#!/bin/sh
+printf '%s\n' "\$0" >>"\$HOSTILE_PATH_RAN"
+exec "$trusted_utility" "\$@"
+HOSTILE_UTILITY
+  chmod +x "$b/repo/evil/$utility"
+done
+command cat >"$b/bin/br" <<'SAFE_BR'
+#!/bin/sh
+printf '%s\n' "$*" >>"$BR_CALLS"
+if [ "$*" != '--no-auto-flush --no-auto-import where --json' ]; then
+  : >"$BR_MUTATION"
+fi
+cat "$BR_OUTPUT"
+exit "${BR_EXIT:-0}"
+SAFE_BR
+chmod +x "$b/bin/br"
+printf '%s\n' ': >"$HOSTILE_BASH_ENV_RAN"' >"$b/bash-env"
+snapshot_fixture "$b" "$b/before"
+br() {
+  : >"$HOSTILE_FUNCTION_RAN"
+  printf '%s\n' '{"jsonl_path":"/not/the/fixture.jsonl"}'
+}
+git() {
+  : >"$HOSTILE_GIT_FUNCTION_RAN"
+  command git "$@"
+}
+export -f br git
+if (
+  cd "$b/repo" || exit 98
+  HOSTILE_PATH_RAN="$b/path-ran" HOSTILE_BASH_ENV_RAN="$b/bash-env-ran" \
+    HOSTILE_FUNCTION_RAN="$b/function-ran" HOSTILE_GIT_FUNCTION_RAN="$b/git-function-ran" \
+    BR_CALLS="$b/br.calls" BR_MUTATION="$b/br.mutation" BR_OUTPUT="$b/where.out" \
+    PATH="$b/repo/evil:$b/bin:$SYSTEM_PATH" BASH_ENV="$b/bash-env" \
+    "$RESOLVER" >"$b/stdout" 2>"$b/stderr"
+); then rc=0; else rc=$?; fi
+unset -f br git
+snapshot_fixture "$b" "$b/after"
+t='hostile PATH, BASH_ENV, and exported functions cannot alter resolver startup'
+printf '%s\n' "$(<"$b/jsonl-path")" >"$b/expected"
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/stderr")"
+elif [[ -e "$b/path-ran" || -e "$b/bash-env-ran" || -e "$b/function-ran" \
+        || -e "$b/git-function-ran" ]]; then
+  fail "$t" "a hostile startup sentinel ran: path=$(test -e "$b/path-ran" && tr '\n' ',' <"$b/path-ran" || echo no), bash-env=$(test -e "$b/bash-env-ran" && echo yes || echo no), br=$(test -e "$b/function-ran" && echo yes || echo no), git=$(test -e "$b/git-function-ran" && echo yes || echo no)"
+elif ! cmp -s "$b/expected" "$b/stdout" || [[ -s "$b/stderr" ]]; then
+  fail "$t" 'resolver output changed under hostile startup state'
+elif ! cmp -s "$b/before" "$b/after" || ! safe_br_calls_only "$b/br.calls"; then
+  fail "$t" 'hostile startup state changed the fixture or br invocation'
+else
+  pass "$t"
+fi
+
+# `br` and `jq` are resolved from PATH because they are not portable members of
+# Bash's POSIX utility path. That exception must not let the driven checkout
+# supply either executable.
+b=$(new_fixture)
+mkdir "$b/repo/bin"
+command cat >"$b/repo/bin/br" <<'WORKTREE_BR'
+#!/bin/sh
+printf '%s\n' ran >"$WORKTREE_TOOL_RAN"
+cat "$BR_OUTPUT"
+WORKTREE_BR
+chmod +x "$b/repo/bin/br"
+assert_refused 'a worktree-controlled br executable is refused' "$b" \
+  'br resolves inside the current Git worktree' "$b/repo/bin:$SYSTEM_PATH"
+
+b=$(new_fixture)
+mkdir "$b/repo/bin"
+trusted_jq=$(command -v jq)
+command cat >"$b/repo/bin/jq" <<WORKTREE_JQ
+#!/bin/sh
+printf '%s\n' ran >"\$WORKTREE_TOOL_RAN"
+exec "$trusted_jq" "\$@"
+WORKTREE_JQ
+chmod +x "$b/repo/bin/jq"
+WORKTREE_TOOL_RAN="$b/worktree-tool-ran"
+export WORKTREE_TOOL_RAN
+assert_refused 'a worktree-controlled jq executable is refused' "$b" \
+  'jq resolves inside the current Git worktree' "$b/repo/bin:$b/bin:$SYSTEM_PATH"
+unset WORKTREE_TOOL_RAN
+if [[ -e "$b/worktree-tool-ran" ]]; then
+  fail 'a worktree-controlled jq executable is refused' 'the refused jq shim executed'
+fi
+
+# A Git worktree rooted at `/` contains every absolute PATH executable. The
+# containment special case must therefore refuse before invoking even an
+# otherwise external-looking stub.
+b=$(new_fixture)
+git init -q --bare "$b/root-admin"
+snapshot_fixture "$b" "$b/before"
+if (
+  cd "$b/repo" || exit 98
+  GIT_DIR="$b/root-admin" GIT_WORK_TREE=/ \
+    BR_CALLS="$b/br.calls" BR_MUTATION="$b/br.mutation" BR_OUTPUT="$b/where.out" \
+    PATH="$b/bin:$SYSTEM_PATH" "$RESOLVER" >"$b/stdout" 2>"$b/stderr"
+); then rc=0; else rc=$?; fi
+snapshot_fixture "$b" "$b/after"
+t='a root worktree refuses every PATH-selected proof executable'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'resolver accepted a proof executable contained by the root worktree'
+elif [[ -s "$b/stdout" ]]; then
+  fail "$t" 'resolver printed a path while refusing the root worktree'
+elif ! grep -Fq -- 'br resolves inside the current Git worktree' "$b/stderr"; then
+  fail "$t" "missing root-worktree diagnostic: $(<"$b/stderr")"
+elif [[ -e "$b/br.calls" || -e "$b/br.mutation" ]]; then
+  fail "$t" 'resolver invoked br before refusing the root worktree'
+elif ! cmp -s "$b/before" "$b/after"; then
+  fail "$t" 'root-worktree refusal changed the fixture'
+else
+  pass "$t"
+fi
+
+# Canonicalizing only an executable's parent is insufficient: a PATH directory
+# outside the checkout can contain a final symlink back to checkout-controlled
+# bytes. Pin the complete target and refuse before either shim can run.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+command cat >"$b/repo/evil-br" <<'WORKTREE_BR_TARGET'
+#!/bin/sh
+printf '%s\n' ran >"$WORKTREE_TOOL_RAN"
+cat "$BR_OUTPUT"
+WORKTREE_BR_TARGET
+chmod +x "$b/repo/evil-br"
+ln -s "$b/repo/evil-br" "$b/outside-bin/br"
+WORKTREE_TOOL_RAN="$b/worktree-tool-ran"
+export WORKTREE_TOOL_RAN
+assert_refused 'an outside br symlink into the worktree is refused' "$b" \
+  'br resolves inside the current Git worktree' "$b/outside-bin:$SYSTEM_PATH"
+unset WORKTREE_TOOL_RAN
+if [[ -e "$b/worktree-tool-ran" ]]; then
+  fail 'an outside br symlink into the worktree is refused' 'the refused br target executed'
+fi
+
+# The last target reached by the maximum permitted 40 follows must still pass
+# through canonicalization and containment before it is accepted. An earlier
+# bounded `for` loop read this target on its final iteration, then type-checked it
+# without inspecting where it lived.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+command cat >"$b/repo/evil-br" <<'WORKTREE_BR_40_TARGET'
+#!/bin/sh
+printf '%s\n' ran >"$WORKTREE_TOOL_RAN"
+cat "$BR_OUTPUT"
+WORKTREE_BR_40_TARGET
+chmod +x "$b/repo/evil-br"
+chain_target="$b/repo/evil-br"
+for ((chain_hop = 39; chain_hop >= 1; chain_hop--)); do
+  ln -s "$chain_target" "$b/outside-bin/br-link-$chain_hop"
+  chain_target="$b/outside-bin/br-link-$chain_hop"
+done
+ln -s "$chain_target" "$b/outside-bin/br"
+WORKTREE_TOOL_RAN="$b/worktree-tool-ran"
+export WORKTREE_TOOL_RAN
+assert_refused 'a 40-hop outside br chain into the worktree is refused' "$b" \
+  'br resolves inside the current Git worktree' "$b/outside-bin:$SYSTEM_PATH"
+unset WORKTREE_TOOL_RAN
+if [[ -e "$b/worktree-tool-ran" ]]; then
+  fail 'a 40-hop outside br chain into the worktree is refused' 'the refused br target executed'
+fi
+
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+trusted_jq=$(command -v jq)
+command cat >"$b/repo/evil-jq" <<WORKTREE_JQ_TARGET
+#!/bin/sh
+printf '%s\n' ran >"\$WORKTREE_TOOL_RAN"
+exec "$trusted_jq" "\$@"
+WORKTREE_JQ_TARGET
+chmod +x "$b/repo/evil-jq"
+ln -s "$b/repo/evil-jq" "$b/outside-bin/jq"
+WORKTREE_TOOL_RAN="$b/worktree-tool-ran"
+export WORKTREE_TOOL_RAN
+assert_refused 'an outside jq symlink into the worktree is refused' "$b" \
+  'jq resolves inside the current Git worktree' "$b/outside-bin:$b/bin:$SYSTEM_PATH"
+unset WORKTREE_TOOL_RAN
+if [[ -e "$b/worktree-tool-ran" ]]; then
+  fail 'an outside jq symlink into the worktree is refused' 'the refused jq target executed'
+fi
+
+b=$(new_fixture)
+old=$(<"$b/jsonl-path")
+tab_path="$b/repo/.beads/issues with"$'\t'"tab.jsonl"
+git -C "$b/repo" mv -- "${old#"$b/repo/"}" "${tab_path#"$b/repo/"}"
+git -C "$b/repo" commit -qm 'tab path'
+printf '%s' "$tab_path" >"$b/jsonl-path"
+set_where_path "$b" "$tab_path"
+assert_success 'NUL-delimited Git records preserve a tab in the path' "$b" "$tab_path"
+
+# `br where` may name any tracked file, including one whose bytes read as Git pathspec
+# magic or a wildmatch pattern. Both lookups must be byte-exact: magic silently resolves a
+# DIFFERENT path, and a wildcard can pull in a sibling and make the entry look ambiguous.
+b=$(new_fixture)
+magic_path="$b/repo/:(literal)graph.beads.jsonl"
+mv -- "$(<"$b/jsonl-path")" "$magic_path"
+git -C "$b/repo" add -A
+git -C "$b/repo" commit -qm 'pathspec-magic path'
+printf '%s' "$magic_path" >"$b/jsonl-path"
+set_where_path "$b" "$magic_path"
+assert_success 'a filename that reads as pathspec magic resolves' "$b" "$magic_path"
+
+b=$(new_fixture)
+glob_path="$b/repo/.beads/is[s]ues.jsonl"
+mv -- "$(<"$b/jsonl-path")" "$glob_path"
+printf '%s\n' '{"id":"sibling"}' >"$b/repo/.beads/issues.jsonl"
+git -C "$b/repo" add -A
+git -C "$b/repo" commit -qm 'wildmatch path'
+printf '%s' "$glob_path" >"$b/jsonl-path"
+set_where_path "$b" "$glob_path"
+assert_success 'a filename holding wildmatch metacharacters resolves' "$b" "$glob_path"
+
+b=$(new_fixture)
+BR_EXIT=9 assert_refused 'br failure after valid JSON is refused' "$b" \
+  'cannot resolve the beads workspace'
+
+while IFS='|' read -r name payload diagnostic; do
+  b=$(new_fixture)
+  printf '%b' "$payload" >"$b/where.out"
+  assert_refused "$name" "$b" "$diagnostic"
+done <<'INVALID_JSON'
+missing jsonl_path|{}\n|cannot resolve exactly one beads JSONL
+null jsonl_path|{"jsonl_path":null}\n|cannot resolve exactly one beads JSONL
+empty jsonl_path|{"jsonl_path":""}\n|cannot resolve exactly one beads JSONL
+non-string jsonl_path|{"jsonl_path":7}\n|cannot resolve exactly one beads JSONL
+zero JSON documents||cannot resolve exactly one beads JSONL
+multiple JSON documents|{"jsonl_path":"one"}\n{"jsonl_path":"two"}\n|cannot resolve exactly one beads JSONL
+malformed JSON|{"jsonl_path":\n|cannot resolve exactly one beads JSONL
+relative jsonl_path|{"jsonl_path":".beads/issues.jsonl"}\n|cannot resolve exactly one beads JSONL
+decoded CR in path|{"jsonl_path":"bad\\rpath"}\n|cannot resolve exactly one beads JSONL
+decoded LF in path|{"jsonl_path":"bad\\npath"}\n|cannot resolve exactly one beads JSONL
+INVALID_JSON
+
+# If the decoded-NUL guard regresses, Bash strips the NUL from command substitution and
+# this payload becomes the fixture's valid tracked path. That makes this a behavior check,
+# not merely an assertion about which diagnostic an independently-invalid path reports.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+printf '{"jsonl_path":"%s%s%s"}\n' "${jsonl%.jsonl}" '\u0000' '.jsonl' >"$b/where.out"
+assert_refused 'JSON-escaped NUL in path is refused before shell capture' "$b" \
+  'cannot resolve exactly one beads JSONL'
+
+b=$(new_fixture)
+printf '{"jsonl_path":"bad\0path"}\n' >"$b/where.out"
+assert_refused 'raw NUL in workspace JSON is refused before jq' "$b" \
+  'beads workspace JSON contains a raw NUL byte'
+
+b=$(new_fixture)
+command cat >"$b/bin/jq" <<'JQ_FAIL'
+#!/usr/bin/env bash
+exit 23
+JQ_FAIL
+chmod +x "$b/bin/jq"
+assert_refused 'failing jq is refused' "$b" 'cannot resolve exactly one beads JSONL'
+
+b=$(new_fixture)
+mkdir -p "$b/no-jq-bin"
+for utility in bash git od grep cmp mktemp unlink rmdir; do
+  utility_path=$(command -v "$utility")
+  ln -s "$utility_path" "$b/no-jq-bin/$utility"
+done
+ln -s "$b/bin/br" "$b/no-jq-bin/br"
+assert_refused 'missing jq is refused' "$b" 'jq is required to resolve the beads JSONL' \
+  "$b/no-jq-bin"
+
+b=$(new_fixture)
+outside="$b/outside.jsonl"
+printf '%s\n' outside >"$outside"
+set_where_path "$b" "$outside"
+assert_refused 'path outside the current worktree is refused' "$b" \
+  'beads JSONL is outside the current worktree'
+
+b=$(new_fixture)
+printf '%s\n' staged >>"$(<"$b/jsonl-path")"
+git -C "$b/repo" add -- .beads/issues.jsonl
+assert_refused 'staged-only content is refused' "$b" \
+  'beads JSONL differs among HEAD, index, and worktree'
+
+b=$(new_fixture)
+printf '%s\n' unstaged >>"$(<"$b/jsonl-path")"
+assert_refused 'unstaged-only content is refused' "$b" \
+  'beads JSONL differs among HEAD, index, and worktree'
+
+# `cat-file blob <HEAD-oid>` follows replacement refs by default.  Replacing the
+# clean HEAD/index blob with the dirty worktree bytes made the old proof accept
+# an unstaged edit, even though the object stored in HEAD was different.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+printf '%s\n' replacement-dirty >>"$jsonl"
+head_oid=$(git -C "$b/repo" rev-parse HEAD:.beads/issues.jsonl)
+replacement_oid=$(git -C "$b/repo" hash-object -w "$jsonl")
+if ! git -C "$b/repo" replace "$head_oid" "$replacement_oid"; then
+  fail 'replacement-ref fixture setup' 'git could not create the replacement ref'
+else
+  assert_refused 'replacement refs cannot spoof the HEAD/index/worktree proof' "$b" \
+    'beads JSONL differs among HEAD, index, and worktree'
+fi
+
+b=$(new_fixture)
+printf '%s\n' staged >>"$(<"$b/jsonl-path")"
+git -C "$b/repo" add -- .beads/issues.jsonl
+printf '%s\n' unstaged >>"$(<"$b/jsonl-path")"
+assert_refused 'staged-plus-unstaged content is refused' "$b" \
+  'beads JSONL differs among HEAD, index, and worktree'
+
+# `git add -N` — on its own or after `git rm --cached` — leaves an index record that every
+# structural check accepts: one stage-0 `100644` entry tagged `H`. Its OID is the empty
+# blob rather than the file's content, so an *empty* tracked JSONL also passes byte
+# identity while Git reports the path as `DA`. The index holds no content for it.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+rel=${jsonl#"$b/repo/"}
+: >"$jsonl"
+git -C "$b/repo" commit -qam 'empty jsonl'
+git -C "$b/repo" rm --cached -q -- "$rel"
+git -C "$b/repo" add -N -- "$rel"
+assert_refused 'intent-to-add JSONL is refused' "$b" \
+  'beads JSONL index entry is intent-to-add'
+
+b=$(new_fixture)
+chmod +x "$(<"$b/jsonl-path")"
+assert_refused 'worktree mode-only change is refused' "$b" \
+  'beads JSONL worktree mode is not 100644'
+
+# The mode a tracked file has is Git's answer, not the invoking user's access rights: Git
+# reads the owner-exec bit and honors `core.filemode`, while an `access(2)` probe such as
+# bash `[[ -x ]]` does neither. Measured on git 2.53.0 with the streams separated by
+# redirection: after `core.filemode=false` and `chmod +x` on the tracked JSONL,
+# `diff-files --raw -z` and `git status --porcelain` each wrote 0 bytes to stdout at exit 0
+# with empty stderr, while bash `[[ -x ]]` was true; with `core.filemode=true` the same
+# chmod wrote `:100644 100755 …`. Every filesystem that carries no executable bit sets
+# exactly that config, so an access probe would refuse forever on a JSONL Git itself
+# reports pristine — and the improvisation that unblocks a dead-ended consumer is the
+# hardcoded `.beads/issues.jsonl` this companion exists to prevent.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+git -C "$b/repo" config core.filemode false
+chmod +x "$jsonl"
+assert_success 'an exec bit Git is configured to ignore still resolves' "$b" "$jsonl"
+
+b=$(new_fixture)
+git -C "$b/repo" update-index --assume-unchanged -- .beads/issues.jsonl
+assert_refused 'assume-unchanged JSONL is refused' "$b" \
+  'beads JSONL has hidden index flags'
+
+b=$(new_fixture)
+git -C "$b/repo" update-index --skip-worktree -- .beads/issues.jsonl
+assert_refused 'skip-worktree JSONL is refused' "$b" \
+  'beads JSONL has hidden index flags'
+
+b=$(new_fixture)
+git -C "$b/repo" checkout -qb conflict-side
+printf '%s\n' side >"$(<"$b/jsonl-path")"
+git -C "$b/repo" commit -qam side
+git -C "$b/repo" checkout -q "$(<"$b/initial-branch")"
+printf '%s\n' main >"$(<"$b/jsonl-path")"
+git -C "$b/repo" commit -qam main
+git -C "$b/repo" merge conflict-side >/dev/null 2>&1 || :
+assert_refused 'unmerged JSONL is refused' "$b" \
+  'beads JSONL index entry is not one stage-0 regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+printf '%s\n' target >"$b/link-target"
+unlink "$jsonl"
+ln -s "$b/link-target" "$jsonl"
+assert_refused 'symlink JSONL is refused' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+rel=${jsonl#"$b/repo/"}
+oid=$(git -C "$b/repo" rev-parse HEAD)
+git -C "$b/repo" rm -q -- "$rel"
+mkdir -p "$jsonl"
+git -C "$b/repo" update-index --add --cacheinfo "160000,$oid,$rel"
+git -C "$b/repo" commit -qm gitlink
+assert_refused 'gitlink JSONL is refused' "$b" \
+  'beads JSONL index entry is not one stage-0 regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+rel=${jsonl#"$b/repo/"}
+git -C "$b/repo" rm --cached -q -- "$rel"
+printf '%s\n' "/$rel" >"$b/repo/.gitignore"
+git -C "$b/repo" add -- .gitignore
+git -C "$b/repo" commit -qm 'ignore jsonl'
+assert_refused 'ignored untracked JSONL is refused' "$b" \
+  'beads JSONL index entry is not one stage-0 regular file'
+
+b=$(new_fixture)
+unlink "$(<"$b/jsonl-path")"
+assert_refused 'missing JSONL is refused' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+unlink "$jsonl"
+mkfifo "$jsonl"
+assert_refused 'nonregular JSONL is refused without reading it' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+b=$(new_fixture)
+git -C "$b/repo" worktree add -qb other "$b/other"
+other_jsonl="$b/other/.beads/issues.jsonl"
+set_where_path "$b" "$other_jsonl"
+assert_refused 'path in a different worktree is refused' "$b" \
+  'beads JSONL is outside the current worktree'
+
+# `--allow-dirty` permits content differences while retaining the structural proof needed
+# before another write: the file is still one normally flagged, tracked stage-0 regular
+# file in both HEAD and the index. Consumers that inspect a flushed-but-uncommitted graph
+# still have to name it through this owner rather than guessing `.beads/issues.jsonl`.
+b=$(new_fixture)
+printf '%s\n' '{"id":"flushed-round"}' >>"$(<"$b/jsonl-path")"
+RESOLVER_ARGS=(--allow-dirty)
+assert_success '--allow-dirty resolves a legitimately dirty JSONL' "$b" "$(<"$b/jsonl-path")"
+
+b=$(new_fixture)
+printf '%s\n' '{"id":"flushed-round"}' >>"$(<"$b/jsonl-path")"
+assert_stdout_failure '--allow-dirty propagates a failed stdout write' "$b"
+
+b=$(new_fixture)
+git -C "$b/repo" update-index --assume-unchanged -- .beads/issues.jsonl
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty refuses assume-unchanged JSONL before another write' "$b" \
+  'beads JSONL has hidden index flags'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+rel=${jsonl#"$b/repo/"}
+git -C "$b/repo" rm --cached -q -- "$rel"
+printf '%s\n' "/$rel" >"$b/repo/.gitignore"
+git -C "$b/repo" add -- .gitignore
+git -C "$b/repo" commit -qm 'ignore jsonl'
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty refuses ignored untracked JSONL before another write' "$b" \
+  'beads JSONL index entry is not one stage-0 regular file'
+
+b=$(new_fixture)
+unlink "$(<"$b/jsonl-path")"
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty refuses a missing JSONL before another write' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+# Byte identity is what catches intent-to-add for a non-empty file, and `--allow-dirty` is
+# exactly the mode that drops it — so the flush it authorizes would write over a path the
+# index does not hold at all.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+rel=${jsonl#"$b/repo/"}
+git -C "$b/repo" rm --cached -q -- "$rel"
+git -C "$b/repo" add -N -- "$rel"
+printf '%s\n' '{"id":"flushed-round"}' >>"$jsonl"
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty refuses intent-to-add JSONL before another write' "$b" \
+  'beads JSONL index entry is intent-to-add'
+
+b=$(new_fixture)
+git -C "$b/repo" update-index --chmod=+x -- .beads/issues.jsonl
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty retains the regular index-mode requirement' "$b" \
+  'beads JSONL index entry is not one stage-0 regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+chmod +x "$jsonl"
+git -C "$b/repo" add -- .beads/issues.jsonl
+git -C "$b/repo" commit -qm 'executable head entry'
+chmod -x "$jsonl"
+git -C "$b/repo" add -- .beads/issues.jsonl
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty retains the regular HEAD-mode requirement' "$b" \
+  'beads JSONL HEAD entry is not one regular file'
+
+b=$(new_fixture)
+git -C "$b/repo" checkout -qb conflict-side
+printf '%s\n' side >"$(<"$b/jsonl-path")"
+git -C "$b/repo" commit -qam side
+git -C "$b/repo" checkout -q "$(<"$b/initial-branch")"
+printf '%s\n' main >"$(<"$b/jsonl-path")"
+git -C "$b/repo" commit -qam main
+git -C "$b/repo" merge conflict-side >/dev/null 2>&1 || :
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty retains the stage-0 index requirement' "$b" \
+  'beads JSONL index entry is not one stage-0 regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+printf '%s\n' target >"$b/link-target"
+unlink "$jsonl"
+ln -s "$b/link-target" "$jsonl"
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty retains the non-symlink worktree requirement' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+b=$(new_fixture)
+outside="$b/outside.jsonl"
+printf '%s\n' outside >"$outside"
+set_where_path "$b" "$outside"
+RESOLVER_ARGS=(--allow-dirty)
+assert_refused '--allow-dirty retains worktree containment' "$b" \
+  'beads JSONL is outside the current worktree'
+
+# A file system monitor that misses a write is the one hidden state `ls-files -v` cannot
+# report: the entry keeps its fsmonitor-valid bit, so `-v` prints `H` and Git answers from
+# that bit. Measured on git 2.53.0 with the stub monitor above: after appending to the
+# tracked JSONL, `git status --porcelain` and `git diff --name-only` each printed zero
+# bytes at exit 0, `ls-files -v` printed `H`, and only `ls-files -f` printed `h`. The
+# consumers of this mode read that same status and `git diff HEAD` to decide what the
+# following `br sync --flush-only` may overwrite, so the cache would hand them a
+# clean-looking review of a file whose bead bodies differ.
+b=$(new_fixture)
+t='--allow-dirty refuses a modification the fsmonitor cache hides'
+if ! mark_fsmonitor_valid "$b"; then
+  fail "$t" 'fixture could not mark the JSONL entry fsmonitor-valid'
+else
+  printf '%s\n' '{"id":"hand-edit"}' >>"$(<"$b/jsonl-path")"
+  RESOLVER_ARGS=(--allow-dirty)
+  assert_refused "$t" "$b" 'beads JSONL modification is hidden by the fsmonitor cache'
+fi
+
+# The mode proof must also bypass a stale fsmonitor answer. With core.filemode=true,
+# Git must inspect the filesystem and report the owner-exec change even when the
+# monitor says the path is unchanged.
+b=$(new_fixture)
+t='--allow-dirty refuses a mode change the fsmonitor cache hides'
+if ! mark_fsmonitor_valid "$b"; then
+  fail "$t" 'fixture could not mark the JSONL entry fsmonitor-valid'
+else
+  chmod +x "$(<"$b/jsonl-path")"
+  RESOLVER_ARGS=(--allow-dirty)
+  assert_refused "$t" "$b" 'beads JSONL worktree mode is not 100644'
+fi
+
+# The bit alone is not the fault, and refusing it would be wrong: every entry in a
+# monitored repository carries it whenever Git last saw the file match the index. That
+# includes the staged-but-uncommitted JSONL this mode's consumers explicitly expect,
+# where the cached answer and the bytes agree and the diff they read is truthful.
+b=$(new_fixture)
+t='--allow-dirty accepts an fsmonitor-valid entry that hides nothing'
+jsonl=$(<"$b/jsonl-path")
+printf '%s\n' '{"id":"flushed-round"}' >>"$jsonl"
+git -C "$b/repo" add -- .beads/issues.jsonl
+if ! mark_fsmonitor_valid "$b"; then
+  fail "$t" 'fixture could not mark the JSONL entry fsmonitor-valid'
+else
+  RESOLVER_ARGS=(--allow-dirty)
+  assert_success "$t" "$b" "$jsonl"
+fi
+
+# The default mode needs no cache check of its own: it compares the worktree bytes, which
+# no index bit can answer for. That is why the check above belongs to `--allow-dirty`.
+b=$(new_fixture)
+t='the default mode refuses a modification the fsmonitor cache hides'
+if ! mark_fsmonitor_valid "$b"; then
+  fail "$t" 'fixture could not mark the JSONL entry fsmonitor-valid'
+else
+  printf '%s\n' '{"id":"hand-edit"}' >>"$(<"$b/jsonl-path")"
+  assert_refused "$t" "$b" 'beads JSONL differs among HEAD, index, and worktree'
+fi
+
+# Recovery is the narrower reason to name a path without the tracked/index/HEAD proof:
+# the JSONL may be the deleted artifact that recovery must restore. Resolution,
+# containment, and non-symlink/nonregular refusal still apply, and the mode remains
+# read-only with respect to Beads.
+b=$(new_fixture)
+unlink "$(<"$b/jsonl-path")"
+RESOLVER_ARGS=(--recovery)
+assert_success '--recovery names a destroyed JSONL for restoration' "$b" "$(<"$b/jsonl-path")"
+
+# The deleted-export exception must not extend to Git's own administrative files:
+# recovery consumers copy and later restore the returned name, so accepting HEAD would
+# let that restoration overwrite repository control state. `assert_refused` snapshots
+# both the actual JSONL and this distinct resolved path, and requires the stub's sole
+# read-only `where` call (no flush-shaped invocation).
+b=$(new_fixture)
+set_where_path "$b" "$b/repo/.git/HEAD"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a Git administrative HEAD path' "$b" \
+  'beads JSONL is inside the Git administrative directory'
+
+# In a linked worktree, `<worktree>/.git` is a regular pointer file rather than
+# the directory returned by `rev-parse --git-dir`. It is administrative state
+# just as surely as the shared/common directory, and a recovery consumer must
+# never copy over it.
+b=$(new_fixture)
+git -C "$b/repo" worktree add -q -b resolver-linked-worktree "$b/linked" HEAD
+set_where_path "$b" "$b/linked/.git"
+RESOLVER_CWD="$b/linked"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a linked-worktree .git pointer file' "$b" \
+  'beads JSONL is inside the Git administrative directory'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+printf '%s\n' outside >"$b/link-target"
+unlink "$jsonl"
+ln -s "$b/link-target" "$jsonl"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a symlink JSONL' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+# A dangling symlink is the symlink state real `br` hands this check, and it is the one
+# `--recovery` must not mistake for the absent artifact it exists to name. Measured on
+# br 0.2.19, streams separated by redirection, against a scratch repository whose
+# `.beads/issues.jsonl` was a symlink: `br --no-auto-flush --no-auto-import where --json`
+# printed the canonical *target* when that target existed (a link to `../unrelated.jsonl`
+# resolved to `<repo>/unrelated.jsonl`, one outside the worktree to its outside path, one
+# to a directory to that directory), and printed the symlink pathname itself only when the
+# target did not exist. So a live link is inspected as the file `br` will write through it,
+# containment refuses one that leaves the worktree, and the stub above additionally covers
+# a path replaced by a symlink after `br` answered.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+unlink "$jsonl"
+ln -s "$b/repo/never-written.jsonl" "$jsonl"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a dangling symlink rather than calling it absent' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+# Absent is the one non-regular state `--recovery` exists to name. Anything else that
+# occupies the path is not the damaged export: consumers `cp` and diff the resolved name,
+# and a FIFO blocks that read indefinitely rather than failing.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+unlink "$jsonl"
+mkfifo "$jsonl"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a FIFO JSONL' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+unlink "$jsonl"
+mkdir -- "$jsonl"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a directory at the JSONL path' "$b" \
+  'beads JSONL worktree path is not a non-symlink regular file'
+
+b=$(new_fixture)
+set_where_path "$b" "$b/repo/."
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses dot as the final path component' "$b" \
+  'beads JSONL path has an unsafe final component'
+
+b=$(new_fixture)
+set_where_path "$b" "$b/repo/.."
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses dot-dot as the final path component' "$b" \
+  'beads JSONL path has an unsafe final component'
+
+b=$(new_fixture)
+outside="$b/outside.jsonl"
+printf '%s\n' outside >"$outside"
+set_where_path "$b" "$outside"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery still refuses a path outside the current worktree' "$b" \
+  'beads JSONL is outside the current worktree'
+
+b=$(new_fixture)
+printf '{}\n' >"$b/where.out"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery still refuses invalid workspace JSON' "$b" \
+  'cannot resolve exactly one beads JSONL'
+
+b=$(new_fixture)
+RESOLVER_ARGS=(--allow-everything)
+assert_refused 'an unknown option is refused' "$b" \
+  'usage: resolve-beads-jsonl [--allow-dirty|--recovery]'
+t='an unknown option refuses before br is invoked'
+if [[ -e "$b/br.calls" ]]; then fail "$t" 'br ran for an unparsed command line'
+else pass "$t"; fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -377,6 +377,7 @@ fi
 # expected object id is checked against the exact blob before update-index.
 cp "$b/staged.jsonl" "$b/reviewed.jsonl"
 printf '%s\n' '{"id":"changed-after-review"}' >"$jsonl"
+stale_oid=$(git -C "$b/repo" hash-object --no-filters "$jsonl")
 if (
   cd "$b/repo" || exit 98
   "$GIT_RUNNER" --literal-pathspecs add --expect-oid "$reviewed_oid" -- "$jsonl" \
@@ -390,6 +391,10 @@ elif ! grep -Fq 'no longer matches the reviewed object id' "$b/stale-add.stderr"
   fail "$t" "runner did not diagnose the stale review: $(<"$b/stale-add.stderr")"
 elif ! cmp -s "$b/reviewed.jsonl" "$b/after-stale-add.jsonl"; then
   fail "$t" 'runner changed the index after the reviewed bytes changed'
+elif git -C "$b/repo" cat-file -e "$stale_oid^{blob}" 2>/dev/null; then
+  fail "$t" 'runner persisted the unreviewed bytes as a dangling Git object'
+elif compgen -G "$b/repo/.git/beads-jsonl-add.*" >/dev/null; then
+  fail "$t" 'runner left the private clean-add snapshot behind'
 else
   pass "$t"
 fi
@@ -715,6 +720,10 @@ fi
 cp "$GIT_RUNNER" "$b/git-clean-no-ssh"
 sed -i 's/if _bjg_ssh=$(command -p -v ssh); then/if false; then/' \
   "$b/git-clean-no-ssh"
+if ! grep -Fq 'if false; then' "$b/git-clean-no-ssh"; then
+  fail 'clean Git runner disables SSH transport when trusted ssh is unavailable' \
+    'fixture could not disable trusted ssh discovery in the runner copy'
+fi
 chmod +x "$b/git-clean-no-ssh"
 command cat >"$b/repo/runner-path/ssh-from-config" <<'RUNNER_CONFIG_SSH'
 #!/bin/sh

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -622,6 +622,237 @@ else
   pass "$t"
 fi
 
+# The accepted helper path also covers authenticated `/usr/bin/env name`
+# interpreter semantics, distinct from the lexical-env spoof refusal.
+mkdir "$b/env-identity-helper-home" "$b/env-identity-helper-bin"
+printf '#!/usr/bin/env sh\nexit 0\n#\0binary-payload\n' \
+  >"$b/env-identity-helper-bin/git-credential-envfixture"
+chmod +x "$b/env-identity-helper-bin/git-credential-envfixture"
+HOME="$b/env-identity-helper-home" git config --global credential.helper envfixture
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/env-identity-helper-home" \
+    PATH="$b/env-identity-helper-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/env-identity-helper.stdout" 2>"$b/env-identity-helper.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner accepts trusted env helper with post-shebang NUL payload'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push to a closed local port unexpectedly succeeded'
+elif grep -Eq 'configured credential helper|credential helper (executable|has|env target)' \
+    "$b/env-identity-helper.stderr"; then
+  fail "$t" "runner rejected trusted env helper: $(<"$b/env-identity-helper.stderr")"
+else
+  pass "$t"
+fi
+
+# A named helper's outside pathname is not the end of its executable chain: the
+# kernel-selected absolute shebang interpreter must also stay outside the worktree.
+mkdir "$b/interpreter-helper-home" "$b/interpreter-helper-bin"
+command cat >"$b/repo/credential-interpreter" <<CREDENTIAL_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/credential-interpreter-ran'
+exec /bin/sh "\$@"
+CREDENTIAL_INTERPRETER
+chmod +x "$b/repo/credential-interpreter"
+command cat >"$b/interpreter-helper-bin/outside-interpreter" \
+  <<OUTSIDE_CREDENTIAL_INTERPRETER
+#!$b/repo/credential-interpreter
+exec /bin/sh "\$@"
+OUTSIDE_CREDENTIAL_INTERPRETER
+chmod +x "$b/interpreter-helper-bin/outside-interpreter"
+command cat >"$b/interpreter-helper-bin/git-credential-interpreter" \
+  <<CREDENTIAL_HELPER_SCRIPT
+#!$b/interpreter-helper-bin/outside-interpreter
+exit 1
+CREDENTIAL_HELPER_SCRIPT
+chmod +x "$b/interpreter-helper-bin/git-credential-interpreter"
+HOME="$b/interpreter-helper-home" git config --global credential.helper interpreter
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/interpreter-helper-home" \
+    PATH="$b/interpreter-helper-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/interpreter-helper.stdout" 2>"$b/interpreter-helper.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner validates a credential helper shebang interpreter'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push with a worktree helper interpreter unexpectedly succeeded'
+elif [[ -e "$b/credential-interpreter-ran" ]]; then
+  fail "$t" 'worktree credential-helper interpreter executed'
+elif ! grep -Fq 'credential helper resolves inside the current Git worktree' \
+    "$b/interpreter-helper.stderr"; then
+  fail "$t" "runner missed helper interpreter provenance: $(<"$b/interpreter-helper.stderr")"
+else
+  pass "$t"
+fi
+
+# The helper-chain parser must preserve the kernel's NUL termination semantics.
+mkdir "$b/nul-helper-home" "$b/nul-helper-bin"
+printf '#!%s\0suffix\nexit 1\n' "$b/repo/credential-interpreter" \
+  >"$b/nul-helper-bin/git-credential-nulinterpreter"
+chmod +x "$b/nul-helper-bin/git-credential-nulinterpreter"
+HOME="$b/nul-helper-home" git config --global credential.helper nulinterpreter
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/nul-helper-home" PATH="$b/nul-helper-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/nul-helper.stdout" 2>"$b/nul-helper.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses a NUL-bearing credential helper interpreter'
+if [[ $rc -eq 0 || -e "$b/credential-interpreter-ran" ]]; then
+  fail "$t" 'NUL-terminated credential-helper interpreter executed'
+elif ! grep -Fq 'credential helper has a NUL-bearing script interpreter' \
+    "$b/nul-helper.stderr"; then
+  fail "$t" "runner missed helper NUL semantics: $(<"$b/nul-helper.stderr")"
+else
+  pass "$t"
+fi
+
+# Credential helpers run under an explicit allowlist, not a language-by-language
+# startup-variable blacklist. A tiny authenticated HTTPS exchange proves the
+# helper ran while an arbitrary caller variable did not reach it.
+mkdir "$b/env-helper-home" "$b/env-helper-bin" "$b/env-helper-cache" \
+  "$b/env-helper-data" "$b/env-helper-state"
+command cat >"$b/env-helper-bin/git-credential-envprobe" <<ENV_HELPER
+#!/bin/sh
+env >'$b/env-helper.environment'
+if [ "\${1-}" = get ]; then
+  printf '%s\n' username=fixture password=fixture
+fi
+ENV_HELPER
+chmod +x "$b/env-helper-bin/git-credential-envprobe"
+HOME="$b/env-helper-home" git config --global credential.helper envprobe
+HOME="$b/env-helper-home" git config --global http.sslVerify false
+command cat >"$b/tls.crt" <<'TLS_CERTIFICATE'
+-----BEGIN CERTIFICATE-----
+MIIC6jCCAdKgAwIBAgIUUu85vjSHDsKkLH/tMZB8c5KrEM0wDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMCAXDTI2MDgxNDIxNTc0MFoYDzIxMjYw
+NzIxMjE1NzQwWjAUMRIwEAYDVQQDDAkxMjcuMC4wLjEwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCzBpYIrorf++3qWdJWwGiSX3VDytmWclTjo8iuEMOk
+WZqUSxQl5Muplol3NAq+PItYmOp1jfpiXU1ZdOd7Hh7XZY76KS57iZi9tCc5iJ9c
+Wf6n0/7+da1xhSvZKx09NC4cnsCv6003Gqw6dE4Uw93KtK+6gHr95caBAIS8Ni3C
+HvBBylbAs9vnN1xd85r5wOQFYhMva/namqYuvK7VPgBs3a1oYguML9zuFACd9o0l
+VoqjEwgReMDndF0n2sCf2+kQ0Xrz2t1DgYEjZvdWv1hxn8WP7shvffOxi56KOYlI
+MD+fc/E/oHFlq+Saq8vB9nMN+HnC2Bf/jTKZLj364FMhAgMBAAGjMjAwMA8GA1Ud
+EQQIMAaHBH8AAAEwHQYDVR0OBBYEFDKKCcgOewN8ZIrMX1huCt2NcswKMA0GCSqG
+SIb3DQEBCwUAA4IBAQA6aYOSZ8MqJUPWl0T4fMjZdqH9fjmCy1HYEgIZAElAJmlC
+77df85Z9FXpd2XVU5ZZZYwyep7FKvMRvypZSpTdxq2YwO4eFKrLs3ltjzVpUgP4S
+lxisD0Whm0FLA6T3wk3jgOQXenRDBba+LTGhRa1k9CiEGTpYIm4UX2+vhEkRMfYv
+12j5zjVELAyLJG5AcaI5U2Mv99iecxFbHTsETSYLmDS7eywgui3qdaSjb6zck4Ua
+oL5AtiGuQI0qf1DVrMSxjj43eqNXbHPGwEdi3vKriD5d1jFZRP7jgzlxbYbkBOrX
+MEaZDo11VnSCfU0xZuky+u8WMR8/6UVmVBxW/eef
+-----END CERTIFICATE-----
+TLS_CERTIFICATE
+command cat >"$b/tls.key" <<'TLS_PRIVATE_KEY'
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCzBpYIrorf++3q
+WdJWwGiSX3VDytmWclTjo8iuEMOkWZqUSxQl5Muplol3NAq+PItYmOp1jfpiXU1Z
+dOd7Hh7XZY76KS57iZi9tCc5iJ9cWf6n0/7+da1xhSvZKx09NC4cnsCv6003Gqw6
+dE4Uw93KtK+6gHr95caBAIS8Ni3CHvBBylbAs9vnN1xd85r5wOQFYhMva/namqYu
+vK7VPgBs3a1oYguML9zuFACd9o0lVoqjEwgReMDndF0n2sCf2+kQ0Xrz2t1DgYEj
+ZvdWv1hxn8WP7shvffOxi56KOYlIMD+fc/E/oHFlq+Saq8vB9nMN+HnC2Bf/jTKZ
+Lj364FMhAgMBAAECggEAE2qvcxmbLlfgof5D9ezAar+3tDaYCt0zn8zvwxFGZtjh
+DxxlfwaloCsXlborQB7I7j8HjuBrO6fq77ziLlRB/BKjwzYcOIHf8xNK/c53mkiY
+ehNgILEasqlC7Dbk4PJ73dbKB0p6AXP/IgfjQBVOROH7/TpaHJeDRBKOUut9YwRQ
+9aL33jpU+N8AagCm4q7T8k8AG0sI456CYXRSMWGoCw3wwNEhOwrAi9Jt7b3nbwdM
+zrYoQhauusT/tKRnxPSiXnJcxgJk1We2w+zL3XJZTagPNLISj/FLa7HKrjps10Gp
+pkhVOBBY9/tLh28XhQYJDPufZ1pMBSpIg7DfyVA2wQKBgQD7yKcaR2qNXoV+52aj
+aSXInQURhFtAR61JwZTXOvYfnaeTSuyKAgNd65sCZiWIBTfsB3TwQcOhzu3p9aID
+EnZDIvcrn8nGmWP4ZjnOjpIqU/CR+yK+BdDoWA8a4zmIW0bX0wubWe4UYh4kS9mc
+VzVP0P8TxGpTBnYkeSGmXiPcjQKBgQC2Bgisp+Ivu7Gsu8571rPvbXGFQlzImt9Q
+nVHG+V4oGFLr6mSTr3ycKWgTGdt+iXmsXZBM0VSR3JrRWrMI/goxRWqwadmqevyu
+fxncx6ogt8hhp3qr+pvHmrQJfHYrOCqiJV37H4278IckVVqBrD9DHIkozdF7zvDR
+Z0900HRt5QKBgQDBnjqKJdMVZVNpFE9EaE5K6ByGrO5zDut+JWPs4wVzqIu948bk
+Fco7BjwMazp/T+wCEHXnb9sd6f/ggyiUDjVtSU0jedvzYe+TjCD164MRE72StLmx
+wM02bskm1wdeCTsAKuXpEA3aFN2y8bUk2ZdAiqosrEVLFVPylke/JPOU3QKBgDSc
+098L+63uY7HY6xsSeRoImVp6TxVQ5qGHh36qz5NpTHaSXpXtkGgW89UpkS8nD3tJ
+5A7AJuCuUjWXMM61lz6coPTy8456VBUf+dq9/6fLV2kanrOdEXAFgGqJhiKB7pjF
+kj+m5DHhmT5gSXPX1MVSNzcLHrTZoPP2F5pdMnodAoGBALbX36yiQaIx9NpFsdjD
+R9S8MH2GGJh23i/463s6SKmlmuCVQbS28NyL5CDbdDKVC9/DfRplmvd/IVae3OZO
+YCxNu9+fA2IG/nZSZjaNqzwo4EH2O7oR0JYnxfXXiQm2393Wpte2oQN48EwbI6Lv
+87Pt1APuH4gqBMlQrE44iqil
+-----END PRIVATE KEY-----
+TLS_PRIVATE_KEY
+command cat >"$b/auth-server.py" <<'AUTH_SERVER'
+import http.server
+import pathlib
+import ssl
+import sys
+
+port_file, cert_file, key_file = map(pathlib.Path, sys.argv[1:])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.headers.get("Authorization"):
+            self.send_response(403)
+        else:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="fixture"')
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *_args):
+        pass
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.load_cert_chain(cert_file, key_file)
+server.socket = context.wrap_socket(server.socket, server_side=True)
+server.timeout = 5
+port_file.write_text(str(server.server_port))
+for _ in range(2):
+    server.handle_request()
+server.server_close()
+AUTH_SERVER
+trusted_python=$(command -p -v python3)
+"$trusted_python" "$b/auth-server.py" "$b/auth-server.port" \
+  "$b/tls.crt" "$b/tls.key" >"$b/auth-server.stdout" \
+  2>"$b/auth-server.stderr" &
+auth_server_pid=$!
+auth_wait=0
+while ((auth_wait < 200)) && [[ ! -s "$b/auth-server.port" ]]; do
+  sleep 0.01
+  auth_wait=$((auth_wait + 1))
+done
+if [[ -s "$b/auth-server.port" ]]; then
+  auth_server_port=$(<"$b/auth-server.port")
+  git -C "$b/repo" remote add helper-https \
+    "https://127.0.0.1:$auth_server_port/repository"
+  if (
+    cd "$b/repo" || exit 98
+    HOME="$b/env-helper-home" PATH="$b/env-helper-bin:$SYSTEM_PATH" \
+      XDG_CACHE_HOME="$b/env-helper-cache" XDG_DATA_HOME="$b/env-helper-data" \
+      XDG_STATE_HOME="$b/env-helper-state" \
+      NO_PROXY=127.0.0.1 no_proxy=127.0.0.1 \
+      UNRELATED_WORKTREE_STARTUP="$b/repo/startup" \
+      ZDOTDIR="$b/repo" JAVA_TOOL_OPTIONS="-javaagent:$b/repo/agent.jar" \
+      "$GIT_RUNNER" push --remote helper-https --branch "$push_branch" \
+        --expect-head "$push_head" \
+      >"$b/env-helper.stdout" 2>"$b/env-helper.stderr"
+  ); then rc=0; else rc=$?; fi
+else
+  rc=99
+fi
+wait "$auth_server_pid" || :
+t='clean Git push gives credential helpers only the explicit environment allowlist'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'fixture HTTPS push unexpectedly succeeded'
+elif [[ ! -s "$b/env-helper.environment" ]]; then
+  fail "$t" "credential helper did not run: $(<"$b/env-helper.stderr")"
+elif grep -Eq '^(UNRELATED_WORKTREE_STARTUP|ZDOTDIR|JAVA_TOOL_OPTIONS)=' \
+    "$b/env-helper.environment"; then
+  fail "$t" 'credential helper inherited a caller startup variable'
+elif ! grep -Fxq "XDG_CACHE_HOME=$b/env-helper-cache" \
+    "$b/env-helper.environment"; then
+  fail "$t" 'credential helper lost the validated XDG cache location'
+else
+  pass "$t"
+fi
+
 # A store path outside the worktree is not sufficient if its inode is also
 # reachable through a worktree hard link.
 mkdir "$b/store-helper-home"
@@ -1091,21 +1322,27 @@ command cat >"$b/mixed-invalid-bin/audit-mixed-valid" <<MIXED_VALID_AUDIT
 #!/bin/sh
 printf '%s\n' valid >'$b/mixed-valid-audit-ran'
 MIXED_VALID_AUDIT
-command cat >"$b/mixed-invalid-bin/unrelated-xonly" <<'MIXED_XONLY'
-#!/missing/interpreter
+command cat >"$b/repo/mixed-worktree-interpreter" <<MIXED_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/mixed-interpreter-ran'
+exit 1
+MIXED_INTERPRETER
+chmod +x "$b/repo/mixed-worktree-interpreter"
+command cat >"$b/mixed-invalid-bin/invalid-sibling" <<MIXED_INVALID_SIBLING
+#!$b/repo/mixed-worktree-interpreter
 exit 0
-MIXED_XONLY
+MIXED_INVALID_SIBLING
 chmod +x "$b/mixed-invalid-bin/audit-mixed-valid"
-chmod 111 "$b/mixed-invalid-bin/unrelated-xonly"
+chmod +x "$b/mixed-invalid-bin/invalid-sibling"
 if (
   cd "$b/repo" || exit 98
   PATH="$b/mixed-invalid-bin:$SYSTEM_PATH" \
     "$GIT_RUNNER" run-audit-tool audit-mixed-valid \
     >"$b/mixed-valid.stdout" 2>"$b/mixed-valid.stderr"
 ); then rc=0; else rc=$?; fi
-chmod 755 "$b/mixed-invalid-bin/unrelated-xonly"
 t='clean audit-tool runner requires the selected parent to remain admitted'
-if [[ $rc -eq 0 || -e "$b/mixed-valid-audit-ran" ]]; then
+if [[ $rc -eq 0 || -e "$b/mixed-valid-audit-ran" \
+      || -e "$b/mixed-interpreter-ran" ]]; then
   fail "$t" 'runner executed a selected tool from an omitted mixed directory'
 else
   pass "$t"
@@ -1301,6 +1538,50 @@ if (
 t='clean audit-tool runner refuses a CR-bearing worktree interpreter'
 if [[ $rc -eq 0 || -e "$b/audit-cr-interpreter-ran" ]]; then
   fail "$t" 'CR-bearing worktree shebang interpreter executed'
+else
+  pass "$t"
+fi
+
+# A NUL terminates the kernel interpreter path but disappears from Bash `read`.
+audit_nul_interpreter="$b/repo/audit-nul-interpreter"
+command cat >"$audit_nul_interpreter" <<AUDIT_NUL_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/audit-nul-interpreter-ran'
+exec /bin/sh "\$@"
+AUDIT_NUL_INTERPRETER
+chmod +x "$audit_nul_interpreter"
+mkdir "$b/outside-nul-shebang-bin"
+printf '#!%s\0suffix\nexit 0\n' "$audit_nul_interpreter" \
+  >"$b/outside-nul-shebang-bin/audit-nul-parent"
+chmod +x "$b/outside-nul-shebang-bin/audit-nul-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-nul-shebang-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-nul-parent \
+    >"$b/audit-nul.stdout" 2>"$b/audit-nul.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner refuses a NUL-bearing worktree interpreter'
+if [[ $rc -eq 0 || -e "$b/audit-nul-interpreter-ran" ]]; then
+  fail "$t" 'NUL-terminated worktree shebang interpreter executed'
+else
+  pass "$t"
+fi
+
+# NUL after the shebang newline is script payload, not interpreter data.
+mkdir "$b/outside-postline-nul-bin"
+printf '#!/bin/sh\nprintf valid >%s\nexit 0\n#\0binary-payload\n' \
+  "$b/audit-postline-nul-ran" \
+  >"$b/outside-postline-nul-bin/audit-postline-nul"
+chmod +x "$b/outside-postline-nul-bin/audit-postline-nul"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-postline-nul-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-postline-nul \
+    >"$b/audit-postline-nul.stdout" 2>"$b/audit-postline-nul.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner accepts NUL after the shebang line'
+if [[ $rc -ne 0 || ! -e "$b/audit-postline-nul-ran" ]]; then
+  fail "$t" "post-shebang NUL audit fixture exit $rc: $(<"$b/audit-postline-nul.stderr")"
 else
   pass "$t"
 fi
@@ -1763,6 +2044,33 @@ if [[ -e "$b/worktree-cr-interpreter-ran" ]]; then
   fail 'a CR-bearing worktree shebang interpreter is refused' \
     'the CR-bearing worktree interpreter executed'
 fi
+
+# Bash drops NUL while reading, but the kernel terminates the interpreter pathname
+# there. The byte-preserving probe must refuse this different parse.
+b=$(new_fixture)
+mkdir "$b/outside-bin"
+command cat >"$b/repo/worktree-nul-interpreter" <<WORKTREE_NUL_INTERPRETER
+#!/bin/sh
+printf '%s\n' interpreter >'$b/worktree-nul-interpreter-ran'
+exec /bin/sh "\$@"
+WORKTREE_NUL_INTERPRETER
+chmod +x "$b/repo/worktree-nul-interpreter"
+printf '#!%s\0suffix\ncat \"$BR_OUTPUT\"\n' "$b/repo/worktree-nul-interpreter" \
+  >"$b/outside-bin/br"
+chmod +x "$b/outside-bin/br"
+assert_refused 'a NUL-bearing worktree shebang interpreter is refused' "$b" \
+  'br has a NUL-bearing script interpreter' "$b/outside-bin:$SYSTEM_PATH"
+if [[ -e "$b/worktree-nul-interpreter-ran" ]]; then
+  fail 'a NUL-bearing worktree shebang interpreter is refused' \
+    'the NUL-terminated worktree interpreter executed'
+fi
+
+# A later NUL belongs to the script body and must not poison interpreter proof.
+b=$(new_fixture)
+printf '#!/bin/sh\ncat "$BR_OUTPUT"\nexit 0\n#\0binary-payload\n' >"$b/bin/br"
+chmod +x "$b/bin/br"
+assert_success 'NUL after the br shebang line remains valid payload' \
+  "$b" "$(<"$b/jsonl-path")"
 
 b=$(new_fixture)
 mkdir "$b/repo/bin"

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -1007,6 +1007,28 @@ else
   pass "$t"
 fi
 
+# Caller-exported values cannot pre-populate the runner's private root cache and
+# make a worktree tool appear to live under a different repository.
+command cat >"$b/repo/audit-tool-path/audit-cache-poison" <<CACHE_POISON_TOOL
+#!/bin/sh
+printf '%s\n' poison >'$b/audit-cache-poison-ran'
+CACHE_POISON_TOOL
+chmod +x "$b/repo/audit-tool-path/audit-cache-poison"
+if (
+  cd "$b/repo" || exit 98
+  _bjg_audit_root_loaded=true _bjg_audit_root=/not-the-repository \
+    _bjg_audit_root_raw=/not-the-repository \
+    PATH="$b/repo/audit-tool-path:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-cache-poison \
+    >"$b/audit-cache-poison.stdout" 2>"$b/audit-cache-poison.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner ignores an inherited private root cache'
+if [[ $rc -eq 0 || -e "$b/audit-cache-poison-ran" ]]; then
+  fail "$t" 'caller cache poisoning admitted a worktree audit tool'
+else
+  pass "$t"
+fi
+
 # A validated outside tool receives only the explicit audit environment, not
 # interpreter startup/code-injection variables.
 mkdir "$b/outside-audit-bin"
@@ -1029,6 +1051,245 @@ if (
 t='clean audit-tool runner strips startup state from outside tools'
 if [[ $rc -ne 0 || ! -e "$b/audit-probe-ran" ]]; then
   fail "$t" "outside audit probe exit $rc: $(<"$b/audit-probe.stderr")"
+else
+  pass "$t"
+fi
+
+# The clean descendant PATH must not expose a nominally outside command whose
+# inode is also repository-controlled through a hard link.
+mkdir "$b/outside-hardlink-bin"
+command cat >"$b/repo/hardlinked-child" <<HARDLINKED_AUDIT_CHILD
+#!/bin/sh
+printf '%s\n' child >'$b/hardlinked-audit-child-ran'
+HARDLINKED_AUDIT_CHILD
+chmod +x "$b/repo/hardlinked-child"
+ln "$b/repo/hardlinked-child" "$b/outside-hardlink-bin/audit-child"
+command cat >"$b/outside-hardlink-bin/audit-parent" <<HARDLINKED_AUDIT_PARENT
+#!/bin/sh
+audit-child
+printf '%s\n' parent >'$b/hardlinked-audit-parent-ran'
+HARDLINKED_AUDIT_PARENT
+chmod +x "$b/outside-hardlink-bin/audit-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-hardlink-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-parent \
+    >"$b/hardlinked-audit.stdout" 2>"$b/hardlinked-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH refuses a hard-linked worktree descendant'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner admitted an outside PATH directory with a hard-linked child'
+elif [[ -e "$b/hardlinked-audit-child-ran" \
+        || -e "$b/hardlinked-audit-parent-ran" ]]; then
+  fail "$t" 'runner executed through a hard-linked audit descendant'
+else
+  pass "$t"
+fi
+
+# Canonicalization must not turn one validated caller entry into multiple runtime
+# PATH entries. A `:` in the real directory name would otherwise expose the
+# worktree path encoded after it without scanning that injected directory.
+mkdir "$b/repo/colon-child-bin"
+command cat >"$b/repo/colon-child-bin/audit-colon-child" <<COLON_AUDIT_CHILD
+#!/bin/sh
+printf '%s\n' child >'$b/colon-audit-child-ran'
+COLON_AUDIT_CHILD
+chmod +x "$b/repo/colon-child-bin/audit-colon-child"
+colon_audit_dir="$b/colon-prefix:$b/repo/colon-child-bin"
+mkdir -p "$colon_audit_dir"
+ln -s "$colon_audit_dir" "$b/colon-audit-alias"
+command cat >"$colon_audit_dir/audit-colon-parent" <<COLON_AUDIT_PARENT
+#!/bin/sh
+audit-colon-child
+printf '%s\n' parent >'$b/colon-audit-parent-ran'
+COLON_AUDIT_PARENT
+chmod +x "$colon_audit_dir/audit-colon-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/colon-audit-alias:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-colon-parent \
+    >"$b/colon-audit.stdout" 2>"$b/colon-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH refuses a colon-bearing canonical directory'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner serialized one validated directory as multiple PATH entries'
+elif [[ -e "$b/colon-audit-child-ran" || -e "$b/colon-audit-parent-ran" ]]; then
+  fail "$t" 'runner executed through an injected worktree PATH entry'
+else
+  pass "$t"
+fi
+
+# Preserve trailing newlines while canonicalizing. Otherwise an alias to `dir\n`
+# is checked as sibling `dir`, while execution through the alias reaches different
+# bytes.
+newline_audit_dir="$b/newline-audit"$'\n'
+mkdir "$b/newline-audit" "$newline_audit_dir"
+ln -s "$newline_audit_dir" "$b/newline-audit-alias"
+command cat >"$b/newline-audit/audit-newline-parent" <<'SAFE_NEWLINE_PARENT'
+#!/bin/sh
+exit 0
+SAFE_NEWLINE_PARENT
+command cat >"$newline_audit_dir/audit-newline-parent" <<NEWLINE_AUDIT_PARENT
+#!/bin/sh
+printf '%s\n' parent >'$b/newline-audit-parent-ran'
+NEWLINE_AUDIT_PARENT
+chmod +x "$b/newline-audit/audit-newline-parent" \
+  "$newline_audit_dir/audit-newline-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/newline-audit-alias:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-newline-parent \
+    >"$b/newline-audit.stdout" 2>"$b/newline-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH preserves and refuses a trailing-newline directory'
+if [[ $rc -eq 0 || -e "$b/newline-audit-parent-ran" ]]; then
+  fail "$t" 'runner validated a different sibling than the executed audit tool'
+else
+  pass "$t"
+fi
+
+# Execute/search permission is insufficient: the runner must be able to enumerate
+# every name that a validated parent could resolve in an admitted directory.
+mkdir "$b/nonlist-audit-bin"
+command cat >"$b/repo/audit-nonlist-child" <<NONLIST_AUDIT_CHILD
+#!/bin/sh
+printf '%s\n' child >'$b/nonlist-audit-child-ran'
+NONLIST_AUDIT_CHILD
+chmod +x "$b/repo/audit-nonlist-child"
+ln "$b/repo/audit-nonlist-child" "$b/nonlist-audit-bin/audit-nonlist-child"
+command cat >"$b/nonlist-audit-bin/audit-nonlist-parent" <<NONLIST_AUDIT_PARENT
+#!/bin/sh
+audit-nonlist-child
+printf '%s\n' parent >'$b/nonlist-audit-parent-ran'
+NONLIST_AUDIT_PARENT
+chmod +x "$b/nonlist-audit-bin/"*
+chmod 111 "$b/nonlist-audit-bin"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/nonlist-audit-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-nonlist-parent \
+    >"$b/nonlist-audit.stdout" 2>"$b/nonlist-audit.stderr"
+); then rc=0; else rc=$?; fi
+chmod 755 "$b/nonlist-audit-bin"
+t='clean audit-tool PATH refuses a search-only non-listable directory'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner admitted a caller directory it could not enumerate'
+elif [[ -e "$b/nonlist-audit-child-ran" || -e "$b/nonlist-audit-parent-ran" ]]; then
+  fail "$t" 'runner executed an unenumerated audit descendant'
+else
+  pass "$t"
+fi
+
+# Compatibility control: an outside symlinked parent can invoke an outside
+# symlinked child after every exposed executable has passed the same provenance
+# and single-link validation.
+mkdir "$b/symlink-audit-bin"
+command cat >"$b/symlink-audit-bin/audit-child-real" <<SYMLINK_AUDIT_CHILD
+#!/bin/sh
+[ "\$*" = 'exact child argument' ] || exit 93
+printf '%s\n' child >'$b/symlink-audit-child-ran'
+SYMLINK_AUDIT_CHILD
+command cat >"$b/symlink-audit-bin/audit-parent-real" <<SYMLINK_AUDIT_PARENT
+#!/bin/sh
+audit-symlink-child exact child argument
+printf '%s\n' parent >'$b/symlink-audit-parent-ran'
+SYMLINK_AUDIT_PARENT
+chmod +x "$b/symlink-audit-bin/"*-real
+ln -s audit-child-real "$b/symlink-audit-bin/audit-symlink-child"
+ln -s audit-parent-real "$b/symlink-audit-bin/audit-symlink-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/symlink-audit-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-symlink-parent \
+    >"$b/symlink-audit.stdout" 2>"$b/symlink-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH keeps validated symlinked parents and descendants working'
+if [[ $rc -ne 0 || ! -e "$b/symlink-audit-child-ran" \
+      || ! -e "$b/symlink-audit-parent-ran" ]]; then
+  fail "$t" "validated symlink wrapper fixture exit $rc: $(<"$b/symlink-audit.stderr")"
+else
+  pass "$t"
+fi
+
+# A moderately populated unrelated caller directory remains compatible while its
+# entries count against the one global streamed-admission budget.
+mkdir "$b/large-audit-bin"
+command cat >"$b/large-audit-bin/audit-large-parent" <<LARGE_AUDIT_PARENT
+#!/bin/sh
+printf '%s\n' parent >'$b/large-audit-parent-ran'
+LARGE_AUDIT_PARENT
+chmod +x "$b/large-audit-bin/audit-large-parent"
+large_entry=1
+while ((large_entry <= 65)); do
+  : >"$b/large-audit-bin/non-executable-$large_entry"
+  large_entry=$((large_entry + 1))
+done
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/large-audit-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-large-parent \
+    >"$b/large-audit.stdout" 2>"$b/large-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH accepts a populated directory within the global budget'
+if [[ $rc -ne 0 || ! -e "$b/large-audit-parent-ran" ]]; then
+  fail "$t" 'runner imposed an artificial 64-entry per-directory cliff'
+else
+  pass "$t"
+fi
+
+# More than 1,024 total exposed entries is refused before the selected parent can
+# run, regardless of how many of those names are executable.
+mkdir "$b/over-budget-audit-bin"
+command cat >"$b/over-budget-audit-bin/audit-over-budget-parent" <<OVER_BUDGET_PARENT
+#!/bin/sh
+printf '%s\n' parent >'$b/over-budget-audit-parent-ran'
+OVER_BUDGET_PARENT
+chmod +x "$b/over-budget-audit-bin/audit-over-budget-parent"
+over_budget_entry=1
+while ((over_budget_entry <= 1025)); do
+  : >"$b/over-budget-audit-bin/non-executable-$over_budget_entry"
+  over_budget_entry=$((over_budget_entry + 1))
+done
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/over-budget-audit-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-over-budget-parent \
+    >"$b/over-budget-audit.stdout" 2>"$b/over-budget-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH refuses more than the global streamed entry budget'
+if [[ $rc -eq 0 || -e "$b/over-budget-audit-parent-ran" ]]; then
+  fail "$t" 'runner admitted more than 1,024 caller PATH entries'
+else
+  pass "$t"
+fi
+
+# The separate directory ceiling bounds find/shell workers even when every
+# directory is nearly empty.
+many_audit_path=
+many_directory=1
+while ((many_directory <= 65)); do
+  mkdir "$b/many-audit-bin-$many_directory"
+  : >"$b/many-audit-bin-$many_directory/non-executable"
+  if [[ -n "$many_audit_path" ]]; then
+    many_audit_path=$many_audit_path:
+  fi
+  many_audit_path=$many_audit_path$b/many-audit-bin-$many_directory
+  many_directory=$((many_directory + 1))
+done
+command cat >"$b/many-audit-bin-1/audit-many-parent" <<MANY_AUDIT_PARENT
+#!/bin/sh
+printf '%s\n' parent >'$b/many-audit-parent-ran'
+MANY_AUDIT_PARENT
+chmod +x "$b/many-audit-bin-1/audit-many-parent"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$many_audit_path:$SYSTEM_PATH" \
+    "$GIT_RUNNER" run-audit-tool audit-many-parent \
+    >"$b/many-audit.stdout" 2>"$b/many-audit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool PATH bounds the combined caller directory count'
+if [[ $rc -eq 0 || -e "$b/many-audit-parent-ran" ]]; then
+  fail "$t" 'runner admitted more than the bounded caller directory count'
 else
   pass "$t"
 fi

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -264,7 +264,7 @@ fi
 # the otherwise hardened implementation ran the `git` and `cmp` sentinels.
 b=$(new_fixture)
 mkdir "$b/repo/evil"
-for utility in bash git cmp od grep mktemp unlink rmdir; do
+for utility in bash git cmp od grep mktemp unlink rmdir readlink stat; do
   trusted_utility=$(command -p -v "$utility") || {
     fail 'hostile startup fixture setup' "cannot locate $utility in the POSIX utility path"
     continue
@@ -520,6 +520,11 @@ printf '%s\n' outside >"$outside"
 set_where_path "$b" "$outside"
 assert_refused 'path outside the current worktree is refused' "$b" \
   'beads JSONL is outside the current worktree'
+
+b=$(new_fixture)
+ln "$(<"$b/jsonl-path")" "$b/outside-hardlink"
+assert_refused 'a clean JSONL with an outside hard-link alias is refused' "$b" \
+  'beads JSONL worktree path has multiple hard links'
 
 b=$(new_fixture)
 printf '%s\n' staged >>"$(<"$b/jsonl-path")"
@@ -840,6 +845,17 @@ set_where_path "$b" "$b/repo/.git/HEAD"
 RESOLVER_ARGS=(--recovery)
 assert_refused '--recovery refuses a Git administrative HEAD path' "$b" \
   'beads JSONL is inside the Git administrative directory'
+
+# Path checks alone cannot see that the in-worktree pathname aliases an
+# administrative inode. Writing a recovery copy through this hard link would
+# overwrite .git/HEAD.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+unlink "$jsonl"
+ln "$b/repo/.git/HEAD" "$jsonl"
+RESOLVER_ARGS=(--recovery)
+assert_refused '--recovery refuses a hard link to Git administrative state' "$b" \
+  'beads JSONL worktree path has multiple hard links'
 
 # In a linked worktree, `<worktree>/.git` is a regular pointer file rather than
 # the directory returned by `rev-parse --git-dir`. It is administrative state

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -99,11 +99,11 @@ snapshot_fixture() {
   resolved=$(<"$base/where-path")
   {
     printf 'STATUS\n'
-    git -C "$repo" status --porcelain=v2 -z --untracked-files=all
+    git -c core.fsmonitor=false -C "$repo" status --porcelain=v2 -z --untracked-files=all
     printf '\nSTAGE\n'
-    git -C "$repo" ls-files --stage -z
+    git -c core.fsmonitor=false -C "$repo" ls-files --stage -z
     printf '\nFLAGS\n'
-    git -C "$repo" ls-files -v -z
+    git -c core.fsmonitor=false -C "$repo" ls-files -v -z
     snapshot_one_path actual "$actual"
     if [[ "$resolved" != "$actual" ]]; then
       snapshot_one_path resolved "$resolved"
@@ -237,6 +237,26 @@ printf '%s\n' 'resolve-beads-jsonl fixtures'
 
 b=$(new_fixture)
 assert_success 'clean tracked JSONL resolves' "$b" "$(<"$b/jsonl-path")"
+
+# Index-reading Git commands must not execute a repository-configured fsmonitor
+# hook. Prime the hook once, erase its marker, then keep the fixture snapshots
+# on their own explicit hook-disabled path so only the resolver is measured.
+b=$(new_fixture)
+command cat >"$b/fsmonitor-hook" <<FSMONITOR_EXECUTION_HOOK
+#!/bin/sh
+printf '%s\n' "\$*" >>"$b/fsmonitor-hook-ran"
+printf 'resolver-fixture-token\\0'
+FSMONITOR_EXECUTION_HOOK
+chmod +x "$b/fsmonitor-hook"
+git -C "$b/repo" config core.fsmonitor "$b/fsmonitor-hook"
+git -C "$b/repo" status --porcelain >/dev/null
+rm -f "$b/fsmonitor-hook-ran"
+assert_success 'resolver Git inspection disables repository fsmonitor hooks' \
+  "$b" "$(<"$b/jsonl-path")"
+if [[ -e "$b/fsmonitor-hook-ran" ]]; then
+  fail 'resolver Git inspection disables repository fsmonitor hooks' \
+    "fsmonitor hook executed: $(tr '\n' ',' <"$b/fsmonitor-hook-ran")"
+fi
 
 # Neither the outer launcher nor the proof may pick up checkout-controlled
 # standard utilities from PATH, a BASH_ENV startup file, or exported functions.
@@ -747,22 +767,18 @@ RESOLVER_ARGS=(--allow-dirty)
 assert_refused '--allow-dirty retains worktree containment' "$b" \
   'beads JSONL is outside the current worktree'
 
-# A file system monitor that misses a write is the one hidden state `ls-files -v` cannot
-# report: the entry keeps its fsmonitor-valid bit, so `-v` prints `H` and Git answers from
-# that bit. Measured on git 2.53.0 with the stub monitor above: after appending to the
-# tracked JSONL, `git status --porcelain` and `git diff --name-only` each printed zero
-# bytes at exit 0, `ls-files -v` printed `H`, and only `ls-files -f` printed `h`. The
-# consumers of this mode read that same status and `git diff HEAD` to decide what the
-# following `br sync --flush-only` may overwrite, so the cache would hand them a
-# clean-looking review of a file whose bead bodies differ.
+# A stale monitor may claim a hand edit does not exist, but this mode deliberately
+# permits content differences. The resolver and every documented consumer force
+# core.fsmonitor=false, so the later status/diff sees the bytes instead of trusting
+# that stale answer; resolution need not reject the difference itself.
 b=$(new_fixture)
-t='--allow-dirty refuses a modification the fsmonitor cache hides'
+t='--allow-dirty permits content differences despite a stale fsmonitor cache'
 if ! mark_fsmonitor_valid "$b"; then
   fail "$t" 'fixture could not mark the JSONL entry fsmonitor-valid'
 else
   printf '%s\n' '{"id":"hand-edit"}' >>"$(<"$b/jsonl-path")"
   RESOLVER_ARGS=(--allow-dirty)
-  assert_refused "$t" "$b" 'beads JSONL modification is hidden by the fsmonitor cache'
+  assert_success "$t" "$b" "$(<"$b/jsonl-path")"
 fi
 
 # The mode proof must also bypass a stale fsmonitor answer. With core.filemode=true,
@@ -794,8 +810,8 @@ else
   assert_success "$t" "$b" "$jsonl"
 fi
 
-# The default mode needs no cache check of its own: it compares the worktree bytes, which
-# no index bit can answer for. That is why the check above belongs to `--allow-dirty`.
+# The default mode compares raw worktree bytes, so it refuses the same edit
+# independently of Git's cached answer.
 b=$(new_fixture)
 t='the default mode refuses a modification the fsmonitor cache hides'
 if ! mark_fsmonitor_valid "$b"; then

--- a/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
+++ b/skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test
@@ -7,6 +7,7 @@ set -euo pipefail
 
 HERE=$(cd "$(dirname "$0")" && pwd -P)
 RESOLVER="$HERE/resolve-beads-jsonl"
+GIT_RUNNER="$HERE/git-clean"
 SYSTEM_PATH=$PATH
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -238,6 +239,791 @@ printf '%s\n' 'resolve-beads-jsonl fixtures'
 b=$(new_fixture)
 assert_success 'clean tracked JSONL resolves' "$b" "$(<"$b/jsonl-path")"
 
+# The same validated br boundary owns later reads and mutations; caller
+# functions/PATH must not reappear after JSONL resolution.
+b=$(new_fixture)
+br() {
+  printf '%s\n' ran >"$HOSTILE_BR_RUNNER_RAN"
+  return 0
+}
+export -f br
+if (
+  cd "$b/repo" || exit 98
+  HOSTILE_BR_RUNNER_RAN="$b/hostile-br-runner-ran" \
+    BR_CALLS="$b/br.calls" BR_MUTATION="$b/br.mutation" BR_OUTPUT="$b/where.out" \
+    PATH="$b/bin:$SYSTEM_PATH" \
+    "$RESOLVER" --run-br sync --flush-only \
+    >"$b/run-br.stdout" 2>"$b/run-br.stderr"
+); then rc=0; else rc=$?; fi
+unset -f br
+t='validated br runner ignores caller functions for mutations'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/run-br.stderr")"
+elif [[ -e "$b/hostile-br-runner-ran" ]]; then
+  fail "$t" 'runner invoked the caller br function'
+elif [[ ! -e "$b/br.calls" || $(<"$b/br.calls") != 'sync --flush-only' ]]; then
+  fail "$t" 'runner did not invoke the validated br with exact arguments'
+elif [[ ! -e "$b/br.mutation" ]]; then
+  fail "$t" 'fixture did not observe the mutation-shaped br invocation'
+else
+  pass "$t"
+fi
+
+# Audit decisions use the same trusted-tool boundary for jq; a caller function
+# cannot forge graph IDs, Claude state, or other JSON-derived control flow.
+b=$(new_fixture)
+jq() {
+  printf '%s\n' ran >"$HOSTILE_JQ_RUNNER_RAN"
+  printf '%s\n' forged
+  return 0
+}
+export -f jq
+if (
+  cd "$b/repo" || exit 98
+  HOSTILE_JQ_RUNNER_RAN="$b/hostile-jq-runner-ran" \
+    PATH="$b/bin:$SYSTEM_PATH" \
+    "$RESOLVER" --run-jq -er '.value' \
+    >"$b/run-jq.stdout" 2>"$b/run-jq.stderr" <<<'{"value":"trusted"}'
+); then rc=0; else rc=$?; fi
+unset -f jq
+t='validated jq runner ignores caller functions for audit decisions'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/run-jq.stderr")"
+elif [[ -e "$b/hostile-jq-runner-ran" ]]; then
+  fail "$t" 'runner invoked the caller jq function'
+elif [[ $(<"$b/run-jq.stdout") != trusted ]]; then
+  fail "$t" 'runner did not invoke validated jq with the exact arguments'
+else
+  pass "$t"
+fi
+
+# Consumer Git runs through the installed sibling so caller repository/index
+# selectors and PATH shims cannot falsify a post-resolution diff.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+alternate_index="$b/alternate.index"
+GIT_INDEX_FILE="$alternate_index" git -C "$b/repo" read-tree HEAD
+printf '%s\n' staged-through-real-index >>"$jsonl"
+git -C "$b/repo" add -- .beads/issues.jsonl
+git -C "$b/repo" show HEAD:.beads/issues.jsonl >"$jsonl"
+printf '%s\n' '.beads/issues.jsonl -diff' >"$b/repo/.gitattributes"
+mkdir "$b/repo/runner-path"
+command cat >"$b/repo/runner-path/git" <<'RUNNER_PATH_GIT'
+#!/bin/sh
+printf '%s\n' ran >"$RUNNER_PATH_GIT_RAN"
+exit 0
+RUNNER_PATH_GIT
+chmod +x "$b/repo/runner-path/git"
+snapshot_fixture "$b" "$b/before"
+if (
+  cd "$b/repo" || exit 98
+  GIT_INDEX_FILE="$alternate_index" RUNNER_PATH_GIT_RAN="$b/runner-path-git-ran" \
+    PATH="$b/repo/runner-path:$SYSTEM_PATH" \
+    "$GIT_RUNNER" --literal-pathspecs diff --cached -- .beads/issues.jsonl \
+    >"$b/runner.stdout" 2>"$b/runner.stderr"
+); then rc=0; else rc=$?; fi
+snapshot_fixture "$b" "$b/after"
+t='clean Git runner ignores inherited index and PATH overrides'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/runner.stderr")"
+elif [[ ! -s "$b/runner.stdout" ]]; then
+  fail "$t" 'runner let an alternate index hide the staged diff'
+elif ! grep -Fq -- 'staged-through-real-index' "$b/runner.stdout"; then
+  fail "$t" 'runner let binary attributes hide the staged JSON body'
+elif [[ -s "$b/runner.stderr" ]]; then
+  fail "$t" "unexpected stderr: $(<"$b/runner.stderr")"
+elif [[ -e "$b/runner-path-git-ran" ]]; then
+  fail "$t" 'runner executed the worktree PATH shim'
+elif ! cmp -s "$b/before" "$b/after"; then
+  fail "$t" 'runner changed repository state'
+else
+  pass "$t"
+fi
+
+# `git add` normally executes worktree-selected clean filters. The runner stages
+# the exact bytes with hash-object --no-filters plus update-index instead.
+b=$(new_fixture)
+jsonl=$(<"$b/jsonl-path")
+command cat >"$b/repo/filter-clean" <<FILTER_CLEAN
+#!/bin/sh
+printf '%s\n' ran >"$b/filter-ran"
+printf '%s\n' filtered
+FILTER_CLEAN
+chmod +x "$b/repo/filter-clean"
+printf '%s\n' '.beads/issues.jsonl filter=fixture' >"$b/repo/.gitattributes"
+git -C "$b/repo" config filter.fixture.clean "$b/repo/filter-clean"
+printf '%s\n' '{"id":"exact-stage"}' >"$jsonl"
+reviewed_oid=$("$GIT_RUNNER" hash-file "$jsonl")
+if (
+  cd "$b/repo" || exit 98
+  "$GIT_RUNNER" --literal-pathspecs add --expect-oid "$reviewed_oid" -- "$jsonl" \
+    >"$b/runner.stdout" 2>"$b/runner.stderr"
+); then rc=0; else rc=$?; fi
+git -C "$b/repo" show :.beads/issues.jsonl >"$b/staged.jsonl"
+t='clean Git runner stages exact bytes without repository filters'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/runner.stderr")"
+elif [[ -e "$b/filter-ran" ]]; then
+  fail "$t" 'runner executed the repository clean filter'
+elif ! cmp -s "$jsonl" "$b/staged.jsonl"; then
+  fail "$t" 'runner did not stage the exact worktree bytes'
+elif [[ -s "$b/runner.stdout" || -s "$b/runner.stderr" ]]; then
+  fail "$t" 'runner leaked output while staging'
+else
+  pass "$t"
+fi
+
+# A later write cannot replace the bytes that produced the reviewed diff. The
+# expected object id is checked against the exact blob before update-index.
+cp "$b/staged.jsonl" "$b/reviewed.jsonl"
+printf '%s\n' '{"id":"changed-after-review"}' >"$jsonl"
+if (
+  cd "$b/repo" || exit 98
+  "$GIT_RUNNER" --literal-pathspecs add --expect-oid "$reviewed_oid" -- "$jsonl" \
+    >"$b/stale-add.stdout" 2>"$b/stale-add.stderr"
+); then rc=0; else rc=$?; fi
+git -C "$b/repo" show :.beads/issues.jsonl >"$b/after-stale-add.jsonl"
+t='clean Git runner refuses bytes changed after the reviewed hash'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner staged bytes written after review'
+elif ! grep -Fq 'no longer matches the reviewed object id' "$b/stale-add.stderr"; then
+  fail "$t" "runner did not diagnose the stale review: $(<"$b/stale-add.stderr")"
+elif ! cmp -s "$b/reviewed.jsonl" "$b/after-stale-add.jsonl"; then
+  fail "$t" 'runner changed the index after the reviewed bytes changed'
+else
+  pass "$t"
+fi
+cp "$b/reviewed.jsonl" "$jsonl"
+
+# Commit must consume the real index just staged above, not an inherited
+# repository selector, and must not execute worktree repository hooks.
+mkdir "$b/forged"
+git init -q "$b/forged"
+git -C "$b/forged" config user.name 'Forged Test'
+git -C "$b/forged" config user.email forged@example.invalid
+printf '%s\n' forged >"$b/forged/baseline"
+git -C "$b/forged" add baseline
+git -C "$b/forged" commit -qm baseline
+command cat >"$b/repo/.git/hooks/pre-commit" <<HOOK_PRE_COMMIT
+#!/bin/sh
+printf '%s\n' ran >"$b/commit-hook-ran"
+exit 1
+HOOK_PRE_COMMIT
+chmod +x "$b/repo/.git/hooks/pre-commit"
+printf '%s\n' unrelated >"$b/repo/unrelated"
+git -C "$b/repo" add -- unrelated
+real_before=$(git -C "$b/repo" rev-parse HEAD)
+forged_before=$(git -C "$b/forged" rev-parse HEAD)
+
+# The reviewed parent is part of the proof. A concurrent ref update must make
+# the commit fail without overwriting the intervening HEAD.
+review_tree=$(git -C "$b/repo" rev-parse "$real_before^{tree}")
+intervening=$(printf '%s\n' intervening |
+  git -C "$b/repo" commit-tree "$review_tree" -p "$real_before")
+git -C "$b/repo" update-ref HEAD "$intervening" "$real_before"
+if (
+  cd "$b/repo" || exit 98
+  "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
+    --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+    -m 'must refuse stale HEAD' \
+    >"$b/stale-head.stdout" 2>"$b/stale-head.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses a HEAD changed after review'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner committed atop an unreviewed parent'
+elif [[ $(git -C "$b/repo" rev-parse HEAD) != "$intervening" ]]; then
+  fail "$t" 'runner overwrote the intervening HEAD'
+elif ! grep -Fq 'HEAD no longer matches the reviewed commit' \
+    "$b/stale-head.stderr"; then
+  fail "$t" "runner did not diagnose stale HEAD: $(<"$b/stale-head.stderr")"
+else
+  pass "$t"
+fi
+git -C "$b/repo" update-ref HEAD "$real_before" "$intervening"
+
+# Temp-index state lives only in the Git administrative directory, ignores a
+# worktree TMPDIR, and is removed even when commit-tree fails after creation.
+mkdir "$b/repo/hostile-tmp" "$b/identity-home"
+git -C "$b/repo" config --unset user.name
+git -C "$b/repo" config --unset user.email
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/identity-home" TMPDIR="$b/repo/hostile-tmp" \
+    "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
+      --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+      -m 'forced identity failure' \
+      >"$b/failed-commit.stdout" 2>"$b/failed-commit.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner removes its private index after commit failure'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'identity-less commit unexpectedly succeeded'
+elif find "$b/repo/hostile-tmp" -mindepth 1 -print -quit | grep -q .; then
+  fail "$t" 'runner used caller-selected worktree TMPDIR'
+elif compgen -G "$b/repo/.git/beads-jsonl-commit.*" >/dev/null; then
+  fail "$t" 'runner left a private isolated-index directory behind'
+else
+  pass "$t"
+fi
+git -C "$b/repo" config user.name 'Resolver Test'
+git -C "$b/repo" config user.email resolver@example.invalid
+
+# No arbitrary commit CLI reaches commit-tree.
+t='clean Git runner rejects commit flags outside the exact message API'
+unsafe_commit_accepted=false
+for unsafe_commit_arg in -a --all --amend -S unrelated; do
+  if (
+    cd "$b/repo" || exit 98
+    "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
+      --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+      "$unsafe_commit_arg" unsafe >/dev/null 2>&1
+  ); then
+    unsafe_commit_accepted=true
+  fi
+done
+if "$unsafe_commit_accepted"; then
+  fail "$t" 'runner accepted an unreviewed commit mode or path'
+else
+  pass "$t"
+fi
+
+if (
+  cd "$b/repo" || exit 98
+  GIT_DIR="$b/forged/.git" GIT_WORK_TREE="$b/repo" \
+    "$GIT_RUNNER" commit --only-reviewed "$jsonl" \
+      --expect-oid "$reviewed_oid" --expect-head "$real_before" \
+      -m 'stage exact JSONL' \
+    >"$b/commit.stdout" 2>"$b/commit.stderr"
+); then rc=0; else rc=$?; fi
+real_after=$(git -C "$b/repo" rev-parse HEAD)
+forged_after=$(git -C "$b/forged" rev-parse HEAD)
+t='clean Git runner commits the real index without repository hooks'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/commit.stderr")"
+elif [[ "$real_before" == "$real_after" ]]; then
+  fail "$t" 'runner did not commit the actual repository'
+elif [[ "$forged_before" != "$forged_after" ]]; then
+  fail "$t" 'runner committed the inherited forged repository'
+elif [[ -e "$b/commit-hook-ran" ]]; then
+  fail "$t" 'runner executed the repository pre-commit hook'
+elif git -C "$b/repo" cat-file -e HEAD:unrelated 2>/dev/null; then
+  fail "$t" 'runner swept an unrelated staged file into the reviewed commit'
+elif git -C "$b/repo" diff --cached --quiet -- unrelated; then
+  fail "$t" 'runner did not preserve the unrelated staged file in the real index'
+elif ! git -C "$b/repo" show HEAD:.beads/issues.jsonl >"$b/committed.jsonl" \
+    || ! cmp -s "$jsonl" "$b/committed.jsonl"; then
+  fail "$t" 'runner committed bytes other than the reviewed JSONL'
+else
+  pass "$t"
+fi
+
+# A push may fail (this fixture points at a closed local port), but it must not
+# execute caller PATH/askpass transport helpers while failing closed.
+push_branch=$(git -C "$b/repo" symbolic-ref --short HEAD)
+push_head=$(git -C "$b/repo" rev-parse HEAD)
+mkdir "$b/repo/runner-path"
+command cat >"$b/repo/runner-path/ssh" <<'RUNNER_PATH_SSH'
+#!/bin/sh
+printf '%s\n' ran >"$RUNNER_PATH_SSH_RAN"
+exit 0
+RUNNER_PATH_SSH
+command cat >"$b/repo/runner-path/askpass" <<'RUNNER_ASKPASS'
+#!/bin/sh
+printf '%s\n' ran >"$RUNNER_ASKPASS_RAN"
+printf '%s\n' secret
+RUNNER_ASKPASS
+chmod +x "$b/repo/runner-path/ssh" "$b/repo/runner-path/askpass"
+git -C "$b/repo" config core.askPass "$b/repo/runner-path/askpass"
+git -C "$b/repo" remote add runner-test ssh://git@127.0.0.1:1/never
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/repo/runner-path:$SYSTEM_PATH" \
+    SSH_ASKPASS="$b/repo/runner-path/askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 \
+    RUNNER_PATH_SSH_RAN="$b/runner-path-ssh-ran" RUNNER_ASKPASS_RAN="$b/runner-askpass-ran" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/push.stdout" 2>"$b/push.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses push without PATH or askpass execution'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push to a closed local port unexpectedly succeeded'
+elif [[ -e "$b/runner-path-ssh-ran" ]]; then
+  fail "$t" 'runner executed the worktree PATH SSH shim'
+elif [[ -e "$b/runner-askpass-ran" ]]; then
+  fail "$t" 'runner executed the worktree askpass helper'
+else
+  pass "$t"
+fi
+
+# A worktree-selected global helper is still untrusted even when HOME itself is
+# outside the repository. Reject shell helpers before Git can invoke them.
+mkdir "$b/helper-home"
+command cat >"$b/repo/runner-path/credential-evil" <<'RUNNER_CREDENTIAL_EVIL'
+#!/bin/sh
+printf '%s\n' ran >"$RUNNER_CREDENTIAL_EVIL_RAN"
+exit 1
+RUNNER_CREDENTIAL_EVIL
+chmod +x "$b/repo/runner-path/credential-evil"
+HOME="$b/helper-home" git config --global credential.helper \
+  "!$b/repo/runner-path/credential-evil"
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/helper-home" \
+    RUNNER_CREDENTIAL_EVIL_RAN="$b/runner-credential-evil-ran" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/helper-push.stdout" 2>"$b/helper-push.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner rejects a global helper that names worktree code'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push with a shell credential helper unexpectedly succeeded'
+elif [[ -e "$b/runner-credential-evil-ran" ]]; then
+  fail "$t" 'runner executed the worktree credential helper'
+elif ! grep -Fq 'configured credential helper is not a simple named helper' \
+    "$b/helper-push.stderr"; then
+  fail "$t" "runner did not diagnose the unsafe helper: $(<"$b/helper-push.stderr")"
+else
+  pass "$t"
+fi
+
+# Simple named helpers from trusted global configuration remain usable even
+# when installed outside Git's POSIX utility path: resolve them once from the
+# caller's PATH, then validate and pass their absolute executable to Git.
+mkdir "$b/named-helper-home" "$b/named-helper-bin"
+command cat >"$b/named-helper-bin/git-credential-fixture" <<'RUNNER_NAMED_HELPER'
+#!/bin/sh
+exit 0
+RUNNER_NAMED_HELPER
+chmod +x "$b/named-helper-bin/git-credential-fixture"
+HOME="$b/named-helper-home" git config --global credential.helper fixture
+HOME="$b/named-helper-home" git config --global --add credential.helper ''
+HOME="$b/named-helper-home" git config --global --add credential.helper \
+  'cache --timeout=3600'
+HOME="$b/named-helper-home" git config --global \
+  credential.https://127.0.0.1.helper 'cache --timeout=60'
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/named-helper-home" PATH="$b/named-helper-bin:$SYSTEM_PATH" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/named-helper.stdout" 2>"$b/named-helper.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner validates a named global helper from the caller PATH'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push to a closed local port unexpectedly succeeded'
+elif grep -Eq 'configured credential helper|credential helper executable' \
+    "$b/named-helper.stderr"; then
+  fail "$t" "runner rejected the outside-worktree named helper: $(<"$b/named-helper.stderr")"
+else
+  pass "$t"
+fi
+
+# A store path outside the worktree is not sufficient if its inode is also
+# reachable through a worktree hard link.
+mkdir "$b/store-helper-home"
+printf '%s\n' 'https://user:secret@example.invalid' >"$b/credential-store"
+ln "$b/credential-store" "$b/repo/credential-store-alias"
+HOME="$b/store-helper-home" git config --global credential.helper \
+  "store --file=$b/credential-store"
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/store-helper-home" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/store-helper.stdout" 2>"$b/store-helper.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner rejects a credential store hard-linked into the worktree'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push with aliased credential storage unexpectedly succeeded'
+elif ! grep -Fq 'credential store has multiple hard links' \
+    "$b/store-helper.stderr"; then
+  fail "$t" "runner did not diagnose the credential-store alias: $(<"$b/store-helper.stderr")"
+else
+  pass "$t"
+fi
+
+# The default store locations are not provenance-safe: require an explicit
+# validated --file path instead of following HOME/XDG aliases implicitly.
+mkdir "$b/default-store-home"
+HOME="$b/default-store-home" git config --global credential.helper store
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/default-store-home" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/default-store.stdout" 2>"$b/default-store.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses the unvalidated default credential store'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push with the default credential store unexpectedly succeeded'
+elif ! grep -Fq 'credential store requires an explicit --file path' \
+    "$b/default-store.stderr"; then
+  fail "$t" "runner did not reject the default store: $(<"$b/default-store.stderr")"
+else
+  pass "$t"
+fi
+
+# An absent XDG config directory is equivalent to no XDG config; its canonical
+# existing ancestor is still checked, and retaining the absent setting prevents
+# Git from falling back to a different HOME-relative XDG file.
+mkdir -p "$b/no-config-home/.config/git"
+command cat >"$b/no-config-home/.config/git/config" <<FALLBACK_XDG_CONFIG
+[credential]
+	helper = !$b/repo/runner-path/credential-evil
+FALLBACK_XDG_CONFIG
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    RUNNER_CREDENTIAL_EVIL_RAN="$b/fallback-credential-ran" \
+    "$GIT_RUNNER" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/absent-xdg.stdout" 2>"$b/absent-xdg.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner accepts an absent outside-worktree XDG config directory'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push to a closed local port unexpectedly succeeded'
+elif grep -Fq 'cannot canonicalize the Git/SSH config home' "$b/absent-xdg.stderr"; then
+  fail "$t" "runner rejected the absent XDG directory: $(<"$b/absent-xdg.stderr")"
+elif grep -Fq 'configured credential helper' "$b/absent-xdg.stderr"; then
+  fail "$t" 'runner fell back to HOME-relative XDG credential configuration'
+elif [[ -e "$b/fallback-credential-ran" ]]; then
+  fail "$t" 'runner executed HOME-relative fallback credential configuration'
+else
+  pass "$t"
+fi
+
+# Credential-bearing pushes never downgrade to plaintext HTTP.
+git -C "$b/repo" remote add http-test http://127.0.0.1:1/never
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    "$GIT_RUNNER" push --remote http-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/http-push.stdout" 2>"$b/http-push.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses plaintext HTTP push transport'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'plaintext HTTP push unexpectedly succeeded'
+elif ! grep -Fq "transport 'http' not allowed" "$b/http-push.stderr"; then
+  fail "$t" "runner did not reject HTTP transport: $(<"$b/http-push.stderr")"
+else
+  pass "$t"
+fi
+
+# Exercise the no-trusted-ssh branch even on development hosts that ship ssh:
+# the temporary copy emulates a POSIX utility path without it. SSH transport
+# must then remain disabled rather than falling back to repository config.
+cp "$GIT_RUNNER" "$b/git-clean-no-ssh"
+sed -i 's/if _bjg_ssh=$(command -p -v ssh); then/if false; then/' \
+  "$b/git-clean-no-ssh"
+chmod +x "$b/git-clean-no-ssh"
+command cat >"$b/repo/runner-path/ssh-from-config" <<'RUNNER_CONFIG_SSH'
+#!/bin/sh
+printf '%s\n' ran >"$RUNNER_CONFIG_SSH_RAN"
+exit 0
+RUNNER_CONFIG_SSH
+chmod +x "$b/repo/runner-path/ssh-from-config"
+git -C "$b/repo" config core.sshCommand "$b/repo/runner-path/ssh-from-config"
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    RUNNER_CONFIG_SSH_RAN="$b/runner-config-ssh-ran" \
+    "$b/git-clean-no-ssh" push --remote runner-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/no-ssh.stdout" 2>"$b/no-ssh.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner disables SSH transport when trusted ssh is unavailable'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'push without trusted ssh unexpectedly succeeded'
+elif [[ -e "$b/runner-config-ssh-ran" ]]; then
+  fail "$t" 'runner executed repository-selected core.sshCommand'
+else
+  pass "$t"
+fi
+
+# Even hostile push.default/remote refspec/tag settings cannot widen the single
+# explicit HEAD-to-branch update. A temporary copy enables local file transport
+# solely so the fixture can inspect a bare remote without network services.
+git init -q --bare "$b/scope-remote.git"
+git -C "$b/repo" remote add scope-test "$b/scope-remote.git"
+git -C "$b/repo" branch unrelated-push "$real_before"
+git -C "$b/repo" tag -a unrelated-tag "$real_before" -m unrelated-tag
+git -C "$b/repo" config push.default matching
+git -C "$b/repo" config push.followTags true
+git -C "$b/repo" config remote.scope-test.mirror true
+git -C "$b/repo" config --add remote.scope-test.push \
+  'refs/heads/*:refs/heads/*'
+cp "$GIT_RUNNER" "$b/git-clean-local-push"
+sed -i '/-c protocol.allow=never \\/a\\      -c protocol.file.allow=always \\' \
+  "$b/git-clean-local-push"
+chmod +x "$b/git-clean-local-push"
+
+push_tree=$(git -C "$b/repo" rev-parse "$push_head^{tree}")
+postreview_head=$(printf '%s\n' post-review |
+  git -C "$b/repo" commit-tree "$push_tree" -p "$push_head")
+git -C "$b/repo" update-ref HEAD "$postreview_head" "$push_head"
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    "$b/git-clean-local-push" push --remote scope-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/stale-push.stdout" 2>"$b/stale-push.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses a HEAD changed after the reviewed commit'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner pushed a post-review commit'
+elif [[ $(git -C "$b/repo" rev-parse HEAD) != "$postreview_head" ]]; then
+  fail "$t" 'runner changed the local post-review HEAD'
+elif ! grep -Fq 'HEAD no longer matches the reviewed commit' \
+    "$b/stale-push.stderr"; then
+  fail "$t" "runner did not diagnose stale push HEAD: $(<"$b/stale-push.stderr")"
+elif git -C "$b/scope-remote.git" show-ref --quiet; then
+  fail "$t" 'runner updated the remote despite stale reviewed HEAD'
+else
+  pass "$t"
+fi
+git -C "$b/repo" update-ref HEAD "$push_head" "$postreview_head"
+
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    "$b/git-clean-local-push" push --remote scope-test --branch wrong-branch \
+      --expect-head "$push_head" \
+    >"$b/wrong-branch.stdout" 2>"$b/wrong-branch.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner refuses a push branch other than the attached branch'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner pushed HEAD to a mistyped branch'
+elif ! grep -Fq 'does not match the current branch' "$b/wrong-branch.stderr"; then
+  fail "$t" "runner did not diagnose the branch mismatch: $(<"$b/wrong-branch.stderr")"
+else
+  pass "$t"
+fi
+
+git -C "$b/repo" checkout --detach -q
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    "$b/git-clean-local-push" push --remote scope-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/detached.stdout" 2>"$b/detached.stderr"
+); then rc=0; else rc=$?; fi
+git -C "$b/repo" checkout -q "$push_branch"
+t='clean Git runner refuses to push a detached HEAD'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner pushed detached HEAD'
+elif ! grep -Fq 'requires an attached current branch' "$b/detached.stderr"; then
+  fail "$t" "runner did not diagnose detached HEAD: $(<"$b/detached.stderr")"
+else
+  pass "$t"
+fi
+
+if (
+  cd "$b/repo" || exit 98
+  HOME="$b/no-config-home" XDG_CONFIG_HOME="$b/not-created/xdg" \
+    "$b/git-clean-local-push" push --remote scope-test --branch "$push_branch" \
+      --expect-head "$push_head" \
+    >"$b/scope-push.stdout" 2>"$b/scope-push.stderr"
+); then rc=0; else rc=$?; fi
+t='clean Git runner pushes only HEAD to the explicit reviewed branch'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "exit $rc: $(<"$b/scope-push.stderr")"
+elif [[ $(git -C "$b/scope-remote.git" rev-parse "refs/heads/$push_branch") \
+        != $(git -C "$b/repo" rev-parse HEAD) ]]; then
+  fail "$t" 'runner did not update the exact reviewed branch to HEAD'
+elif git -C "$b/scope-remote.git" show-ref --verify --quiet \
+    refs/heads/unrelated-push \
+    || git -C "$b/scope-remote.git" show-ref --verify --quiet \
+      refs/tags/unrelated-tag; then
+  fail "$t" 'runner widened the push through repository refspec/tag settings'
+elif [[ $(git -C "$b/scope-remote.git" for-each-ref --format='%(refname)' \
+        refs/heads | wc -l) -ne 1 ]]; then
+  fail "$t" 'runner published an extra branch'
+else
+  pass "$t"
+fi
+
+# Snapshot copy/comparison uses the same clean companion rather than caller
+# functions or worktree PATH shims.
+for utility in cp diff; do
+  trusted_utility=$(command -p -v "$utility")
+  command cat >"$b/repo/runner-path/$utility" <<PATH_FILE_UTILITY
+#!/bin/sh
+printf '%s\n' "$utility" >>"\$RUNNER_PATH_FILE_RAN"
+exec "$trusted_utility" "\$@"
+PATH_FILE_UTILITY
+  chmod +x "$b/repo/runner-path/$utility"
+done
+if (
+  cd "$b/repo" || exit 98
+  cp() { printf '%s\n' cp >>"$RUNNER_FUNCTION_FILE_RAN"; }
+  diff() { printf '%s\n' diff >>"$RUNNER_FUNCTION_FILE_RAN"; }
+  export -f cp diff
+  PATH="$b/repo/runner-path:$SYSTEM_PATH" \
+    RUNNER_PATH_FILE_RAN="$b/runner-path-file-ran" \
+    RUNNER_FUNCTION_FILE_RAN="$b/runner-function-file-ran" \
+    "$GIT_RUNNER" copy-file "$jsonl" "$b/copied.jsonl" &&
+  PATH="$b/repo/runner-path:$SYSTEM_PATH" \
+    RUNNER_PATH_FILE_RAN="$b/runner-path-file-ran" \
+    RUNNER_FUNCTION_FILE_RAN="$b/runner-function-file-ran" \
+    "$GIT_RUNNER" diff-files "$b/copied.jsonl" "$jsonl"
+); then rc=0; else rc=$?; fi
+t='clean runner isolates snapshot copy and comparison utilities'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" "copy/comparison exit $rc"
+elif [[ -e "$b/runner-path-file-ran" || -e "$b/runner-function-file-ran" ]]; then
+  fail "$t" 'copy/comparison executed a caller utility'
+elif ! cmp -s "$b/copied.jsonl" "$jsonl"; then
+  fail "$t" 'clean copy changed snapshot bytes'
+else
+  pass "$t"
+fi
+
+# Pure proof utilities run under env -i, so BSD/macOS option variables cannot
+# suppress a diff or invert a grep admission.
+printf '%s\n' before >"$b/env-diff-before"
+printf '%s\n' after >"$b/env-diff-after"
+if DIFF_OPTIONS=-q "$GIT_RUNNER" diff-files \
+    "$b/env-diff-before" "$b/env-diff-after" >"$b/env-diff.out" 2>"$b/env-diff.err"; then
+  diff_rc=0
+else
+  diff_rc=$?
+fi
+if GREP_OPTIONS=-v "$GIT_RUNNER" grep -q before "$b/env-diff-before"; then
+  grep_rc=0
+else
+  grep_rc=$?
+fi
+t='clean proof utilities ignore inherited option environments'
+if [[ $diff_rc -ne 1 || $grep_rc -ne 0 ]]; then
+  fail "$t" "diff rc $diff_rc, grep rc $grep_rc"
+elif ! grep -q '^--- ' "$b/env-diff.out" \
+    || ! grep -q '^+++ ' "$b/env-diff.out"; then
+  fail "$t" 'clean diff output was suppressed by inherited options'
+else
+  pass "$t"
+fi
+
+# The panel's final source-drift admission runs inside the clean companion too.
+# Caller cp/cmp/hash/grep functions and shims cannot forge an unchanged result.
+for utility in cmp grep; do
+  trusted_utility=$(command -p -v "$utility")
+  command cat >"$b/repo/runner-path/$utility" <<PATH_ADMISSION_UTILITY
+#!/bin/sh
+printf '%s\n' "$utility" >>"\$RUNNER_PATH_ADMISSION_RAN"
+exec "$trusted_utility" "\$@"
+PATH_ADMISSION_UTILITY
+  chmod +x "$b/repo/runner-path/$utility"
+done
+if (
+  cd "$b/repo" || exit 98
+  cp() { printf '%s\n' cp >>"$RUNNER_FUNCTION_ADMISSION_RAN"; }
+  cmp() { printf '%s\n' cmp >>"$RUNNER_FUNCTION_ADMISSION_RAN"; return 0; }
+  grep() { printf '%s\n' grep >>"$RUNNER_FUNCTION_ADMISSION_RAN"; return 0; }
+  sha256sum() { printf '%s\n' forged; }
+  shasum() { printf '%s\n' forged; }
+  export -f cp cmp grep sha256sum shasum
+  export RUNNER_PATH_ADMISSION_RAN="$b/runner-path-admission-ran"
+  export RUNNER_FUNCTION_ADMISSION_RAN="$b/runner-function-admission-ran"
+  PATH="$b/repo/runner-path:$SYSTEM_PATH"
+  export PATH
+  "$GIT_RUNNER" make-dir "$b/source-snapshots"
+  "$GIT_RUNNER" snapshot-files "$b/source-manifest" "$b/source-before" \
+    "$b/source-snapshots" -- "$jsonl"
+  printf '%s\n' changed-after-snapshot >>"$jsonl"
+  ! "$GIT_RUNNER" verify-files "$b/source-before" "$b/source-after" -- "$jsonl"
+); then rc=0; else rc=$?; fi
+t='clean runner owns source snapshot and final drift admission'
+if [[ $rc -ne 0 ]]; then
+  fail "$t" 'clean snapshot/drift fixture did not reject changed source'
+elif [[ -e "$b/runner-path-admission-ran" \
+        || -e "$b/runner-function-admission-ran" ]]; then
+  fail "$t" 'source snapshot/drift admission executed a caller utility'
+else
+  pass "$t"
+fi
+
+# Auto-discovered source names cannot follow a repository symlink to outside
+# bytes and copy a user secret into reviewer-visible audit artifacts.
+printf '%s\n' 'outside-user-secret' >"$b/outside-secret"
+ln -s "$b/outside-secret" "$b/repo/README.md"
+"$GIT_RUNNER" make-dir "$b/symlink-source-snapshots"
+if (
+  cd "$b/repo" || exit 98
+  "$GIT_RUNNER" snapshot-files "$b/symlink-manifest" "$b/symlink-state" \
+    "$b/symlink-source-snapshots" -- "$b/repo/README.md" \
+    >"$b/symlink-source.stdout" 2>"$b/symlink-source.stderr"
+); then rc=0; else rc=$?; fi
+t='clean runner refuses a worktree source symlink to outside bytes'
+if [[ $rc -eq 0 ]]; then
+  fail "$t" 'runner snapshotted a symlinked worktree source'
+elif find "$b/symlink-source-snapshots" -type f -size +0c -print -quit |
+    grep -q .; then
+  fail "$t" 'runner copied outside secret bytes into the audit directory'
+else
+  pass "$t"
+fi
+
+# Audit-side bv/timeout/model commands use the same outside-worktree provenance
+# boundary; a behaviorally plausible PATH shim or exported function is refused.
+b=$(new_fixture)
+mkdir "$b/repo/audit-tool-path"
+for audit_tool in bv timeout codex claude; do
+  command cat >"$b/repo/audit-tool-path/$audit_tool" <<AUDIT_TOOL_SHIM
+#!/bin/sh
+printf '%s\n' '$audit_tool' >>'$b/audit-tool-shim-ran'
+exit 0
+AUDIT_TOOL_SHIM
+  chmod +x "$b/repo/audit-tool-path/$audit_tool"
+  eval "$audit_tool() { printf '%s\\n' '$audit_tool' >>'$b/audit-tool-function-ran'; return 0; }"
+  export -f "$audit_tool"
+done
+audit_tools_refused=true
+for audit_tool in bv timeout codex claude; do
+  if (
+    cd "$b/repo" || exit 98
+    PATH="$b/repo/audit-tool-path:$SYSTEM_PATH" \
+      "$GIT_RUNNER" run-audit-tool "$audit_tool" --version \
+      >"$b/$audit_tool.stdout" 2>"$b/$audit_tool.stderr"
+  ); then
+    audit_tools_refused=false
+  fi
+done
+for audit_tool in bv timeout codex claude; do unset -f "$audit_tool"; done
+t='clean audit-tool runner refuses worktree PATH shims and caller functions'
+if ! "$audit_tools_refused"; then
+  fail "$t" 'runner accepted a worktree-selected audit tool'
+elif [[ -e "$b/audit-tool-shim-ran" || -e "$b/audit-tool-function-ran" ]]; then
+  fail "$t" 'runner executed a caller-selected audit tool'
+else
+  pass "$t"
+fi
+
+# A validated outside tool receives only the explicit audit environment, not
+# interpreter startup/code-injection variables.
+mkdir "$b/outside-audit-bin"
+command cat >"$b/outside-audit-bin/audit-probe" <<AUDIT_PROBE
+#!/bin/sh
+[ -z "\${BASH_ENV-}\${ENV-}\${NODE_OPTIONS-}\${PYTHONPATH-}" ] || exit 91
+case ":\$PATH:" in *":$b/repo/audit-tool-path:"*) exit 92 ;; esac
+[ "\$*" = 'exact argument' ] || exit 93
+printf '%s\n' clean >'$b/audit-probe-ran'
+AUDIT_PROBE
+chmod +x "$b/outside-audit-bin/audit-probe"
+if (
+  cd "$b/repo" || exit 98
+  PATH="$b/outside-audit-bin:$b/repo/audit-tool-path:$SYSTEM_PATH" \
+    BASH_ENV="$b/repo/startup" ENV="$b/repo/startup" \
+    NODE_OPTIONS="--require=$b/repo/module" PYTHONPATH="$b/repo/python" \
+    "$GIT_RUNNER" run-audit-tool audit-probe exact argument \
+    >"$b/audit-probe.stdout" 2>"$b/audit-probe.stderr"
+); then rc=0; else rc=$?; fi
+t='clean audit-tool runner strips startup state from outside tools'
+if [[ $rc -ne 0 || ! -e "$b/audit-probe-ran" ]]; then
+  fail "$t" "outside audit probe exit $rc: $(<"$b/audit-probe.stderr")"
+else
+  pass "$t"
+fi
+
 # Index-reading Git commands must not execute a repository-configured fsmonitor
 # hook. Prime the hook once, erase its marker, then keep the fixture snapshots
 # on their own explicit hook-disabled path so only the resolver is measured.
@@ -250,6 +1036,10 @@ FSMONITOR_EXECUTION_HOOK
 chmod +x "$b/fsmonitor-hook"
 git -C "$b/repo" config core.fsmonitor "$b/fsmonitor-hook"
 git -C "$b/repo" status --porcelain >/dev/null
+if [[ ! -e "$b/fsmonitor-hook-ran" ]]; then
+  fail 'resolver Git inspection disables repository fsmonitor hooks' \
+    'fixture could not prime the fsmonitor hook'
+fi
 rm -f "$b/fsmonitor-hook-ran"
 assert_success 'resolver Git inspection disables repository fsmonitor hooks' \
   "$b" "$(<"$b/jsonl-path")"
@@ -264,7 +1054,7 @@ fi
 # the otherwise hardened implementation ran the `git` and `cmp` sentinels.
 b=$(new_fixture)
 mkdir "$b/repo/evil"
-for utility in bash git cmp od grep mktemp unlink rmdir readlink stat getconf; do
+for utility in bash git cmp od grep mktemp unlink rmdir readlink stat getconf env; do
   trusted_utility=$(command -p -v "$utility") || {
     fail 'hostile startup fixture setup' "cannot locate $utility in the POSIX utility path"
     continue
@@ -288,10 +1078,17 @@ SAFE_BR
 chmod +x "$b/bin/br"
 trusted_jq=$(command -v jq)
 command cat >"$b/bin/jq" <<SAFE_JQ
-#!/usr/bin/env bash
-exec "$trusted_jq" "\$@"
+#!/usr/bin/env python3
+import os
+import sys
+os.execv("$trusted_jq", ["$trusted_jq", *sys.argv[1:]])
 SAFE_JQ
 chmod +x "$b/bin/jq"
+mkdir "$b/repo/py"
+command cat >"$b/repo/py/sitecustomize.py" <<PYTHON_STARTUP
+from pathlib import Path
+Path("$b/python-ran").write_text("ran\\n")
+PYTHON_STARTUP
 printf '%s\n' ': >"$HOSTILE_BASH_ENV_RAN"' >"$b/bash-env"
 snapshot_fixture "$b" "$b/before"
 br() {
@@ -309,6 +1106,7 @@ if (
     HOSTILE_FUNCTION_RAN="$b/function-ran" HOSTILE_GIT_FUNCTION_RAN="$b/git-function-ran" \
     BR_CALLS="$b/br.calls" BR_MUTATION="$b/br.mutation" BR_OUTPUT="$b/where.out" \
     PATH="$b/repo/evil:$b/bin:$SYSTEM_PATH" BASH_ENV="$b/bash-env" \
+    PYTHONPATH="$b/repo/py" \
     "$RESOLVER" >"$b/stdout" 2>"$b/stderr"
 ); then rc=0; else rc=$?; fi
 unset -f br git
@@ -317,9 +1115,9 @@ t='hostile PATH, BASH_ENV, and exported functions cannot alter resolver startup'
 printf '%s\n' "$(<"$b/jsonl-path")" >"$b/expected"
 if [[ $rc -ne 0 ]]; then
   fail "$t" "exit $rc: $(<"$b/stderr")"
-elif [[ -e "$b/path-ran" || -e "$b/bash-env-ran" || -e "$b/function-ran" \
-        || -e "$b/git-function-ran" ]]; then
-  fail "$t" "a hostile startup sentinel ran: path=$(test -e "$b/path-ran" && tr '\n' ',' <"$b/path-ran" || echo no), bash-env=$(test -e "$b/bash-env-ran" && echo yes || echo no), br=$(test -e "$b/function-ran" && echo yes || echo no), git=$(test -e "$b/git-function-ran" && echo yes || echo no)"
+elif [[ -e "$b/path-ran" || -e "$b/python-ran" || -e "$b/bash-env-ran" || -e "$b/function-ran" \
+         || -e "$b/git-function-ran" ]]; then
+  fail "$t" "a hostile startup sentinel ran: path=$(test -e "$b/path-ran" && tr '\n' ',' <"$b/path-ran" || echo no), python=$(test -e "$b/python-ran" && echo yes || echo no), bash-env=$(test -e "$b/bash-env-ran" && echo yes || echo no), br=$(test -e "$b/function-ran" && echo yes || echo no), git=$(test -e "$b/git-function-ran" && echo yes || echo no)"
 elif ! cmp -s "$b/expected" "$b/stdout" || [[ -s "$b/stderr" ]]; then
   fail "$t" 'resolver output changed under hostile startup state'
 elif ! cmp -s "$b/before" "$b/after" || ! safe_br_calls_only "$b/br.calls"; then

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -463,7 +463,7 @@ A phase closes on evidence or it does not close.
   flush re-exports **every** bead from the gitignored `.beads/beads.db` over the tracked
   JSONL, so any body the cache holds a stale copy of is reverted, silently, at exit 0.
   Hand-editing `.beads/issues.jsonl` is what makes the cache stale — do not; use
-  `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`. Then rerun the resolver-locator block above,
+  `"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "<full body>"`. Then rerun the resolver-locator block above,
   stopping before its final clean-mode `BEADS_JSONL=` call, resolve the post-write path
   with `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1`,
   and field-diff the tracked JSONL before committing; the write you just made is the

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -318,7 +318,7 @@ A phase closes on evidence or it does not close.
       printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
       exit 1
     }
-    _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
       printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
       exit 1
     }

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -295,6 +295,14 @@ A phase closes on evidence or it does not close.
     printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
     exit 1
   }
+  _bjp_git_environment=( "${!GIT_@}" )
+  for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+    command unset -- "$_bjp_git_variable" || {
+      printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+      exit 1
+    }
+  done
+  unset _bjp_git_variable _bjp_git_environment
 
   BEADS_JSONL_RESOLVER=
   for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -171,7 +171,7 @@ wants to re-run a phase.
 | Phase | Entry condition | Skill it runs | Exit gate (evidence required) |
 |---|---|---|---|
 | **SHAPE** | Goal is prose; no reviewed spec | `planning-workflow`, `grill-with-docs`, `spec` | Spec file committed **and** a codex xhigh review returns no P0/P1 |
-| **GRAPH** | Spec exists; no bead graph covering it | `plan-to-beads-transfer` → `bead-polish-loop` → `second-model-bead-audit` | Audit verdict PASS; a **scoped** `br ready` bead exists (see `Scope:` in `DRIVE.md`) |
+| **GRAPH** | Spec exists; no bead graph covering it | `plan-to-beads-transfer` → `bead-polish-loop` → `second-model-bead-audit` | Audit verdict PASS; a **scoped** `"$BEADS_JSONL_RESOLVER" --run-br ready` bead exists (see `Scope:` in `DRIVE.md`) |
 | **BUILD** | A ready bead exists | `orchestrating-with-rb-lite` (one bead = one branch) | rb-lite exits clean, you ran the gate yourself at a real exit code, **and** each load-bearing behavior the bead introduced was inverted with its pinning assertion observed to fail |
 | **PROVE** | Bead's deliverable is a test/gate, or the change touches money/data/infra | gate folded into the BUILD task, **or** a separate test bead run through `testing-with-rb-lite` — decide *before* BUILD starts, since a second rb-lite run on the same branch is forbidden | the gate ran green at a real exit code **and** a matching assertion was observed to FAIL for every property it claims; quote both runs. Green alone does not close PROVE |
 | **HARDEN** | Branch has unreviewed substantive code | `multi-reviewer-loop` (its "ask the user at the end" step is satisfied by the drive goal — keep going; its stop-list still applies), then a final pinned `codex review --base <ref>` | `multi-reviewer-loop` reports `CLEAN` — both reviewers clean **and** its consistency pass clean, on the same tree; gate green at a real exit code |
@@ -253,13 +253,13 @@ A phase closes on evidence or it does not close.
   was real when they ran. See
   [multi-reviewer-loop/references/reviewer-panel.md](../multi-reviewer-loop/references/reviewer-panel.md).
 - **`br` is not exempt — but know which failure you are guarding.** An *explicit*
-  `br sync --flush-only` propagates a real exit code, so just require it to succeed. The
-  *automatic* flush that follows a mutating command like `br close` does not: its error is
-  caught and logged at debug level, so `br close` exits 0 with the JSONL unwritten. A
+  `"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only` propagates a real exit code, so just require it to succeed. The
+  *automatic* flush that follows a mutating command like `"$BEADS_JSONL_RESOLVER" --run-br close` does not: its error is
+  caught and logged at debug level, so `"$BEADS_JSONL_RESOLVER" --run-br close` exits 0 with the JSONL unwritten. A
   closed bead is not a closed bead until an explicit sync has confirmed the write:
 
   ```bash
-  # Resolve and prove the JSONL clean FIRST: `br close` auto-flushes the cache over it.
+  # Resolve and prove the JSONL clean FIRST: `"$BEADS_JSONL_RESOLVER" --run-br close` auto-flushes the cache over it.
   BEADS_JSONL_RESOLVER=$(
     (
       # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
@@ -310,7 +310,7 @@ A phase closes on evidence or it does not close.
     fi
     printf '%s\n' "$count"
   }
-  _bjp_git_environment=( "${!GIT_@}" )
+  _bjp_git_environment=( "${!GIT@}" )
   for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
     command unset -- "$_bjp_git_variable" || {
       printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -320,6 +320,7 @@ A phase closes on evidence or it does not close.
   unset _bjp_git_variable _bjp_git_environment
 
   BEADS_JSONL_RESOLVER=
+  BEADS_GIT_RUNNER=
   for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
     "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -364,6 +365,10 @@ A phase closes on evidence or it does not close.
         exit 1
         ;;
     esac
+    [ -f "$_bjp_candidate" ] || {
+      printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+      exit 1
+    }
     _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
       printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
       exit 1
@@ -382,16 +387,50 @@ A phase closes on evidence or it does not close.
       exit 1
     }
     unset _bjp_shebang
+    _bjp_runner="$_bjp_candidate_dir/git-clean"
+    [ -x "$_bjp_runner" ] || {
+      printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+      exit 1
+    }
+    [ ! -L "$_bjp_runner" ] || {
+      printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+      exit 1
+    }
+    [ -f "$_bjp_runner" ] || {
+      printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+      exit 1
+    }
+    _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+      printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+      exit 1
+    }
+    [ "$_bjp_link_count" = 1 ] || {
+      printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+      exit 1
+    }
+    unset _bjp_link_count
+    if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+      printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+      exit 1
+    fi
+    [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+      printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+      exit 1
+    }
+    unset _bjp_shebang
     unset _bjp_candidate_dir
     if [ -z "$BEADS_JSONL_RESOLVER" ]; then
       BEADS_JSONL_RESOLVER=$_bjp_candidate
-    elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+      BEADS_GIT_RUNNER=$_bjp_runner
+    elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+        || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
       printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
       exit 1
     fi
+    unset _bjp_runner
   done
   unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-  [ -n "$BEADS_JSONL_RESOLVER" ] || {
+  [ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
     printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
     exit 1
   }
@@ -399,6 +438,7 @@ A phase closes on evidence or it does not close.
   __BJP_TRUSTED_BASH__
     )
   ) || exit 1
+  BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
   unset _bjp_candidate
   # Installed targets only, for the same provenance reason as Phase 0's resolver: a
   # relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl` is whatever executable
@@ -408,8 +448,8 @@ A phase closes on evidence or it does not close.
     exit 1
   }
   BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
-  br close <id> || { echo "br close failed"; exit 1; }
-  br sync --flush-only || { echo "closure not persisted to the JSONL"; exit 1; }
+  "$BEADS_JSONL_RESOLVER" --run-br close <id> || { echo "br close failed"; exit 1; }
+  "$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "closure not persisted to the JSONL"; exit 1; }
   ```
 
   The explicit sync is the whole guard, and it needs to know nothing about the repo: the
@@ -423,7 +463,7 @@ A phase closes on evidence or it does not close.
   flush re-exports **every** bead from the gitignored `.beads/beads.db` over the tracked
   JSONL, so any body the cache holds a stale copy of is reverted, silently, at exit 0.
   Hand-editing `.beads/issues.jsonl` is what makes the cache stale — do not; use
-  `br update -d/--notes`. Then rerun the resolver-locator block above,
+  `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`. Then rerun the resolver-locator block above,
   stopping before its final clean-mode `BEADS_JSONL=` call, resolve the post-write path
   with `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1`,
   and field-diff the tracked JSONL before committing; the write you just made is the
@@ -448,7 +488,7 @@ Declare before entering BUILD, in the task file:
 
 - exact file list (file-lock — forbid all others from round 1), **plus a standing
   exemption for `DRIVE.md` and the beads JSONL**. Guard 4 rewrites `DRIVE.md` at every
-  transition and LAND runs `br close`, so a lock that forbids them forbids the
+  transition and LAND runs `"$BEADS_JSONL_RESOLVER" --run-br close`, so a lock that forbids them forbids the
   bookkeeping this skill requires. Exempt them; do not spend budget on them. The exemption
   is from the **budget**, not from review — they ride the same branch, the same panel and
   the same bots as everything else (`references/phases.md` § LAND).

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -373,6 +373,15 @@ A phase closes on evidence or it does not close.
       exit 1
     }
     unset _bjp_link_count
+    if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+      printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+      exit 1
+    fi
+    [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+      printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+      exit 1
+    }
+    unset _bjp_shebang
     unset _bjp_candidate_dir
     if [ -z "$BEADS_JSONL_RESOLVER" ]; then
       BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -295,6 +295,21 @@ A phase closes on evidence or it does not close.
     printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
     exit 1
   }
+  _bjp_stat=$(command -p -v stat) || {
+    printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+  _bjp_regular_link_count() {
+    local path=$1 count
+    if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+      :
+    elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+      :
+    else
+      return 1
+    fi
+    printf '%s\n' "$count"
+  }
   _bjp_git_environment=( "${!GIT_@}" )
   for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
     command unset -- "$_bjp_git_variable" || {
@@ -349,6 +364,15 @@ A phase closes on evidence or it does not close.
         exit 1
         ;;
     esac
+    _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+      printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+      exit 1
+    }
+    [ "$_bjp_link_count" = 1 ] || {
+      printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+      exit 1
+    }
+    unset _bjp_link_count
     unset _bjp_candidate_dir
     if [ -z "$BEADS_JSONL_RESOLVER" ]; then
       BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -357,7 +381,7 @@ A phase closes on evidence or it does not close.
       exit 1
     fi
   done
-  unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+  unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
   [ -n "$BEADS_JSONL_RESOLVER" ] || {
     printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
     exit 1

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -259,16 +259,114 @@ A phase closes on evidence or it does not close.
   closed bead is not a closed bead until an explicit sync has confirmed the write:
 
   ```bash
-  # Divergence check FIRST — `br close` auto-flushes the cache over the tracked JSONL, so
-  # an unstaged hand-edit is destroyed by this very command and neither the index nor HEAD
-  # holds it. Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so
-  # a failed inspection would read as clean and let the write through.
-  _bw=$(br where --json) || { echo "cannot resolve the beads JSONL — do NOT close"; exit 1; }
-  BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL — do NOT close"; exit 1; }
-  _st=$(git status --porcelain -- "$BEADS_JSONL") \
-    || { echo "cannot read the worktree — do NOT close"; exit 1; }
-  [ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
-    echo "JSONL differs from HEAD — resolve that BEFORE closing"; exit 1; }
+  # Resolve and prove the JSONL clean FIRST: `br close` auto-flushes the cache over it.
+  BEADS_JSONL_RESOLVER=$(
+    (
+      # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+      # prevents exported caller functions from redefining this trust path, and the
+      # subshell leaves the caller's shell state untouched.
+      POSIXLY_CORRECT=y
+      export POSIXLY_CORRECT
+      \unset -f command builtin exec unset 2>/dev/null || :
+      _bjp_bash=$(command -p -v bash) || {
+        printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+        exit 1
+      }
+      unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+      exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+  # Privileged Bash ignores inherited functions. Clear the other startup controls too,
+  # then perform every candidate, worktree, provenance, and byte-agreement decision here.
+  command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+  while command builtin read -r _ _ _bjp_function; do
+    command unset -f -- "$_bjp_function" || {
+      printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+      exit 1
+    }
+  done < <(command builtin declare -F)
+  unset _bjp_function
+  _bjp_git=$(command -p -v git) || {
+    printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+  _bjp_cmp=$(command -p -v cmp) || {
+    printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+
+  BEADS_JSONL_RESOLVER=
+  for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+    "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+    "$HOME/.agents/skills/beads-jsonl-path"; do
+    case $_bjp_dir in
+      /*) ;;
+      *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+    esac
+    _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+    [ -x "$_bjp_candidate" ] || continue
+    [ ! -L "$_bjp_candidate" ] || {
+      printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+      exit 1
+    }
+    _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+      printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+      exit 1
+    }
+    _bjp_root=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+      exit 1
+    }
+    _bjp_candidate_dir=$(
+      CDPATH=
+      export CDPATH
+      cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+    ) || {
+      printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+      exit 1
+    }
+    _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+    [ ! -L "$_bjp_candidate" ] || {
+      printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+      exit 1
+    }
+    case $_bjp_root:$_bjp_candidate_dir in
+      /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+        printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+        exit 1
+        ;;
+    esac
+    unset _bjp_candidate_dir
+    if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+      BEADS_JSONL_RESOLVER=$_bjp_candidate
+    elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+      printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+      exit 1
+    fi
+  done
+  unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+  [ -n "$BEADS_JSONL_RESOLVER" ] || {
+    printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+    exit 1
+  }
+  printf '%s\n' "$BEADS_JSONL_RESOLVER"
+  __BJP_TRUSTED_BASH__
+    )
+  ) || exit 1
+  unset _bjp_candidate
+  # Installed targets only, for the same provenance reason as Phase 0's resolver: a
+  # relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl` is whatever executable
+  # the DRIVEN repo planted there. From a checkout, run its copy by absolute path.
+  [ -n "$BEADS_JSONL_RESOLVER" ] || {
+    echo "beads-jsonl-path companion unavailable — do NOT close" >&2
+    exit 1
+  }
+  BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
   br close <id> || { echo "br close failed"; exit 1; }
   br sync --flush-only || { echo "closure not persisted to the JSONL"; exit 1; }
   ```
@@ -284,9 +382,12 @@ A phase closes on evidence or it does not close.
   flush re-exports **every** bead from the gitignored `.beads/beads.db` over the tracked
   JSONL, so any body the cache holds a stale copy of is reverted, silently, at exit 0.
   Hand-editing `.beads/issues.jsonl` is what makes the cache stale — do not; use
-  `br update -d/--notes`. Then field-diff the tracked JSONL before committing and read the
-  changes — resolving its path rather than assuming it, with
-  `br where --json | jq -er .jsonl_path`. `.beads/issues.jsonl` is only the default:
+  `br update -d/--notes`. Then rerun the resolver-locator block above,
+  stopping before its final clean-mode `BEADS_JSONL=` call, resolve the post-write path
+  with `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1`,
+  and field-diff the tracked JSONL before committing; the write you just made is the
+  divergence the default mode refuses.
+  `.beads/issues.jsonl` is only the default:
   `.beads.jsonl` and `<name>.beads.jsonl` are supported too, and a hardcoded path diffs
   nothing on those — a false all-clear in the direction that loses text. Detail and
   recovery:

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -260,6 +260,26 @@ A phase closes on evidence or it does not close.
 
   ```bash
   # Resolve and prove the JSONL clean FIRST: `"$BEADS_JSONL_RESOLVER" --run-br close` auto-flushes the cache over it.
+  # Clear loader injection in this already-running shell before the locator starts
+  # any new process. The resolver/git-clean script bodies are too late: a shebang
+  # interpreter would already have loaded caller-selected libraries.
+  _bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+  _bjp_posixly_value=${POSIXLY_CORRECT-}
+  POSIXLY_CORRECT=y
+  export POSIXLY_CORRECT
+  \unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+    LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+    DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+    DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+    printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+  if [ -n "$_bjp_posixly_was_set" ]; then
+    POSIXLY_CORRECT=$_bjp_posixly_value
+    export POSIXLY_CORRECT
+  else
+    \unset POSIXLY_CORRECT
+  fi
   BEADS_JSONL_RESOLVER=$(
     (
       # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -796,6 +796,14 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_git_environment=( "${!GIT_@}" )
+for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+  command unset -- "$_bjp_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+done
+unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -94,7 +94,7 @@ consumers of the new invariant) before writing more spec.
 3. `second-model-bead-audit` — the default final gate. A conditional/failed verdict feeds
    accepted findings back into one more focused polish round, then re-audits.
 
-**Exit gate:** audit verdict PASS and a **scoped** ready bead exists — `br ready` filtered
+**Exit gate:** audit verdict PASS and a **scoped** ready bead exists — `"$BEADS_JSONL_RESOLVER" --run-br ready` filtered
 through `DRIVE.md`'s `Scope:` line, not the raw repository count.
 
 **Failure:** the audit says coverage is thin → the *spec* is thin. Go back to SHAPE for
@@ -104,13 +104,13 @@ the uncovered area rather than inventing beads to paper over it.
 
 ## BUILD — one bead → one branch
 
-**Enter when:** `br ready` has a bead **inside the goal's scope**.
+**Enter when:** `"$BEADS_JSONL_RESOLVER" --run-br ready` has a bead **inside the goal's scope**.
 
 Scope first, then pick. The scope is the `Scope:` line in `DRIVE.md` — one canonical
 definition every phase reads. If the goal named a bead, epic, or milestone, only beads in
 that set are eligible, and DONE means *that set* is empty — not the whole repository
 backlog.
-A bare `br ready` in a repo with unrelated work will happily hand you a higher-priority
+A bare `"$BEADS_JSONL_RESOLVER" --run-br ready` in a repo with unrelated work will happily hand you a higher-priority
 bead the user never asked for, and the drive would then build, review, and **merge** it
 autonomously. Draining the entire backlog is a legitimate goal, but only when the user
 actually said so ("drain the backlog"), never as a side effect of a scoped request.
@@ -626,12 +626,12 @@ good diff and the cap is spent on real findings.
 
 **Exit gate:** merged at a tip the codex bot read with no pending round, no undispositioned
 finding from either bot, with a fresh base, branch reset, bead
-closed (`br close <id>`), `DRIVE.md` updated — the last two through a reviewed path.
+closed (`"$BEADS_JSONL_RESOLVER" --run-br close <id>`), `DRIVE.md` updated — the last two through a reviewed path.
 
-`br close` cannot ride this branch. It is tempting to think it can: `.beads/issues.jsonl`
+`"$BEADS_JSONL_RESOLVER" --run-br close` cannot ride this branch. It is tempting to think it can: `.beads/issues.jsonl`
 is tracked, so a closure committed on the branch looks transactional. **It is not** — see
 ADR 0003, which records the code evidence, because this is attractive enough to be
-re-proposed. In short: `br close` auto-flushes immediately, the local SQLite DB is shared
+re-proposed. In short: `"$BEADS_JSONL_RESOLVER" --run-br close` auto-flushes immediately, the local SQLite DB is shared
 by every branch with no git awareness, and import is last-write-wins on `updated_at`, so
 the default branch's older OPEN record loses to the branch's newer closure. The closure
 leaks across the checkout and nothing errors.
@@ -706,7 +706,7 @@ and silently carry the previous bead's closure into its diff. Instead:
           | test("(^|[^a-z0-9._-])" + ($id|ascii_downcase|gsub("\\.";"\\.")) + "([^a-z0-9._-]|$)")))'
   ```
 
-`BEAD_ID` comes from the bead you are resuming — on a fresh clone take it from `br list`'s
+`BEAD_ID` comes from the bead you are resuming — on a fresh clone take it from `"$BEADS_JSONL_RESOLVER" --run-br list`'s
 open beads, one query per candidate. There is no durable variable carrying it across a
 clone boundary, so a snippet that assumes one silently rejects every PR (`$id != ""`) and
 misses the closure it exists to find.
@@ -756,11 +756,11 @@ when its PRs were written.
   query.** An open closure PR means the drive is `WAITING_FOR_MERGE`, not unfinished —
   land that PR rather than starting the work again.
 
-And verify the closure actually happened. `br close` exits 0 even when the flush that
+And verify the closure actually happened. `"$BEADS_JSONL_RESOLVER" --run-br close` exits 0 even when the flush that
 writes the JSONL failed, because the error is caught and logged at debug level:
 
 ```bash
-# Resolve and prove the JSONL clean FIRST: `br close` auto-flushes the cache over it.
+# Resolve and prove the JSONL clean FIRST: `"$BEADS_JSONL_RESOLVER" --run-br close` auto-flushes the cache over it.
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
@@ -811,7 +811,7 @@ _bjp_regular_link_count() {
   fi
   printf '%s\n' "$count"
 }
-_bjp_git_environment=( "${!GIT_@}" )
+_bjp_git_environment=( "${!GIT@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
     printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -821,6 +821,7 @@ done
 unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
+BEADS_GIT_RUNNER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
   "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
   "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -865,6 +866,10 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  [ -f "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+    exit 1
+  }
   _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
     printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
     exit 1
@@ -883,16 +888,50 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_shebang
+  _bjp_runner="$_bjp_candidate_dir/git-clean"
+  [ -x "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+    exit 1
+  }
+  [ ! -L "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  [ -f "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+    exit 1
+  }
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
-  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    BEADS_GIT_RUNNER=$_bjp_runner
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+      || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
     printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
     exit 1
   fi
+  unset _bjp_runner
 done
 unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-[ -n "$BEADS_JSONL_RESOLVER" ] || {
+[ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
 }
@@ -900,6 +939,7 @@ printf '%s\n' "$BEADS_JSONL_RESOLVER"
 __BJP_TRUSTED_BASH__
   )
 ) || exit 1
+BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
 unset _bjp_candidate
 # Installed targets only, for the same provenance reason as Phase 0's resolver: a relative
 # `skills/beads-jsonl-path/scripts/resolve-beads-jsonl` is whatever executable the DRIVEN
@@ -909,8 +949,8 @@ unset _bjp_candidate
   exit 1
 }
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
-br close <id> || { echo "br close failed"; exit 1; }
-br sync --flush-only || { echo "closure not persisted — auto-flush was swallowed"; exit 1; }
+"$BEADS_JSONL_RESOLVER" --run-br close <id> || { echo "br close failed"; exit 1; }
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "closure not persisted — auto-flush was swallowed"; exit 1; }
 ```
 
 `||`, not `;`: a semicolon discards the exit status of the command before it, so the pair
@@ -931,14 +971,14 @@ and read the field-level changes before staging — resolving its path first, si
 # guards writes, and this diff runs after one. Never hardcode `.beads/issues.jsonl` here.
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
   || { echo "cannot resolve the beads JSONL"; exit 1; }
-git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
+"$BEADS_GIT_RUNNER" --literal-pathspecs diff --no-ext-diff --no-textconv --text HEAD -- "$BEADS_JSONL" \
   || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
 ```
 
 Ids on only one side, or a `description` this phase did not write, is the tell. Never
 hand-edit that file (a hand
 edit does not advance `updated_at`, which is what makes the cache stale and undetectable);
-write bead text with `br update -d/--notes`. Recovery is in
+write bead text with `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`. Recovery is in
 [exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
 
 A flush
@@ -948,11 +988,11 @@ blanket "must be non-empty" would fail a healthy preflight.
 Either way the tree is clean before BUILD re-enters, and nothing reaches the default
 branch unreviewed.
 
-Then go straight back to BUILD if a **scoped** ready bead remains — `br ready` filtered to
+Then go straight back to BUILD if a **scoped** ready bead remains — `"$BEADS_JSONL_RESOLVER" --run-br ready` filtered to
 the goal's bead set, exactly as at BUILD entry. That loop is the whole point; do not stop to
 ask whether to take the next bead *inside* the scope.
 
-A bare `br ready` here re-opens the scope escape the entry check closes: the named scope
+A bare `"$BEADS_JSONL_RESOLVER" --run-br ready` here re-opens the scope escape the entry check closes: the named scope
 empties, an unrelated repository bead is ready, and the loop builds, reviews, and **merges**
 work the user never authorized. When the scope is empty, the drive is done — even if the
 repository still has ready beads. Say so and stop.
@@ -960,8 +1000,8 @@ repository still has ready beads. Say so and stop.
 
 ## DONE
 
-**Within the goal's scope**, `br ready` is empty and so is the unresolved set — bare
-`br list` (there is no `br open` subcommand; bare `br list` is open + in_progress, excluding
+**Within the goal's scope**, `"$BEADS_JSONL_RESOLVER" --run-br ready` is empty and so is the unresolved set — bare
+`"$BEADS_JSONL_RESOLVER" --run-br list` (there is no `"$BEADS_JSONL_RESOLVER" --run-br open` subcommand; bare `"$BEADS_JSONL_RESOLVER" --run-br list` is open + in_progress, excluding
 closed). Scope matters here as much as at BUILD entry: a scoped goal is DONE when *its* set
 is empty, not when the repository is. Waiting on the global backlog turns a finished
 milestone into an open-ended drain the user never asked for.
@@ -983,6 +1023,6 @@ legitimately the end of the turn.
 bead numbers are repository-wide. Filter them against the scope in `DRIVE.md` yourself
 before believing them.
 
-If `br ready` is empty but the unresolved set is **not**, you are not done: every remaining
+If `"$BEADS_JSONL_RESOLVER" --run-br ready` is empty but the unresolved set is **not**, you are not done: every remaining
 bead is blocked or deferred. That is a graph problem — re-audit dependencies and deferrals
 in GRAPH rather than hunting for a bead to build. `drive-status` flags this case explicitly.

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -819,7 +819,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
     exit 1
   }
-  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
     printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
     exit 1
   }
@@ -898,7 +898,7 @@ and read the field-level changes before staging — resolving its path first, si
 # guards writes, and this diff runs after one. Never hardcode `.beads/issues.jsonl` here.
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
   || { echo "cannot resolve the beads JSONL"; exit 1; }
-git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
+git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
   || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
 ```
 

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -760,19 +760,114 @@ And verify the closure actually happened. `br close` exits 0 even when the flush
 writes the JSONL failed, because the error is caught and logged at debug level:
 
 ```bash
-# DIVERGENCE CHECK FIRST: `br close` auto-flushes, so an unstaged hand-edit in the JSONL is
-# destroyed by this very command and neither the index nor HEAD holds it — the diff below
-# would then be empty and the loss undetectable.
-_bw=$(br where --json) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
-# Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so a FAILED
-# inspection reads as a clean tree and lets the write through — the guard failing open at
-# exactly the moment it matters. Compare against HEAD, not the index: a damaged JSONL that
-# is staged leaves a worktree-vs-index diff empty while HEAD holds the good bodies.
-_st=$(git status --porcelain -- "$BEADS_JSONL") \
-  || { echo "cannot read the worktree — do NOT write"; exit 1; }
-[ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
-  echo "JSONL differs from HEAD — read that diff and resolve it BEFORE writing"; exit 1; }
+# Resolve and prove the JSONL clean FIRST: `br close` auto-flushes the cache over it.
+BEADS_JSONL_RESOLVER=$(
+  (
+    # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+    # prevents exported caller functions from redefining this trust path, and the
+    # subshell leaves the caller's shell state untouched.
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset -f command builtin exec unset 2>/dev/null || :
+    _bjp_bash=$(command -p -v bash) || {
+      printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+      exit 1
+    }
+    unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+    exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+# Privileged Bash ignores inherited functions. Clear the other startup controls too,
+# then perform every candidate, worktree, provenance, and byte-agreement decision here.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjp_function; do
+  command unset -f -- "$_bjp_function" || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjp_function
+_bjp_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_cmp=$(command -p -v cmp) || {
+  printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in
+    /*) ;;
+    *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+  esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+      printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+      exit 1
+      ;;
+  esac
+  unset _bjp_candidate_dir
+  if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+    BEADS_JSONL_RESOLVER=$_bjp_candidate
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+    exit 1
+  fi
+done
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+  exit 1
+}
+printf '%s\n' "$BEADS_JSONL_RESOLVER"
+__BJP_TRUSTED_BASH__
+  )
+) || exit 1
+unset _bjp_candidate
+# Installed targets only, for the same provenance reason as Phase 0's resolver: a relative
+# `skills/beads-jsonl-path/scripts/resolve-beads-jsonl` is whatever executable the DRIVEN
+# repo planted there. From a checkout, run its copy by absolute path instead.
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  echo "beads-jsonl-path companion unavailable — do NOT write" >&2
+  exit 1
+}
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
 br close <id> || { echo "br close failed"; exit 1; }
 br sync --flush-only || { echo "closure not persisted — auto-flush was swallowed"; exit 1; }
 ```
@@ -789,9 +884,14 @@ and read the field-level changes before staging — resolving its path first, si
 `.beads.jsonl` layout:
 
 ```bash
-_bw=$(br where --json) || { echo "cannot resolve the JSONL"; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
-git diff "$BEADS_JSONL"
+# In a fresh shell, rerun the resolver-locator block above first,
+# stopping before its final clean-mode `BEADS_JSONL=` call. `--allow-dirty` because
+# the closure you just flushed IS the divergence the default mode refuses — that mode
+# guards writes, and this diff runs after one. Never hardcode `.beads/issues.jsonl` here.
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
+  || { echo "cannot resolve the beads JSONL"; exit 1; }
+git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
+  || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
 ```
 
 Ids on only one side, or a `description` this phase did not write, is the tell. Never

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -796,6 +796,21 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
 _bjp_git_environment=( "${!GIT_@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
@@ -850,6 +865,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -858,7 +882,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   fi
 done
-unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
 [ -n "$BEADS_JSONL_RESOLVER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -761,6 +761,26 @@ writes the JSONL failed, because the error is caught and logged at debug level:
 
 ```bash
 # Resolve and prove the JSONL clean FIRST: `"$BEADS_JSONL_RESOLVER" --run-br close` auto-flushes the cache over it.
+# Clear loader injection in this already-running shell before the locator starts
+# any new process. The resolver/git-clean script bodies are too late: a shebang
+# interpreter would already have loaded caller-selected libraries.
+_bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+_bjp_posixly_value=${POSIXLY_CORRECT-}
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+  printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+if [ -n "$_bjp_posixly_was_set" ]; then
+  POSIXLY_CORRECT=$_bjp_posixly_value
+  export POSIXLY_CORRECT
+else
+  \unset POSIXLY_CORRECT
+fi
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -978,7 +978,7 @@ BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
 Ids on only one side, or a `description` this phase did not write, is the tell. Never
 hand-edit that file (a hand
 edit does not advance `updated_at`, which is what makes the cache stale and undetectable);
-write bead text with `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`. Recovery is in
+write bead text with `"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "<full body>"`. Recovery is in
 [exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
 
 A flush

--- a/skills/drive/references/phases.md
+++ b/skills/drive/references/phases.md
@@ -874,6 +874,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -15,7 +15,7 @@ compatibility: Requires `rb-lite` on `PATH` or `nix run --refresh github:douglaz
 
 Use `rb-lite` as the default lightweight implement → review loop for
 single-branch, single-task work in the current repo. Also use it as the
-execution engine for draining an existing `br` backlog: `br ready` supplies
+execution engine for draining an existing `br` backlog: `"$BEADS_JSONL_RESOLVER" --run-br ready` supplies
 the work list, and each bead gets one focused rb-lite run. When the work list
 does not exist yet and the goal is a clean branch, the harden-until-clean drive
 generates it from a review panel and feeds the same drain.
@@ -185,11 +185,11 @@ to you. Load exact companion skill `rb-lite-backlog-drain` for
 which resolve the graph's real path through exact companion
 `beads-jsonl-path/scripts/resolve-beads-jsonl` — its default clean-state mode before the
 first write, `--allow-dirty` for the structurally tracked post-write field diff, and
-`--recovery` only when naming the damaged artifact. Without that owner a drain can run `br update`
+`--recovery` only when naming the damaged artifact. Without that owner a drain can run `"$BEADS_JSONL_RESOLVER" --run-br update`
 and flush — silently reverting unrelated bead bodies — and only then fail at the command
 that would have located the damage. Check it before the first bead, not after. Require **`br` ≥ 0.1.45**: older builds corrupt
-their DB after branch resets, so `br update`/`br close` start returning
-`ISSUE_NOT_FOUND` while `br show`/`br list` keep working — which hides the
+their DB after branch resets, so `"$BEADS_JSONL_RESOLVER" --run-br update`/`"$BEADS_JSONL_RESOLVER" --run-br close` start returning
+`ISSUE_NOT_FOUND` while `"$BEADS_JSONL_RESOLVER" --run-br show`/`"$BEADS_JSONL_RESOLVER" --run-br list` keep working — which hides the
 failure until bead state is already lost. Both drain modes reset branches after
 every merge, so they hit that bug hard. It should use the repo's documented local gates;
 for Rust/Nix repos, default to `cargo fmt`, `cargo clippy`, `cargo test`, and
@@ -541,7 +541,7 @@ The load-bearing points, if you read nothing else:
   branch; the loop resets it to origin after every merge.
 - **Run the two reviewers in parallel and never show one the other's findings.**
   Correlated reviewers are one reviewer at twice the price.
-- **One defect, one bead.** Dedupe across reviewers before `br create`, or you
+- **One defect, one bead.** Dedupe across reviewers before `"$BEADS_JSONL_RESOLVER" --run-br create`, or you
   build yourself a merge conflict out of two branches fixing the same line.
 - **Every bead's acceptance criteria name what must KEEP working**, not only
   what is broken. Skip that and a security narrowing produces an over-correction
@@ -594,7 +594,7 @@ phrases like "X happens when Y", not only test function names.>
   `.beads/` as orchestration/state directories, not product code to review.
   That is a *reviewing* scope rule, not an editing licence — nobody, implementer
   or operator, hand-edits `.beads/issues.jsonl`; bead text is written with
-  `br update -d/--notes` or it gets silently reverted by the next flush
+  `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes` or it gets silently reverted by the next flush
   ([exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11)).
   This does NOT forbid ordinary git usage: **`git add` any new SOURCE file you
   create** so it appears in the reviewed diff (`git diff <base>` omits untracked
@@ -610,7 +610,7 @@ phrases like "X happens when Y", not only test function names.>
   show.
 
 ## Acceptance criteria
-- <Acceptance criteria copied from `br show <id>`.>
+- <Acceptance criteria copied from `"$BEADS_JSONL_RESOLVER" --run-br show <id>`.>
 - <What must KEEP working — name the legitimate cases the change must preserve.
   Criteria that only describe what to block get signed off, and the breakage
   they cause comes back as its own bead later.>
@@ -628,7 +628,7 @@ while the evidence is fresh:
 - If rb-lite fails for a reason unrelated to the bead (tool crash, reviewer
   panel failure, auth/config breakage, task parser bug, ignored-files problem,
   or implementer self-interference), file a fresh bead with
-  `br create -t bug -p <0|1|2> -l dogfood,rb-lite "..." -d "..."`. Include
+  `"$BEADS_JSONL_RESOLVER" --run-br create -t bug -p <0|1|2> -l dogfood,rb-lite "..." -d "..."`. Include
   observed behavior, repro trace, expected behavior, likely fix options, and
   acceptance criteria.
 - If the dogfood bead is P0 or P1, interrupt the queue and fix it next. Since
@@ -990,7 +990,9 @@ rb-lite run \
 **Run one bead from a backlog:**
 
 ```bash
-br show <id>
+# First initialize BEADS_JSONL_RESOLVER with the installed companion procedure
+# in references/harden-until-clean.md section 2.
+"$BEADS_JSONL_RESOLVER" --run-br show <id>
 rb-lite run \
   --implementer claude,codex \
   --task-file .rb-lite/tasks/bead-<id>.md \

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -594,7 +594,7 @@ phrases like "X happens when Y", not only test function names.>
   `.beads/` as orchestration/state directories, not product code to review.
   That is a *reviewing* scope rule, not an editing licence — nobody, implementer
   or operator, hand-edits `.beads/issues.jsonl`; bead text is written with
-  `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes` or it gets silently reverted by the next flush
+  `"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "<full body>"` or it gets silently reverted by the next flush
   ([exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11)).
   This does NOT forbid ordinary git usage: **`git add` any new SOURCE file you
   create** so it appears in the reviewed diff (`git diff <base>` omits untracked

--- a/skills/orchestrating-with-rb-lite/SKILL.md
+++ b/skills/orchestrating-with-rb-lite/SKILL.md
@@ -182,7 +182,10 @@ for PR creation/checks/merge, and **`jq` in the HOST shell**. That last one is n
 covered by the Nix-wrapper exemption above: the wrapper supplies `jq` to rb-lite, not
 to you. Load exact companion skill `rb-lite-backlog-drain` for
 [step 11's collateral-damage check and recovery](../rb-lite-backlog-drain/SKILL.md#backlog-step-11),
-which resolve the graph's real path through `br where --json | jq`. Without host `jq` a drain can run `br update`
+which resolve the graph's real path through exact companion
+`beads-jsonl-path/scripts/resolve-beads-jsonl` — its default clean-state mode before the
+first write, `--allow-dirty` for the structurally tracked post-write field diff, and
+`--recovery` only when naming the damaged artifact. Without that owner a drain can run `br update`
 and flush — silently reverting unrelated bead bodies — and only then fail at the command
 that would have located the damage. Check it before the first bead, not after. Require **`br` ≥ 0.1.45**: older builds corrupt
 their DB after branch resets, so `br update`/`br close` start returning

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -48,10 +48,10 @@ loop:
   many subcommands and a silent misconfiguration is expensive.
 - The exact `beads-jsonl-path` companion is available. Run it before section 3; it
   diagnoses host dependencies such as `jq` and refuses any JSONL state that is not clean,
-  tracked, and owned by this worktree before the first `br create` can flush.
+  tracked, and owned by this worktree before the first `"$BEADS_JSONL_RESOLVER" --run-br create` can flush.
 - `br` is **≥ 0.1.45**. Older versions corrupt their DB after branch resets:
-  `br update`/`br close` start returning `ISSUE_NOT_FOUND` while `br show` and
-  `br list` keep working, which hides the problem until you have lost bead state.
+  `"$BEADS_JSONL_RESOLVER" --run-br update`/`"$BEADS_JSONL_RESOLVER" --run-br close` start returning `ISSUE_NOT_FOUND` while `"$BEADS_JSONL_RESOLVER" --run-br show` and
+  `"$BEADS_JSONL_RESOLVER" --run-br list` keep working, which hides the problem until you have lost bead state.
   This loop resets branches constantly, so it hits that bug hard.
 
 Set up once, before iteration 1:
@@ -308,7 +308,7 @@ _bjp_regular_link_count() {
   fi
   printf '%s\n' "$count"
 }
-_bjp_git_environment=( "${!GIT_@}" )
+_bjp_git_environment=( "${!GIT@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
     printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -318,6 +318,7 @@ done
 unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
+BEADS_GIT_RUNNER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
   "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
   "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -362,6 +363,10 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  [ -f "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+    exit 1
+  }
   _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
     printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
     exit 1
@@ -380,16 +385,50 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_shebang
+  _bjp_runner="$_bjp_candidate_dir/git-clean"
+  [ -x "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+    exit 1
+  }
+  [ ! -L "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  [ -f "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+    exit 1
+  }
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
-  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    BEADS_GIT_RUNNER=$_bjp_runner
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+      || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
     printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
     exit 1
   fi
+  unset _bjp_runner
 done
 unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-[ -n "$BEADS_JSONL_RESOLVER" ] || {
+[ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
 }
@@ -397,6 +436,7 @@ printf '%s\n' "$BEADS_JSONL_RESOLVER"
 __BJP_TRUSTED_BASH__
   )
 ) || exit 1
+BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
 unset _bjp_candidate
 # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
 # is whatever executable the repo you are hardening planted there, and this snippet would
@@ -412,7 +452,7 @@ If the owner refuses, resolve the reported state first — recovery case (a) in
 [exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11). After the first flush the choice
 is gone.
 
-**Start a replay manifest before minting.** Section 3 runs one `br create` per finding,
+**Start a replay manifest before minting.** Section 3 runs one `"$BEADS_JSONL_RESOLVER" --run-br create` per finding,
 each auto-flushing, and the damage check comes after all of them. If it fires,
 [exact companion skill `rb-lite-backlog-drain`, step 11 recovery](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11) deletes the cache
 and requires every intended mutation replayed — so record the
@@ -422,7 +462,7 @@ the good JSONL discards the whole iteration's legitimate bead additions.
 ## 3. Mint one bead per real finding
 
 ```bash
-br create --actor "$ACTOR" "<short, concrete title>" \
+"$BEADS_JSONL_RESOLVER" --run-br create --actor "$ACTOR" "<short, concrete title>" \
   --priority <0..4> \
   --type bug \
   --labels <area>,code-review,review-src:<both|codex|claude> \
@@ -455,15 +495,28 @@ extra round trip.
 Then flush and commit — `br` never touches git, that part is yours:
 
 ```bash
-br sync --flush-only || { echo "findings not persisted"; exit 1; }
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "findings not persisted"; exit 1; }
 # In a fresh shell, rerun the resolver-locator block from section 2 first,
 # stopping before its final clean-mode `BEADS_JSONL=` call. `--allow-dirty`
 # because the findings you just flushed ARE the divergence the default mode refuses — that
 # mode guards writes, and this diff runs after one.
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
   || { echo "cannot resolve the beads JSONL"; exit 1; }
-git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
+BEADS_REVIEWED_HEAD=$("$BEADS_GIT_RUNNER" head-oid) \
+  || { echo "cannot resolve HEAD before review"; exit 1; }
+BEADS_REVIEWED_OID=$("$BEADS_GIT_RUNNER" hash-file "$BEADS_JSONL") \
+  || { echo "cannot hash the JSONL before review"; exit 1; }
+unset BEADS_DIFF_REVIEWED
+"$BEADS_GIT_RUNNER" --literal-pathspecs diff --no-ext-diff --no-textconv --text HEAD -- "$BEADS_JSONL" \
   || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
+BEADS_POSTDIFF_OID=$("$BEADS_GIT_RUNNER" hash-file "$BEADS_JSONL") \
+  || { echo "cannot hash the JSONL after review"; exit 1; }
+BEADS_POSTDIFF_HEAD=$("$BEADS_GIT_RUNNER" head-oid) \
+  || { echo "cannot resolve HEAD after review"; exit 1; }
+[[ "$BEADS_REVIEWED_OID" == "$BEADS_POSTDIFF_OID" \
+   && "$BEADS_REVIEWED_HEAD" == "$BEADS_POSTDIFF_HEAD" ]] \
+  || { echo "the JSONL or HEAD changed while its diff was rendered — rerun the review"; exit 1; }
+unset BEADS_POSTDIFF_OID BEADS_POSTDIFF_HEAD
 ```
 
 **Stop the block here and read that diff.** This is a real split, not a comment: run the
@@ -479,13 +532,21 @@ exists to catch. Prose underneath a `git add` cannot stop a shell.
 # Bind the acknowledgement to THIS pass. The loop runs in one shell, so a value set in
 # iteration 1 would satisfy every later iteration and let an unreviewed diff stage,
 # commit and push — the gate passing on the strength of a decision about a different
-# graph. Unset it before the diff, and record the pass it belongs to.
-unset BEADS_DIFF_REVIEWED
+# graph. The first block unset it before rendering this pass's diff.
 # ...print and read the diff, then:
 : "${BEADS_DIFF_REVIEWED:?read THIS pass's diff, then set it to \"pass $ITERATION: <what you found>\"}"
-git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs add -- "$BEADS_JSONL"
-git commit -m "chore(beads): record review findings (iteration <N>, codex+claude/<model>)"
-git push
+: "${BEADS_REVIEWED_OID:?rerun this pass's stable JSONL diff before staging}"
+"$BEADS_GIT_RUNNER" --literal-pathspecs add --expect-oid "$BEADS_REVIEWED_OID" -- "$BEADS_JSONL" \
+  || { echo "cannot stage the reviewed JSONL — do NOT commit"; exit 1; }
+BEADS_COMMIT_OID=$("$BEADS_GIT_RUNNER" commit --only-reviewed "$BEADS_JSONL" \
+  --expect-oid "$BEADS_REVIEWED_OID" \
+  --expect-head "$BEADS_REVIEWED_HEAD" \
+  -m "chore(beads): record review findings (iteration <N>, codex+claude/<model>)") \
+  || { echo "cannot commit the reviewed JSONL — do NOT push"; exit 1; }
+: "${WORK_BRANCH:?set the exact reviewed work branch before pushing}"
+"$BEADS_GIT_RUNNER" push --remote origin --branch "$WORK_BRANCH" \
+  --expect-head "$BEADS_COMMIT_OID" \
+  || { echo "cannot push the reviewed JSONL commit"; exit 1; }
 ```
 
 Do not stage that file unread. The flush re-exports **every** bead from the
@@ -507,7 +568,7 @@ message. Months later it explains why iteration N looks thin.
 Hand off to exact companion skill
 [`rb-lite-backlog-drain`](../../rb-lite-backlog-drain/SKILL.md) and follow it exactly:
 one bead, one branch, one rb-lite run, local gates, one **work** PR, one
-squash merge, one `br close`. (Closing the last bead in a scope needs its own small
+squash merge, one `"$BEADS_JSONL_RESOLVER" --run-br close`. (Closing the last bead in a scope needs its own small
 metadata PR — that is bookkeeping, not a second work PR, and the rule still holds.) Nothing about draining changes here.
 
 Two rules from the drain workflow matter more in this mode than usual:
@@ -515,8 +576,8 @@ Two rules from the drain workflow matter more in this mode than usual:
 - **Serialize.** Do not start bead B's run while bead A is open. Two long-lived
   branches merging into the same base is where conflicts live.
 - **Evidence-first closure.** The closure has to say which merge satisfied the bead:
-  put the merge SHA and PR number in the **closure commit message**. `br close` also
-  takes `--reason`, but the drain path closes with `br update <id> -s closed` for the
+  put the merge SHA and PR number in the **closure commit message**. `"$BEADS_JSONL_RESOLVER" --run-br close` also
+  takes `--reason`, but the drain path closes with `"$BEADS_JSONL_RESOLVER" --run-br update <id> -s closed` for the
   flush behaviour that
   [exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11)
   explains — so the commit message is where this evidence reliably lands. A bead closed

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -316,7 +316,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
     exit 1
   }
-  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
     printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
     exit 1
   }
@@ -429,7 +429,7 @@ br sync --flush-only || { echo "findings not persisted"; exit 1; }
 # mode guards writes, and this diff runs after one.
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
   || { echo "cannot resolve the beads JSONL"; exit 1; }
-git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
+git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
   || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
 ```
 
@@ -450,7 +450,7 @@ exists to catch. Prose underneath a `git add` cannot stop a shell.
 unset BEADS_DIFF_REVIEWED
 # ...print and read the diff, then:
 : "${BEADS_DIFF_REVIEWED:?read THIS pass's diff, then set it to \"pass $ITERATION: <what you found>\"}"
-git --no-replace-objects --literal-pathspecs add -- "$BEADS_JSONL"
+git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs add -- "$BEADS_JSONL"
 git commit -m "chore(beads): record review findings (iteration <N>, codex+claude/<model>)"
 git push
 ```

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -371,6 +371,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -258,6 +258,26 @@ unstaged, hidden-index, unmerged, type, mode, or wrong-worktree state must refus
 write before the cache can overwrite it:
 
 ```bash
+# Clear loader injection in this already-running shell before the locator starts
+# any new process. The resolver/git-clean script bodies are too late: a shebang
+# interpreter would already have loaded caller-selected libraries.
+_bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+_bjp_posixly_value=${POSIXLY_CORRECT-}
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+  printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+if [ -n "$_bjp_posixly_was_set" ]; then
+  POSIXLY_CORRECT=$_bjp_posixly_value
+  export POSIXLY_CORRECT
+else
+  \unset POSIXLY_CORRECT
+fi
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -522,6 +522,8 @@ Then flush and commit — `br` never touches git, that part is yours:
 # mode guards writes, and this diff runs after one.
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
   || { echo "cannot resolve the beads JSONL"; exit 1; }
+BEADS_REVIEWED_BRANCH=$("$BEADS_GIT_RUNNER" head-branch) \
+  || { echo "cannot resolve the attached branch before review"; exit 1; }
 BEADS_REVIEWED_HEAD=$("$BEADS_GIT_RUNNER" head-oid) \
   || { echo "cannot resolve HEAD before review"; exit 1; }
 BEADS_REVIEWED_OID=$("$BEADS_GIT_RUNNER" hash-file "$BEADS_JSONL") \
@@ -533,10 +535,13 @@ BEADS_POSTDIFF_OID=$("$BEADS_GIT_RUNNER" hash-file "$BEADS_JSONL") \
   || { echo "cannot hash the JSONL after review"; exit 1; }
 BEADS_POSTDIFF_HEAD=$("$BEADS_GIT_RUNNER" head-oid) \
   || { echo "cannot resolve HEAD after review"; exit 1; }
+BEADS_POSTDIFF_BRANCH=$("$BEADS_GIT_RUNNER" head-branch) \
+  || { echo "cannot resolve the attached branch after review"; exit 1; }
 [[ "$BEADS_REVIEWED_OID" == "$BEADS_POSTDIFF_OID" \
-   && "$BEADS_REVIEWED_HEAD" == "$BEADS_POSTDIFF_HEAD" ]] \
-  || { echo "the JSONL or HEAD changed while its diff was rendered — rerun the review"; exit 1; }
-unset BEADS_POSTDIFF_OID BEADS_POSTDIFF_HEAD
+   && "$BEADS_REVIEWED_HEAD" == "$BEADS_POSTDIFF_HEAD" \
+   && "$BEADS_REVIEWED_BRANCH" == "$BEADS_POSTDIFF_BRANCH" ]] \
+  || { echo "the JSONL, HEAD, or branch changed while its diff was rendered — rerun the review"; exit 1; }
+unset BEADS_POSTDIFF_OID BEADS_POSTDIFF_HEAD BEADS_POSTDIFF_BRANCH
 ```
 
 **Stop the block here and read that diff.** This is a real split, not a comment: run the
@@ -556,14 +561,18 @@ exists to catch. Prose underneath a `git add` cannot stop a shell.
 # ...print and read the diff, then:
 : "${BEADS_DIFF_REVIEWED:?read THIS pass's diff, then set it to \"pass $ITERATION: <what you found>\"}"
 : "${BEADS_REVIEWED_OID:?rerun this pass's stable JSONL diff before staging}"
+: "${BEADS_REVIEWED_BRANCH:?rerun this pass's stable branch proof before staging}"
+: "${WORK_BRANCH:?set the exact reviewed work branch before staging}"
+[[ "$WORK_BRANCH" == "$BEADS_REVIEWED_BRANCH" ]] \
+  || { echo "WORK_BRANCH differs from the branch whose diff was reviewed"; exit 1; }
 "$BEADS_GIT_RUNNER" --literal-pathspecs add --expect-oid "$BEADS_REVIEWED_OID" -- "$BEADS_JSONL" \
   || { echo "cannot stage the reviewed JSONL — do NOT commit"; exit 1; }
 BEADS_COMMIT_OID=$("$BEADS_GIT_RUNNER" commit --only-reviewed "$BEADS_JSONL" \
   --expect-oid "$BEADS_REVIEWED_OID" \
   --expect-head "$BEADS_REVIEWED_HEAD" \
+  --expect-branch "$BEADS_REVIEWED_BRANCH" \
   -m "chore(beads): record review findings (iteration <N>, codex+claude/<model>)") \
   || { echo "cannot commit the reviewed JSONL — do NOT push"; exit 1; }
-: "${WORK_BRANCH:?set the exact reviewed work branch before pushing}"
 "$BEADS_GIT_RUNNER" push --remote origin --branch "$WORK_BRANCH" \
   --expect-head "$BEADS_COMMIT_OID" \
   || { echo "cannot push the reviewed JSONL commit"; exit 1; }

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -293,6 +293,21 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
 _bjp_git_environment=( "${!GIT_@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
@@ -347,6 +362,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -355,7 +379,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   fi
 done
-unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
 [ -n "$BEADS_JSONL_RESOLVER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -46,11 +46,9 @@ loop:
 - You know both refs: the *work branch* being hardened and the *review base*
   (usually the default branch). Ask once if either is unclear — the loop runs
   many subcommands and a silent misconfiguration is expensive.
-- **`jq` is on the HOST `PATH`.** Not a backlog-drain-only prerequisite: section 3 runs
-  `br create` and flushes before anything resolves the graph's path, and that resolution
-  is `br where --json | jq` in *your* shell — the Nix wrapper supplies jq to rb-lite, not
-  to you. Without it this loop mutates the graph and only then fails at the command that
-  would have located the damage. Check before section 3, not after.
+- The exact `beads-jsonl-path` companion is available. Run it before section 3; it
+  diagnoses host dependencies such as `jq` and refuses any JSONL state that is not clean,
+  tracked, and owned by this worktree before the first `br create` can flush.
 - `br` is **≥ 0.1.45**. Older versions corrupt their DB after branch resets:
   `br update`/`br close` start returning `ISSUE_NOT_FOUND` while `br show` and
   `br list` keep working, which hides the problem until you have lost bead state.
@@ -254,39 +252,122 @@ it still chooses how far to read, so run the grep yourself. Classes that repeat:
 - scheme/domain/host scoping at every write site of the same cookie
 
 
-**Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
-auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
-first write — and since neither the index nor `HEAD` holds it, every later diff shows only
-your intended changes and the loss becomes *undetectable*. Resolve the path in its own
-checked steps, and check the inspection too — embedded in a `git status` argument the
-resolution's exit code is swallowed, and two of those failures are **silent** rather than
-loud. Measured on git 2.54.0 / jq 1.8.2:
-
-- `br where` exiting non-zero *after* emitting valid JSON. The pipeline reports only its
-  last command's status, so `jq` succeeds and the assignment returns 0.
-- `br where` emitting JSON without the key: `jq -er .jsonl_path` exits 1 **and prints
-  `null`**, so the substitution yields the literal pathspec `null` and
-  `git status --porcelain -- null` exits 0 printing nothing.
-
-(A genuinely empty pathspec is *not* the hazard — `git status --porcelain -- ""` fails
-loudly with `fatal: empty string is not a valid pathspec`, exit 128, on the version stated
-above. Behavior may differ on older git — unmeasured here; if you must support one,
-measure there.)
-
-And `git status` itself can fail — a JSONL resolved outside this worktree exits 128
-(`fatal: … is outside repository`) — printing nothing on **stdout**, so gating on stdout
-emptiness alone reads a failed inspection as a clean tree right before the destructive
-first flush:
+**Before the first `br` write, resolve and prove the JSONL clean through its exact fact
+owner.** Any `br` mutation auto-flushes the cache over the tracked file, so staged,
+unstaged, hidden-index, unmerged, type, mode, or wrong-worktree state must refuse the
+write before the cache can overwrite it:
 
 ```bash
-_bw=$(br where --json) || { echo "cannot resolve the beads JSONL"; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
-_st=$(git status --porcelain -- "$BEADS_JSONL") \
-  || { echo "cannot read the worktree — do NOT write"; exit 1; }
-printf '%s' "$_st"
+BEADS_JSONL_RESOLVER=$(
+  (
+    # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+    # prevents exported caller functions from redefining this trust path, and the
+    # subshell leaves the caller's shell state untouched.
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset -f command builtin exec unset 2>/dev/null || :
+    _bjp_bash=$(command -p -v bash) || {
+      printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+      exit 1
+    }
+    unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+    exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+# Privileged Bash ignores inherited functions. Clear the other startup controls too,
+# then perform every candidate, worktree, provenance, and byte-agreement decision here.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjp_function; do
+  command unset -f -- "$_bjp_function" || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjp_function
+_bjp_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_cmp=$(command -p -v cmp) || {
+  printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in
+    /*) ;;
+    *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+  esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+      printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+      exit 1
+      ;;
+  esac
+  unset _bjp_candidate_dir
+  if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+    BEADS_JSONL_RESOLVER=$_bjp_candidate
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+    exit 1
+  fi
+done
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+  exit 1
+}
+printf '%s\n' "$BEADS_JSONL_RESOLVER"
+__BJP_TRUSTED_BASH__
+  )
+) || exit 1
+unset _bjp_candidate
+# Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
+# is whatever executable the repo you are hardening planted there, and this snippet would
+# run it. From a checkout, run that checkout's copy by absolute path instead.
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  echo "beads-jsonl-path companion unavailable — do NOT write" >&2
+  exit 1
+}
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
 ```
 
-If it is not empty, resolve it first — recovery case (a) in
+If the owner refuses, resolve the reported state first — recovery case (a) in
 [exact companion skill `rb-lite-backlog-drain`, step 11](../../rb-lite-backlog-drain/SKILL.md#backlog-step-11). After the first flush the choice
 is gone.
 
@@ -334,9 +415,14 @@ Then flush and commit — `br` never touches git, that part is yours:
 
 ```bash
 br sync --flush-only || { echo "findings not persisted"; exit 1; }
-_bw=$(br where --json) || { echo "cannot resolve the beads JSONL"; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
-git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
+# In a fresh shell, rerun the resolver-locator block from section 2 first,
+# stopping before its final clean-mode `BEADS_JSONL=` call. `--allow-dirty`
+# because the findings you just flushed ARE the divergence the default mode refuses — that
+# mode guards writes, and this diff runs after one.
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
+  || { echo "cannot resolve the beads JSONL"; exit 1; }
+git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" \
+  || { echo "cannot diff the JSONL — do NOT stage"; exit 1; }
 ```
 
 **Stop the block here and read that diff.** This is a real split, not a comment: run the
@@ -356,7 +442,7 @@ exists to catch. Prose underneath a `git add` cannot stop a shell.
 unset BEADS_DIFF_REVIEWED
 # ...print and read the diff, then:
 : "${BEADS_DIFF_REVIEWED:?read THIS pass's diff, then set it to \"pass $ITERATION: <what you found>\"}"
-git add -- "$BEADS_JSONL"
+git --no-replace-objects --literal-pathspecs add -- "$BEADS_JSONL"
 git commit -m "chore(beads): record review findings (iteration <N>, codex+claude/<model>)"
 git push
 ```

--- a/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
+++ b/skills/orchestrating-with-rb-lite/references/harden-until-clean.md
@@ -293,6 +293,14 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_git_environment=( "${!GIT_@}" )
+for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+  command unset -- "$_bjp_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+done
+unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -71,6 +71,14 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_git_environment=( "${!GIT_@}" )
+for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+  command unset -- "$_bjp_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+done
+unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -308,7 +308,7 @@ order.
     copy of is reverted — silently, exit 0. Transferring a plan means writing long
     specification bodies, and pasting one into `.beads/issues.jsonl` by hand is precisely
     what makes the cache stale: a hand edit does not advance `updated_at`, so the two
-    become indistinguishable by timestamp. Write every body through `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`,
+    become indistinguishable by timestamp. Write every body through `"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "<full body>"`,
     rerun the resolver-locator block above,
     stopping before its final clean-mode `BEADS_JSONL=` call, and resolve the post-write
     path with

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -71,6 +71,21 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
 _bjp_git_environment=( "${!GIT_@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
@@ -125,6 +140,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -133,7 +157,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   fi
 done
-unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
 [ -n "$BEADS_JSONL_RESOLVER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -86,7 +86,7 @@ _bjp_regular_link_count() {
   fi
   printf '%s\n' "$count"
 }
-_bjp_git_environment=( "${!GIT_@}" )
+_bjp_git_environment=( "${!GIT@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
     printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -96,6 +96,7 @@ done
 unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
+BEADS_GIT_RUNNER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
   "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
   "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -140,6 +141,10 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  [ -f "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+    exit 1
+  }
   _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
     printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
     exit 1
@@ -158,16 +163,50 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_shebang
+  _bjp_runner="$_bjp_candidate_dir/git-clean"
+  [ -x "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+    exit 1
+  }
+  [ ! -L "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  [ -f "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+    exit 1
+  }
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
-  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    BEADS_GIT_RUNNER=$_bjp_runner
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+      || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
     printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
     exit 1
   fi
+  unset _bjp_runner
 done
 unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-[ -n "$BEADS_JSONL_RESOLVER" ] || {
+[ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
 }
@@ -175,6 +214,7 @@ printf '%s\n' "$BEADS_JSONL_RESOLVER"
 __BJP_TRUSTED_BASH__
   )
 ) || exit 1
+BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
 unset _bjp_candidate
 # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
 # is whatever executable the repo you are transferring into planted there, and this
@@ -210,7 +250,7 @@ Stop and report plan gaps when any of these are still fuzzy:
 1. Establish the current graph baseline before creating anything:
 
    ```bash
-   br list --limit 0 --json -a
+   "$BEADS_JSONL_RESOLVER" --run-br list --limit 0 --json -a
    bv --robot-triage
    bv --robot-plan
    bv --robot-search --search "..."    # optional overlap check
@@ -223,7 +263,7 @@ Stop and report plan gaps when any of these are still fuzzy:
    - constraints, non-goals, and security boundaries
    - migrations, rollout, docs, and compatibility work when the plan calls for them
    - verification obligations: unit, integration/e2e, logging, diagnostics, observability
-3. Choose the graph shape before typing `br create`:
+3. Choose the graph shape before typing `"$BEADS_JSONL_RESOLVER" --run-br create`:
    - use epics only for real umbrella surfaces or architectural slices
    - use tasks for independently claimable work packets
    - use subtasks only when they sharpen sequencing instead of hiding it
@@ -244,16 +284,16 @@ order.
    - failure handling or recovery obligations
    - decisive tests and diagnostics
    - gotchas a future agent would otherwise rediscover
-7. Add explicit dependencies with `br dep add`. Optimize for correctness and a healthy ready frontier; over-constraining the graph slows the swarm.
+7. Add explicit dependencies with `"$BEADS_JSONL_RESOLVER" --run-br dep add`. Optimize for correctness and a healthy ready frontier; over-constraining the graph slows the swarm.
 8. Run the transfer audit in both directions:
    - plan -> beads: every important plan element lands somewhere
    - beads -> plan: every bead has clear backing in the plan or an explicitly approved delta
    - if the audit feels suspiciously short or self-satisfied, assume coverage is incomplete and rerun more exhaustively
 9. Split, merge, rewrite, or close beads until the graph can stand on its own as executable memory.
-10. Flush with an **explicit** `br sync --flush-only` and require it to succeed:
+10. Flush with an **explicit** `"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only` and require it to succeed:
 
     ```bash
-    br sync --flush-only || { echo "flush failed — mutations not persisted"; exit 1; }
+    "$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "flush failed — mutations not persisted"; exit 1; }
     ```
 
     The explicit sync propagates a real exit code, which the *automatic* flush after each
@@ -268,7 +308,7 @@ order.
     copy of is reverted — silently, exit 0. Transferring a plan means writing long
     specification bodies, and pasting one into `.beads/issues.jsonl` by hand is precisely
     what makes the cache stale: a hand edit does not advance `updated_at`, so the two
-    become indistinguishable by timestamp. Write every body through `br update -d/--notes`,
+    become indistinguishable by timestamp. Write every body through `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`,
     rerun the resolver-locator block above,
     stopping before its final clean-mode `BEADS_JSONL=` call, and resolve the post-write
     path with
@@ -276,7 +316,7 @@ order.
     (the transfer you just wrote is the divergence the default mode refuses; `.beads/` is
     only the default layout, and a hardcoded path diffs nothing on the others) — ids on
     only one side, or a
-    `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
+    `description` you did not touch, is the tell. Recovery, and why `"$BEADS_JSONL_RESOLVER" --run-br sync --import-only`
     cannot do it, is in
     [exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11) — but note
     its replay step assumes a SINGLE mutation, the drain's case. A transfer has a whole
@@ -286,7 +326,7 @@ order.
     which is not automatically `HEAD`: if the index holds the last good export and HEAD
     an older one, `git checkout HEAD --` overwrites the good staged copy too. Step 11
     requires that choice explicitly; make it there rather than assuming.
-11. If the repo workflow supports it, run `br lint` after major rewrites to catch missing sections.
+11. If the repo workflow supports it, run `"$BEADS_JSONL_RESOLVER" --run-br lint` after major rewrites to catch missing sections.
 
 ## Quality bar
 
@@ -315,20 +355,20 @@ Do not:
 ## Command palette
 
 ```bash
-br list --limit 0 --json -a
-br search "query" -a --json
-br show <id> --json
-br create "Title" --type task --priority 2 --description "..."
-br create "Epic" --type epic --priority 1 --description "..."
-br create "Subtask" --parent <epic-id> --priority 2 --description "..."
-br update <id> --description "..."
-br dep add <issue> <depends-on>
-br close <id> --reason "..."
-br lint
+"$BEADS_JSONL_RESOLVER" --run-br list --limit 0 --json -a
+"$BEADS_JSONL_RESOLVER" --run-br search "query" -a --json
+"$BEADS_JSONL_RESOLVER" --run-br show <id> --json
+"$BEADS_JSONL_RESOLVER" --run-br create "Title" --type task --priority 2 --description "..."
+"$BEADS_JSONL_RESOLVER" --run-br create "Epic" --type epic --priority 1 --description "..."
+"$BEADS_JSONL_RESOLVER" --run-br create "Subtask" --parent <epic-id> --priority 2 --description "..."
+"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "..."
+"$BEADS_JSONL_RESOLVER" --run-br dep add <issue> <depends-on>
+"$BEADS_JSONL_RESOLVER" --run-br close <id> --reason "..."
+"$BEADS_JSONL_RESOLVER" --run-br lint
 bv --robot-triage
 bv --robot-plan
 bv --robot-search --search "query"
-br sync --flush-only
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only
 ```
 
 ## Pipeline position

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -94,7 +94,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
     exit 1
   }
-  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
     printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
     exit 1
   }

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -22,50 +22,130 @@ Turn plan-space intent into bead-space executable memory without losing anything
 
 ## Preflight
 
-- Confirm `br`, `bv`, **and `jq`** are on `PATH`. If any is missing, stop and say so.
-  `jq` is load-bearing, not optional: every `br` write can silently revert other beads
-  (step 10), and both the damage check and the recovery resolve the graph's real path
-  through `br where --json | jq`. Without it a transfer can write a whole graph and then
-  be unable to tell whether it destroyed one — the ordering that must not be possible.
-  If `br where --json` cannot be parsed on this host, do not write to the graph.
+- Confirm `br`, `bv`, and the exact `beads-jsonl-path` companion are available. The
+  companion diagnoses its own host dependencies, including `jq`; if it cannot resolve
+  and prove a clean tracked JSONL, do not write to the graph.
 - Re-read `AGENTS.md`, `README.md`, and every relevant plan/spec file before mutating the graph.
 - If the session was compacted, or the plan changed materially since the last pass, reread before editing.
 - Refuse the transfer if core workflows, boundaries, constraints, failure modes, sequencing, or verification are still unstable. Report plan gaps instead of encoding guesses into beads.
 
 
-**Before the first `br` write, check the JSONL for divergence.** Any `br` mutation
-auto-flushes the cache over the tracked file, so an unstaged hand-edit is erased by your
-first write — and since neither the index nor `HEAD` holds it, every later diff shows only
-your intended changes and the loss becomes *undetectable*. Resolve the path in its own
-checked steps, and check the inspection too — embedded in a `git status` argument the
-resolution's exit code is swallowed, and two of those failures are **silent** rather than
-loud. Measured on git 2.54.0 / jq 1.8.2:
-
-- `br where` exiting non-zero *after* emitting valid JSON. The pipeline reports only its
-  last command's status, so `jq` succeeds and the assignment returns 0.
-- `br where` emitting JSON without the key: `jq -er .jsonl_path` exits 1 **and prints
-  `null`**, so the substitution yields the literal pathspec `null` and
-  `git status --porcelain -- null` exits 0 printing nothing.
-
-(A genuinely empty pathspec is *not* the hazard — `git status --porcelain -- ""` fails
-loudly with `fatal: empty string is not a valid pathspec`, exit 128, on the version stated
-above. Behavior may differ on older git — unmeasured here; if you must support one,
-measure there.)
-
-And `git status` itself can fail — a JSONL resolved outside this worktree exits 128
-(`fatal: … is outside repository`) — printing nothing on **stdout**, so gating on stdout
-emptiness alone reads a failed inspection as a clean tree right before the destructive
-first flush:
+**Before the first `br` write, resolve and prove the JSONL clean through its exact fact
+owner.** Any `br` mutation auto-flushes the cache over the tracked file, so staged,
+unstaged, hidden-index, unmerged, type, mode, or wrong-worktree state must refuse the
+write before the cache can overwrite it:
 
 ```bash
-_bw=$(br where --json) || { echo "cannot resolve the beads JSONL"; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL"; exit 1; }
-_st=$(git status --porcelain -- "$BEADS_JSONL") \
-  || { echo "cannot read the worktree — do NOT write"; exit 1; }
-printf '%s' "$_st"
+BEADS_JSONL_RESOLVER=$(
+  (
+    # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+    # prevents exported caller functions from redefining this trust path, and the
+    # subshell leaves the caller's shell state untouched.
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset -f command builtin exec unset 2>/dev/null || :
+    _bjp_bash=$(command -p -v bash) || {
+      printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+      exit 1
+    }
+    unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+    exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+# Privileged Bash ignores inherited functions. Clear the other startup controls too,
+# then perform every candidate, worktree, provenance, and byte-agreement decision here.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjp_function; do
+  command unset -f -- "$_bjp_function" || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjp_function
+_bjp_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_cmp=$(command -p -v cmp) || {
+  printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in
+    /*) ;;
+    *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+  esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+      printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+      exit 1
+      ;;
+  esac
+  unset _bjp_candidate_dir
+  if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+    BEADS_JSONL_RESOLVER=$_bjp_candidate
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+    exit 1
+  fi
+done
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+  exit 1
+}
+printf '%s\n' "$BEADS_JSONL_RESOLVER"
+__BJP_TRUSTED_BASH__
+  )
+) || exit 1
+unset _bjp_candidate
+# Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
+# is whatever executable the repo you are transferring into planted there, and this
+# snippet would run it. From a checkout, run that checkout's copy by absolute path.
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  echo "beads-jsonl-path companion unavailable — do NOT write" >&2
+  exit 1
+}
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
 ```
 
-If it is not empty, resolve it first — recovery case (a) in
+If the owner refuses, resolve the reported state first — recovery case (a) in
 [exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11).
 **Companion unavailable: stop, rerun the same installer command once, reload it, and do
 not improvise this procedure.**
@@ -148,9 +228,13 @@ order.
     specification bodies, and pasting one into `.beads/issues.jsonl` by hand is precisely
     what makes the cache stale: a hand edit does not advance `updated_at`, so the two
     become indistinguishable by timestamp. Write every body through `br update -d/--notes`,
-    and field-diff the tracked JSONL before committing (resolve it with
-    `br where --json | jq -er .jsonl_path`; `.beads/` is only the default layout, and a
-    hardcoded path diffs nothing on the others) — ids on only one side, or a
+    rerun the resolver-locator block above,
+    stopping before its final clean-mode `BEADS_JSONL=` call, and resolve the post-write
+    path with
+    `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1` before field-diffing it
+    (the transfer you just wrote is the divergence the default mode refuses; `.beads/` is
+    only the default layout, and a hardcoded path diffs nothing on the others) — ids on
+    only one side, or a
     `description` you did not touch, is the tell. Recovery, and why `br sync --import-only`
     cannot do it, is in
     [exact companion skill `rb-lite-backlog-drain`, step 11](../rb-lite-backlog-drain/SKILL.md#backlog-step-11) — but note

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -149,6 +149,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/plan-to-beads-transfer/SKILL.md
+++ b/skills/plan-to-beads-transfer/SKILL.md
@@ -36,6 +36,26 @@ unstaged, hidden-index, unmerged, type, mode, or wrong-worktree state must refus
 write before the cache can overwrite it:
 
 ```bash
+# Clear loader injection in this already-running shell before the locator starts
+# any new process. The resolver/git-clean script bodies are too late: a shebang
+# interpreter would already have loaded caller-selected libraries.
+_bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+_bjp_posixly_value=${POSIXLY_CORRECT-}
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+  printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+if [ -n "$_bjp_posixly_was_set" ]; then
+  POSIXLY_CORRECT=$_bjp_posixly_value
+  export POSIXLY_CORRECT
+else
+  \unset POSIXLY_CORRECT
+fi
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -351,29 +351,125 @@ implement → review loop for each bead.
     mutation is already in the shared DB, so the sync either writes it out or fails loudly:
 
     ```bash
-    # DIVERGENCE CHECK FIRST — `br update` auto-flushes, so an unstaged hand-edit in the
-    # JSONL is destroyed by this very command, and neither the index nor HEAD holds it.
-        _bw=$(br where --json) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
-        BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL path — do NOT write"; exit 1; }
-    # Capture separately: `[ -z "$(git status ...)" ]` discards git's exit code, so a FAILED
-    # inspection reads as a clean tree and lets the write through — the guard failing open at
-    # exactly the moment it matters. Compare against HEAD, not the index: a damaged JSONL that
-    # is staged leaves a worktree-vs-index diff empty while HEAD holds the good bodies.
-    _st=$(git status --porcelain -- "$BEADS_JSONL") \
-      || { echo "cannot read the worktree — do NOT write"; exit 1; }
-    [ -z "$_st" ] || { git diff HEAD -- "$BEADS_JSONL"
-      echo "JSONL differs from HEAD — read that diff and resolve it BEFORE writing"; exit 1; }
+    # Resolve and prove the JSONL clean FIRST: `br update` auto-flushes the cache over it.
+    BEADS_JSONL_RESOLVER=$(
+      (
+        # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+        # prevents exported caller functions from redefining this trust path, and the
+        # subshell leaves the caller's shell state untouched.
+        POSIXLY_CORRECT=y
+        export POSIXLY_CORRECT
+        \unset -f command builtin exec unset 2>/dev/null || :
+        _bjp_bash=$(command -p -v bash) || {
+          printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+          exit 1
+        }
+        unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+        exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+    # Privileged Bash ignores inherited functions. Clear the other startup controls too,
+    # then perform every candidate, worktree, provenance, and byte-agreement decision here.
+    command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+      printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+      exit 1
+    }
+    while command builtin read -r _ _ _bjp_function; do
+      command unset -f -- "$_bjp_function" || {
+        printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+        exit 1
+      }
+    done < <(command builtin declare -F)
+    unset _bjp_function
+    _bjp_git=$(command -p -v git) || {
+      printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+      exit 1
+    }
+    _bjp_cmp=$(command -p -v cmp) || {
+      printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+      exit 1
+    }
+
+    BEADS_JSONL_RESOLVER=
+    for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+      "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+      "$HOME/.agents/skills/beads-jsonl-path"; do
+      case $_bjp_dir in
+        /*) ;;
+        *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+      esac
+      _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+      [ -x "$_bjp_candidate" ] || continue
+      [ ! -L "$_bjp_candidate" ] || {
+        printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+        exit 1
+      }
+      _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+        printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+        exit 1
+      }
+      _bjp_root=$(
+        CDPATH=
+        export CDPATH
+        cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+      ) || {
+        printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+        exit 1
+      }
+      _bjp_candidate_dir=$(
+        CDPATH=
+        export CDPATH
+        cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+      ) || {
+        printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+        exit 1
+      }
+      _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+      [ ! -L "$_bjp_candidate" ] || {
+        printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+        exit 1
+      }
+      case $_bjp_root:$_bjp_candidate_dir in
+        /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+          printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+          exit 1
+          ;;
+      esac
+      unset _bjp_candidate_dir
+      if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+        BEADS_JSONL_RESOLVER=$_bjp_candidate
+      elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+        printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+        exit 1
+      fi
+    done
+    unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+    [ -n "$BEADS_JSONL_RESOLVER" ] || {
+      printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+      exit 1
+    }
+    printf '%s\n' "$BEADS_JSONL_RESOLVER"
+    __BJP_TRUSTED_BASH__
+      )
+    ) || exit 1
+    unset _bjp_candidate
+    # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
+    # is whatever executable the repo being drained planted there, and this snippet would
+    # run it. From a checkout, run that checkout's copy by absolute path instead.
+    [ -n "$BEADS_JSONL_RESOLVER" ] || {
+      echo "beads-jsonl-path companion unavailable — do NOT write" >&2
+      exit 1
+    }
+    BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
     br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
     br sync --flush-only || { echo "not persisted"; exit 1; }
     ```
 
     **Check for divergence BEFORE the first `br` write.** `br update` auto-flushes, so a
-    hand-edit sitting unstaged in the JSONL is destroyed by the very first mutation — and
+    staged or unstaged divergence in the JSONL is destroyed by the very first mutation — and
     since neither the index nor `HEAD` holds it, every later diff shows only your intended
-    change, which makes the loss *undetectable*, not merely unrecoverable. Resolve the real
-    path (`br where --json | jq -er .jsonl_path`; `.beads/issues.jsonl` is only the default
-    layout, and a hardcoded path diffs nothing on a `.beads.jsonl` repo — a false
-    all-clear) and run `git status --porcelain` on it before any `br` command.
+    change, which makes the loss *undetectable*, not merely unrecoverable. Resolve and
+    prove the real path clean with `beads-jsonl-path/scripts/resolve-beads-jsonl` before
+    any writing `br` command; `.beads/issues.jsonl` is only the default layout, and a
+    hardcoded path gives a false all-clear on a `.beads.jsonl` repo.
 
     **That sync proves the closure reached the file. It says nothing about what else the
     same write overwrote.** Every `br` write flushes the whole gitignored cache over the
@@ -391,7 +487,16 @@ implement → review loop for each bead.
     --help`'s "Stale DB Guard" is an **id**-level check, so same-id-different-body — the
     case that loses text — is unguarded by design.
 
-    So field-diff the resolved path before committing any `br` write. A full-file
+    So field-diff the resolved path before committing any `br` write. Rerun the
+    resolver-locator block above, stopping before its final clean-mode `BEADS_JSONL=` call,
+    and resolve it with
+    `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1` here: the write already
+    happened, so the divergence you are inspecting is exactly what the default clean-state
+    mode refuses. In recovery use
+    `BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --recovery) || exit 1`, which can name a missing
+    artifact without pretending it is still tracked and structurally safe. A fresh
+    recovery session that
+    hardcodes `.beads/issues.jsonl` restores nothing on a `.beads.jsonl` repo. A full-file
     re-serialization with every id on both sides is normal; ids on only one side, or a
     `description` you did not touch, is the tell.
 

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -465,6 +465,15 @@ implement → review loop for each bead.
         exit 1
       }
       unset _bjp_link_count
+      if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+        printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+        exit 1
+      fi
+      [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+        printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+        exit 1
+      }
+      unset _bjp_shebang
       unset _bjp_candidate_dir
       if [ -z "$BEADS_JSONL_RESOLVER" ]; then
         BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -387,6 +387,21 @@ implement → review loop for each bead.
       printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
       exit 1
     }
+    _bjp_stat=$(command -p -v stat) || {
+      printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+      exit 1
+    }
+    _bjp_regular_link_count() {
+      local path=$1 count
+      if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+        :
+      elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+        :
+      else
+        return 1
+      fi
+      printf '%s\n' "$count"
+    }
     _bjp_git_environment=( "${!GIT_@}" )
     for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
       command unset -- "$_bjp_git_variable" || {
@@ -441,6 +456,15 @@ implement → review loop for each bead.
           exit 1
           ;;
       esac
+      _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+        printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+        exit 1
+      }
+      [ "$_bjp_link_count" = 1 ] || {
+        printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+        exit 1
+      }
+      unset _bjp_link_count
       unset _bjp_candidate_dir
       if [ -z "$BEADS_JSONL_RESOLVER" ]; then
         BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -449,7 +473,7 @@ implement → review loop for each bead.
         exit 1
       fi
     done
-    unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+    unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
     [ -n "$BEADS_JSONL_RESOLVER" ] || {
       printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
       exit 1

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -352,6 +352,26 @@ implement → review loop for each bead.
 
     ```bash
     # Resolve and prove the JSONL clean FIRST: `"$BEADS_JSONL_RESOLVER" --run-br update` auto-flushes the cache over it.
+    # Clear loader injection in this already-running shell before the locator starts
+    # any new process. The resolver/git-clean script bodies are too late: a shebang
+    # interpreter would already have loaded caller-selected libraries.
+    _bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+    _bjp_posixly_value=${POSIXLY_CORRECT-}
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+      LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+      DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+      DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+      printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+      exit 1
+    }
+    if [ -n "$_bjp_posixly_was_set" ]; then
+      POSIXLY_CORRECT=$_bjp_posixly_value
+      export POSIXLY_CORRECT
+    else
+      \unset POSIXLY_CORRECT
+    fi
     BEADS_JSONL_RESOLVER=$(
       (
         # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -410,7 +410,7 @@ implement → review loop for each bead.
         printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
         exit 1
       }
-      _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+      _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
         printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
         exit 1
       }

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -562,7 +562,7 @@ implement → review loop for each bead.
 
     Hand-editing the JSONL is what makes the cache stale — a hand edit does not advance
     `updated_at`, so cache and file hold different bodies under identical timestamps and
-    nothing can tell them apart. **Write bead text through `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`, never
+    nothing can tell them apart. **Write bead text through `"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "<full body>"`, never
     the file.** The task template's ".beads/ is orchestration state" line is a *reviewing*
     scope rule, not an editing licence. And the advertised guard does not help: `"$BEADS_JSONL_RESOLVER" --run-br sync
     --help`'s "Stale DB Guard" is an **id**-level check, so same-id-different-body — the

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -387,6 +387,14 @@ implement → review loop for each bead.
       printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
       exit 1
     }
+    _bjp_git_environment=( "${!GIT_@}" )
+    for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+      command unset -- "$_bjp_git_variable" || {
+        printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+        exit 1
+      }
+    done
+    unset _bjp_git_variable _bjp_git_environment
 
     BEADS_JSONL_RESOLVER=
     for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -35,11 +35,11 @@ rb-lite. The beads are the input; do not invent a fresh work list. Codex is
 operating the queue and PR workflow, while rb-lite handles the inner
 implement → review loop for each bead.
 
-1. **Pick.** Run `br ready --limit 10`. Take the top P0 first; if none,
+1. **Pick.** Run `"$BEADS_JSONL_RESOLVER" --run-br ready --limit 10`. Take the top P0 first; if none,
    the lowest-numbered P1; only descend to P2 if the user says so or the
    P1 list is empty / oversized.
 
-2. **Read.** Run `br show <id>` (and `br show <id> --json` if structured
+2. **Read.** Run `"$BEADS_JSONL_RESOLVER" --run-br show <id>` (and `"$BEADS_JSONL_RESOLVER" --run-br show <id> --json` if structured
    fields help). If the acceptance criteria are vague, pause and ask the
    user before writing the task.
 
@@ -325,7 +325,7 @@ implement → review loop for each bead.
 
 <a id="backlog-step-11"></a>
 
-11. **Close the bead, through a reviewed path.** Run `br update <bead-id> -s closed`
+11. **Close the bead, through a reviewed path.** Run `"$BEADS_JSONL_RESOLVER" --run-br update <bead-id> -s closed`
     after the merged code is present on the base branch. That write lands in the
     tracked `.beads/*.jsonl`, so do **not** commit it straight to the default branch —
     it would reach the branch unreviewed. Carry the closure commit into the next bead's
@@ -347,11 +347,11 @@ implement → review loop for each bead.
     discovery depends on telling them apart. The marker is what it filters on.
 
     Verify it landed with a checked *explicit* sync: it propagates a real exit code, which
-    the automatic flush after `br update` does not — that one swallows its error. The
+    the automatic flush after `"$BEADS_JSONL_RESOLVER" --run-br update` does not — that one swallows its error. The
     mutation is already in the shared DB, so the sync either writes it out or fails loudly:
 
     ```bash
-    # Resolve and prove the JSONL clean FIRST: `br update` auto-flushes the cache over it.
+    # Resolve and prove the JSONL clean FIRST: `"$BEADS_JSONL_RESOLVER" --run-br update` auto-flushes the cache over it.
     BEADS_JSONL_RESOLVER=$(
       (
         # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
@@ -402,7 +402,7 @@ implement → review loop for each bead.
       fi
       printf '%s\n' "$count"
     }
-    _bjp_git_environment=( "${!GIT_@}" )
+    _bjp_git_environment=( "${!GIT@}" )
     for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
       command unset -- "$_bjp_git_variable" || {
         printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -412,6 +412,7 @@ implement → review loop for each bead.
     unset _bjp_git_variable _bjp_git_environment
 
     BEADS_JSONL_RESOLVER=
+    BEADS_GIT_RUNNER=
     for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
       "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -456,6 +457,10 @@ implement → review loop for each bead.
           exit 1
           ;;
       esac
+      [ -f "$_bjp_candidate" ] || {
+        printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+        exit 1
+      }
       _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
         printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
         exit 1
@@ -474,16 +479,50 @@ implement → review loop for each bead.
         exit 1
       }
       unset _bjp_shebang
+      _bjp_runner="$_bjp_candidate_dir/git-clean"
+      [ -x "$_bjp_runner" ] || {
+        printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+        exit 1
+      }
+      [ ! -L "$_bjp_runner" ] || {
+        printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+        exit 1
+      }
+      [ -f "$_bjp_runner" ] || {
+        printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+        exit 1
+      }
+      _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+        printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+        exit 1
+      }
+      [ "$_bjp_link_count" = 1 ] || {
+        printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+        exit 1
+      }
+      unset _bjp_link_count
+      if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+        printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+        exit 1
+      fi
+      [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+        printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+        exit 1
+      }
+      unset _bjp_shebang
       unset _bjp_candidate_dir
       if [ -z "$BEADS_JSONL_RESOLVER" ]; then
         BEADS_JSONL_RESOLVER=$_bjp_candidate
-      elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+        BEADS_GIT_RUNNER=$_bjp_runner
+      elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+          || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
         printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
         exit 1
       fi
+      unset _bjp_runner
     done
     unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-    [ -n "$BEADS_JSONL_RESOLVER" ] || {
+    [ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
       printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
       exit 1
     }
@@ -491,6 +530,7 @@ implement → review loop for each bead.
     __BJP_TRUSTED_BASH__
       )
     ) || exit 1
+    BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
     unset _bjp_candidate
     # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
     # is whatever executable the repo being drained planted there, and this snippet would
@@ -500,11 +540,11 @@ implement → review loop for each bead.
       exit 1
     }
     BEADS_JSONL=$("$BEADS_JSONL_RESOLVER") || exit 1
-    br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
-    br sync --flush-only || { echo "not persisted"; exit 1; }
+    "$BEADS_JSONL_RESOLVER" --run-br update <bead-id> -s closed || { echo "br update failed"; exit 1; }
+    "$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "not persisted"; exit 1; }
     ```
 
-    **Check for divergence BEFORE the first `br` write.** `br update` auto-flushes, so a
+    **Check for divergence BEFORE the first `br` write.** `"$BEADS_JSONL_RESOLVER" --run-br update` auto-flushes, so a
     staged or unstaged divergence in the JSONL is destroyed by the very first mutation — and
     since neither the index nor `HEAD` holds it, every later diff shows only your intended
     change, which makes the loss *undetectable*, not merely unrecoverable. Resolve and
@@ -515,16 +555,16 @@ implement → review loop for each bead.
     **That sync proves the closure reached the file. It says nothing about what else the
     same write overwrote.** Every `br` write flushes the whole gitignored cache over the
     tracked JSONL, so a write to **one** bead rewrites **all** of them, and any body the
-    cache holds a stale copy of is reverted. Observed on `br 0.2.19`: closing a single bead
+    cache holds a stale copy of is reverted. Observed on `"$BEADS_JSONL_RESOLVER" --run-br 0.2.19`: closing a single bead
     silently reverted ~40 KB of specification text across three *other* beads and deleted a
     fourth. Exit 0, success message, nothing failed. This step is the last write of every
     bead, which is how the drain routes you into it every time.
 
     Hand-editing the JSONL is what makes the cache stale — a hand edit does not advance
     `updated_at`, so cache and file hold different bodies under identical timestamps and
-    nothing can tell them apart. **Write bead text through `br update -d/--notes`, never
+    nothing can tell them apart. **Write bead text through `"$BEADS_JSONL_RESOLVER" --run-br update -d/--notes`, never
     the file.** The task template's ".beads/ is orchestration state" line is a *reviewing*
-    scope rule, not an editing licence. And the advertised guard does not help: `br sync
+    scope rule, not an editing licence. And the advertised guard does not help: `"$BEADS_JSONL_RESOLVER" --run-br sync
     --help`'s "Stale DB Guard" is an **id**-level check, so same-id-different-body — the
     case that loses text — is unguarded by design.
 
@@ -544,16 +584,16 @@ implement → review loop for each bead.
     **Recovery depends on which side holds the good text, and guessing cements the loss.**
 
     - **(a) cache stale, file still good** — rebuild the cache from the file.
-      `br sync --import-only` alone cannot do it: it compares `updated_at`, so equal
+      `"$BEADS_JSONL_RESOLVER" --run-br sync --import-only` alone cannot do it: it compares `updated_at`, so equal
       timestamps with different bodies report `Skipped: N (up-to-date)` forever. The stale
       DB has to go first.
     - **(b) the flush already ran and the diff shows damage** — the working copy *is* the
       damaged artifact. Restore it from the good side, **rebuild the cache**, and only then
       replay: replaying first lets the still-stale cache auto-flush over what you just
       restored. Read
-      `git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff --cached -- "$BEADS_JSONL"`
+      `"$BEADS_GIT_RUNNER" --literal-pathspecs diff --no-ext-diff --no-textconv --text --cached -- "$BEADS_JSONL"`
       and
-      `git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff -- "$BEADS_JSONL"`,
+      `"$BEADS_GIT_RUNNER" --literal-pathspecs diff --no-ext-diff --no-textconv --text -- "$BEADS_JSONL"`,
       then decide explicitly which of the index, worktree, or `HEAD` holds the good
       bodies; a staged copy only proves a choice exists, and an earlier flush may
       have been staged before anyone noticed.
@@ -594,7 +634,7 @@ implement → review loop for each bead.
 
 <a id="backlog-step-12"></a>
 
-12. **Loop.** Return to `br ready --limit 10` — but **on a resumed drain, look for an
+12. **Loop.** Return to `"$BEADS_JSONL_RESOLVER" --run-br ready --limit 10` — but **on a resumed drain, look for an
     in-flight closure PR before selecting work.** A closure lives on its metadata branch
     until it merges, so a fresh clone of the default branch sees the old JSONL with the
     bead still open and will happily rebuild and re-merge work that is already done. The
@@ -641,7 +681,7 @@ implement → review loop for each bead.
     ```
 
     `BEAD_ID` is the bead you are about to take — loop this query over each open bead from
-    `br ready`/`br list` rather than assuming a variable survived the clone. Empty, the
+    `"$BEADS_JSONL_RESOLVER" --run-br ready`/`"$BEADS_JSONL_RESOLVER" --run-br list` rather than assuming a variable survived the clone. Empty, the
     filter rejects everything and the closure PR this exists to find is missed.
 
     Keyed on the **`bead-closure:` marker plus the bead id**, not on the id alone: step 8

--- a/skills/rb-lite-backlog-drain/SKILL.md
+++ b/skills/rb-lite-backlog-drain/SKILL.md
@@ -517,9 +517,13 @@ implement → review loop for each bead.
     - **(b) the flush already ran and the diff shows damage** — the working copy *is* the
       damaged artifact. Restore it from the good side, **rebuild the cache**, and only then
       replay: replaying first lets the still-stale cache auto-flush over what you just
-      restored. Read `git diff --cached` and `git diff` and decide explicitly which of
-      the index or `HEAD` holds the good bodies; a staged copy only proves a choice exists,
-      and an earlier flush may have been staged before anyone noticed.
+      restored. Read
+      `git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff --cached -- "$BEADS_JSONL"`
+      and
+      `git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff -- "$BEADS_JSONL"`,
+      then decide explicitly which of the index, worktree, or `HEAD` holds the good
+      bodies; a staged copy only proves a choice exists, and an earlier flush may
+      have been staged before anyone noticed.
 
     Four things the recipe must do in both cases, each learned by getting it wrong: back up
     the cache and **check the copy succeeded**; **verify the DB and its `-wal`/`-shm`

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -222,6 +222,21 @@ recorded acceptance of the reduced review coverage.
      printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
      exit 1
    }
+   _bjp_stat=$(command -p -v stat) || {
+     printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+     exit 1
+   }
+   _bjp_regular_link_count() {
+     local path=$1 count
+     if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+       :
+     elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+       :
+     else
+       return 1
+     fi
+     printf '%s\n' "$count"
+   }
    _bjp_git_environment=( "${!GIT_@}" )
    for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
      command unset -- "$_bjp_git_variable" || {
@@ -276,6 +291,15 @@ recorded acceptance of the reduced review coverage.
          exit 1
          ;;
      esac
+     _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+       printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+       exit 1
+     }
+     [ "$_bjp_link_count" = 1 ] || {
+       printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+       exit 1
+     }
+     unset _bjp_link_count
      unset _bjp_candidate_dir
      if [ -z "$BEADS_JSONL_RESOLVER" ]; then
        BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -284,7 +308,7 @@ recorded acceptance of the reduced review coverage.
        exit 1
      fi
    done
-   unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+   unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
    [ -n "$BEADS_JSONL_RESOLVER" ] || {
      printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
      exit 1

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -245,7 +245,7 @@ recorded acceptance of the reduced review coverage.
        printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
        exit 1
      }
-     _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+     _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
        printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
        exit 1
      }
@@ -313,15 +313,15 @@ recorded acceptance of the reduced review coverage.
    # The status and diff are both still required: status
    # distinguishes staged from unstaged intended edits, while the HEAD diff exposes both.
    BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
-   git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush"; exit 1; }
-   git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
+   git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush"; exit 1; }
+   git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
    : "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
    br sync --flush-only || { echo "flush failed"; exit 1; }
    # AND AGAIN AFTER. A clean pre-flush diff only means the worktree matched git — it says
    # nothing about the gitignored cache, so a stale DB introduces the damage HERE. Read
    # this before consuming the graph; auditing a truncated one reviews text the reviewers
    # will never see.
-   git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT audit"; exit 1; }
+   git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT audit"; exit 1; }
    : "${BEADS_POSTFLUSH_REVIEWED:?read the post-flush diff above before auditing}"
    br list --limit 0 --json -a
    bv --robot-triage

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -160,7 +160,10 @@ recorded acceptance of the reduced review coverage.
 2. Confirm the graph is meaningful and has already had a real polish pass. If it
    is raw, redirect to `bead-polish-loop`; the final gate should not substitute for
    routine cleanup.
-3. Confirm `br`, `bv`, the requested reviewer CLIs, and `jq` as applicable.
+3. Confirm `br`, `bv`, `jq`, the requested reviewer CLIs, and the exact
+   `beads-jsonl-path` companion are available. The audit still runs `jq` itself for
+   the graph snapshot and the Claude JSON result, so the companion owning its own
+   `jq` check does not retire this one.
 4. Define the audit scope explicitly:
    - authoritative plan/spec files, approved deltas, and recorded waivers
    - plan-backed root beads/epics and their child/dependency closure
@@ -184,22 +187,133 @@ recorded acceptance of the reduced review coverage.
    # ../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
    # Companion unavailable: stop, rerun the same installer command once, reload it, and
    # do not improvise this procedure.
-   _bw=$(br where --json) || { echo "cannot resolve the JSONL"; exit 1; }
-   BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the JSONL"; exit 1; }
-   # INSPECT, do not gate on cleanliness: the normal bead-polish-loop handoff arrives with
-   # the round's intended `br` edits uncommitted, so demanding a clean file would block the
-   # audit after every non-noop round. `git status` cannot tell an intended mutation from a
-   # hand edit — only reading the diff can. Compare against HEAD, not the index: a damaged
-   # JSONL that is staged makes a worktree-vs-index diff empty while HEAD still holds the
-   # good bodies.
-   git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
-   : "${BEADS_DIFF_REVIEWED:?read the diff above, then set this to how you resolved it}"
+   BEADS_JSONL_RESOLVER=$(
+     (
+       # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+       # prevents exported caller functions from redefining this trust path, and the
+       # subshell leaves the caller's shell state untouched.
+       POSIXLY_CORRECT=y
+       export POSIXLY_CORRECT
+       \unset -f command builtin exec unset 2>/dev/null || :
+       _bjp_bash=$(command -p -v bash) || {
+         printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+         exit 1
+       }
+       unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+       exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+   # Privileged Bash ignores inherited functions. Clear the other startup controls too,
+   # then perform every candidate, worktree, provenance, and byte-agreement decision here.
+   command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+     printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+     exit 1
+   }
+   while command builtin read -r _ _ _bjp_function; do
+     command unset -f -- "$_bjp_function" || {
+       printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+       exit 1
+     }
+   done < <(command builtin declare -F)
+   unset _bjp_function
+   _bjp_git=$(command -p -v git) || {
+     printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+     exit 1
+   }
+   _bjp_cmp=$(command -p -v cmp) || {
+     printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+     exit 1
+   }
+
+   BEADS_JSONL_RESOLVER=
+   for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+     "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+     "$HOME/.agents/skills/beads-jsonl-path"; do
+     case $_bjp_dir in
+       /*) ;;
+       *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+     esac
+     _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+     [ -x "$_bjp_candidate" ] || continue
+     [ ! -L "$_bjp_candidate" ] || {
+       printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+       exit 1
+     }
+     _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+       printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+       exit 1
+     }
+     _bjp_root=$(
+       CDPATH=
+       export CDPATH
+       cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+     ) || {
+       printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+       exit 1
+     }
+     _bjp_candidate_dir=$(
+       CDPATH=
+       export CDPATH
+       cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+     ) || {
+       printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+       exit 1
+     }
+     _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+     [ ! -L "$_bjp_candidate" ] || {
+       printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+       exit 1
+     }
+     case $_bjp_root:$_bjp_candidate_dir in
+       /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+         printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+         exit 1
+         ;;
+     esac
+     unset _bjp_candidate_dir
+     if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+       BEADS_JSONL_RESOLVER=$_bjp_candidate
+     elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+       printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+       exit 1
+     fi
+   done
+   unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+   [ -n "$BEADS_JSONL_RESOLVER" ] || {
+     printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+     exit 1
+   }
+   printf '%s\n' "$BEADS_JSONL_RESOLVER"
+   __BJP_TRUSTED_BASH__
+     )
+   ) || exit 1
+   unset _bjp_candidate
+   # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
+   # is whatever executable the audited repo planted there, and this snippet would run it.
+   # From a checkout, run that checkout's copy by absolute path instead.
+   [ -n "$BEADS_JSONL_RESOLVER" ] || {
+     echo "beads-jsonl-path companion unavailable — do NOT flush" >&2
+     exit 1
+   }
+   # --allow-dirty, and INSPECT rather than gate on cleanliness: the normal
+   # bead-polish-loop handoff arrives with the round's intended `br` edits flushed and
+   # uncommitted, so the owner's default clean-state mode would refuse the audit after
+   # every non-noop round. Nothing tells an intended mutation from a hand edit — only
+   # reading the diff can. Compare against HEAD, not the index: a damaged JSONL that is
+   # staged makes a worktree-vs-index diff empty while HEAD still holds the good bodies.
+   # `--allow-dirty` retains the owner's tracked stage-0, normal-flag, regular-mode proof
+   # and drops byte identity only where the two commands below can still see the
+   # difference — it refuses a write a file system monitor's cache is hiding from them.
+   # The status and diff are both still required: status
+   # distinguishes staged from unstaged intended edits, while the HEAD diff exposes both.
+   BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
+   git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush"; exit 1; }
+   git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
+   : "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
    br sync --flush-only || { echo "flush failed"; exit 1; }
    # AND AGAIN AFTER. A clean pre-flush diff only means the worktree matched git — it says
    # nothing about the gitignored cache, so a stale DB introduces the damage HERE. Read
    # this before consuming the graph; auditing a truncated one reviews text the reviewers
    # will never see.
-   git diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT audit"; exit 1; }
+   git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT audit"; exit 1; }
    : "${BEADS_POSTFLUSH_REVIEWED:?read the post-flush diff above before auditing}"
    br list --limit 0 --json -a
    bv --robot-triage

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -222,6 +222,14 @@ recorded acceptance of the reduced review coverage.
      printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
      exit 1
    }
+   _bjp_git_environment=( "${!GIT_@}" )
+   for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+     command unset -- "$_bjp_git_variable" || {
+       printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+       exit 1
+     }
+   done
+   unset _bjp_git_variable _bjp_git_environment
 
    BEADS_JSONL_RESOLVER=
    for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -98,7 +98,7 @@ before launching the panel.
 Panel health and graph independence are different claims. Report both.
 
 Determine who built or substantially polished the graph from session context or
-`br show <id> --json` actor/history fields when practical. Do not delay the audit
+`"$BEADS_JSONL_RESOLVER" --run-br show <id> --json` actor/history fields when practical. Do not delay the audit
 just to establish authorship.
 
 For each reviewer, label independence:
@@ -170,7 +170,7 @@ recorded acceptance of the reduced review coverage.
    - the wider graph only for cross-scope dependencies and frontier health
 
    Do not label unrelated backlog beads as unplanned merely because
-   `br list -a` includes them.
+   `"$BEADS_JSONL_RESOLVER" --run-br list -a` includes them.
 5. Flush once, capture one shared baseline, and fingerprint it before launching
    either reviewer:
 
@@ -237,7 +237,7 @@ recorded acceptance of the reduced review coverage.
      fi
      printf '%s\n' "$count"
    }
-   _bjp_git_environment=( "${!GIT_@}" )
+   _bjp_git_environment=( "${!GIT@}" )
    for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
      command unset -- "$_bjp_git_variable" || {
        printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -247,6 +247,7 @@ recorded acceptance of the reduced review coverage.
    unset _bjp_git_variable _bjp_git_environment
 
    BEADS_JSONL_RESOLVER=
+   BEADS_GIT_RUNNER=
    for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
      "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
      "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -291,6 +292,10 @@ recorded acceptance of the reduced review coverage.
          exit 1
          ;;
      esac
+     [ -f "$_bjp_candidate" ] || {
+       printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+       exit 1
+     }
      _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
        printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
        exit 1
@@ -309,16 +314,50 @@ recorded acceptance of the reduced review coverage.
        exit 1
      }
      unset _bjp_shebang
+     _bjp_runner="$_bjp_candidate_dir/git-clean"
+     [ -x "$_bjp_runner" ] || {
+       printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+       exit 1
+     }
+     [ ! -L "$_bjp_runner" ] || {
+       printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+       exit 1
+     }
+     [ -f "$_bjp_runner" ] || {
+       printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+       exit 1
+     }
+     _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+       printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+       exit 1
+     }
+     [ "$_bjp_link_count" = 1 ] || {
+       printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+       exit 1
+     }
+     unset _bjp_link_count
+     if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+       printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+       exit 1
+     fi
+     [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+       printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+       exit 1
+     }
+     unset _bjp_shebang
      unset _bjp_candidate_dir
      if [ -z "$BEADS_JSONL_RESOLVER" ]; then
        BEADS_JSONL_RESOLVER=$_bjp_candidate
-     elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+       BEADS_GIT_RUNNER=$_bjp_runner
+     elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+         || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
        printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
        exit 1
      fi
+     unset _bjp_runner
    done
    unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-   [ -n "$BEADS_JSONL_RESOLVER" ] || {
+   [ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
      printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
      exit 1
    }
@@ -326,6 +365,7 @@ recorded acceptance of the reduced review coverage.
    __BJP_TRUSTED_BASH__
      )
    ) || exit 1
+   BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
    unset _bjp_candidate
    # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
    # is whatever executable the audited repo planted there, and this snippet would run it.
@@ -334,36 +374,19 @@ recorded acceptance of the reduced review coverage.
      echo "beads-jsonl-path companion unavailable — do NOT flush" >&2
      exit 1
    }
-   # --allow-dirty, and INSPECT rather than gate on cleanliness: the normal
-   # bead-polish-loop handoff arrives with the round's intended `br` edits flushed and
-   # uncommitted, so the owner's default clean-state mode would refuse the audit after
-   # every non-noop round. Nothing tells an intended mutation from a hand edit — only
-   # reading the diff can. Compare against HEAD, not the index: a damaged JSONL that is
-   # staged makes a worktree-vs-index diff empty while HEAD still holds the good bodies.
-   # `--allow-dirty` retains the owner's tracked stage-0, normal-flag, regular-mode proof
-   # and drops byte identity only where the two commands below can still see the
-   # difference — it refuses a write a file system monitor's cache is hiding from them.
-   # The status and diff are both still required: status
-   # distinguishes staged from unstaged intended edits, while the HEAD diff exposes both.
-   BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
-   git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush"; exit 1; }
-   git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT flush"; exit 1; }
-   : "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
-   br sync --flush-only || { echo "flush failed"; exit 1; }
-   # AND AGAIN AFTER. A clean pre-flush diff only means the worktree matched git — it says
-   # nothing about the gitignored cache, so a stale DB introduces the damage HERE. Read
-   # this before consuming the graph; auditing a truncated one reviews text the reviewers
-   # will never see.
-   git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL" || { echo "cannot diff the JSONL — do NOT audit"; exit 1; }
-   : "${BEADS_POSTFLUSH_REVIEWED:?read the post-flush diff above before auditing}"
-   br list --limit 0 --json -a
-   bv --robot-triage
-   bv --robot-plan
-   bv --robot-suggest
    ```
 
-   Add `bv --robot-insights`, `bv --robot-priority`, and targeted
-   `br show <id> --json` when useful.
+   The block above only resolves and validates the installed companions. **Do not
+   flush, diff, or list the graph in a second abbreviated transaction here.** In
+   the same Bash process, execute the complete
+   [Shared graph snapshot procedure](references/reviewer-panel.md#shared-graph-snapshot).
+   That single owner clears both this audit's pre-flush and post-flush
+   acknowledgements, stops after each rendered diff so the current run can bind
+   its acknowledgement, captures stable source/graph snapshots, and only then
+   runs the `br`/`bv` reads. Duplicating those gates here lets the copies drift
+   and lets a prior round's shell variables authorize this round's destructive
+   flush.
+
 6. Create a unique audit directory and one neutral prompt containing the
    snapshotted requirement and graph paths, audit scope, categories, severity
    rules, and output contract. Do not include your conclusions or prior polish
@@ -491,7 +514,7 @@ Normal mode is report-only:
   `bead-polish-loop`'s ledger, fix them there, then rerun the full panel.
 
 If the user explicitly asks this skill to apply fixes, mutate only reconciled,
-clearly justified items with `br`, flush with `br sync --flush-only`, and rerun the
+clearly justified items with `br`, flush with `"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only`, and rerun the
 panel before upgrading the verdict. Never let a reviewer edit the graph directly.
 
 Bound an automatic polish/audit cycle to three panel runs. Stop earlier when the
@@ -513,19 +536,19 @@ in the plan rather than a bead-quality defect.
 ## Command palette
 
 ```bash
-br list --limit 0 --json -a
-br show <id> --json
-br update <id> --description "..."
-br close <id> --reason "..."
-br dep add <issue> <depends-on>
-br dep remove <issue> <depends-on>
-br lint
+"$BEADS_JSONL_RESOLVER" --run-br list --limit 0 --json -a
+"$BEADS_JSONL_RESOLVER" --run-br show <id> --json
+"$BEADS_JSONL_RESOLVER" --run-br update <id> --description "..."
+"$BEADS_JSONL_RESOLVER" --run-br close <id> --reason "..."
+"$BEADS_JSONL_RESOLVER" --run-br dep add <issue> <depends-on>
+"$BEADS_JSONL_RESOLVER" --run-br dep remove <issue> <depends-on>
+"$BEADS_JSONL_RESOLVER" --run-br lint
 bv --robot-triage
 bv --robot-plan
 bv --robot-suggest
 bv --robot-insights
 bv --robot-priority
-br sync --flush-only
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only
 ```
 
 ## Failure patterns to avoid

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -300,6 +300,15 @@ recorded acceptance of the reduced review coverage.
        exit 1
      }
      unset _bjp_link_count
+     if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+       printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+       exit 1
+     fi
+     [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+       printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+       exit 1
+     }
+     unset _bjp_shebang
      unset _bjp_candidate_dir
      if [ -z "$BEADS_JSONL_RESOLVER" ]; then
        BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/second-model-bead-audit/SKILL.md
+++ b/skills/second-model-bead-audit/SKILL.md
@@ -187,6 +187,26 @@ recorded acceptance of the reduced review coverage.
    # ../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
    # Companion unavailable: stop, rerun the same installer command once, reload it, and
    # do not improvise this procedure.
+   # Clear loader injection in this already-running shell before the locator starts
+   # any new process. The resolver/git-clean script bodies are too late: a shebang
+   # interpreter would already have loaded caller-selected libraries.
+   _bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+   _bjp_posixly_value=${POSIXLY_CORRECT-}
+   POSIXLY_CORRECT=y
+   export POSIXLY_CORRECT
+   \unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+     LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+     DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+     DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+     printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+     exit 1
+   }
+   if [ -n "$_bjp_posixly_was_set" ]; then
+     POSIXLY_CORRECT=$_bjp_posixly_value
+     export POSIXLY_CORRECT
+   else
+     \unset POSIXLY_CORRECT
+   fi
    BEADS_JSONL_RESOLVER=$(
      (
        # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -142,13 +142,115 @@ done
 # so an unstaged hand-edit is destroyed HERE — and the diff below then compares the file
 # against an index that already matches it, comes back empty, and the audit snapshots the
 # truncated graph having "checked". The check has to precede the write it guards.
-_bw=$(br where --json) || { echo "cannot resolve the beads JSONL path" >&2; exit 1; }
-BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve the beads JSONL path" >&2; exit 1; }
-# INSPECT before flushing — the next line writes the cache over this file, so anything in
-# the worktree that the cache does not know about is gone afterwards, with no diff left to
-# show it. Do NOT gate on a clean file: the normal `bead-polish-loop` handoff arrives with
-# the round's intended `br` edits uncommitted, so demanding cleanliness would block the
-# audit after every non-noop round.
+BEADS_JSONL_RESOLVER=$(
+  (
+    # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
+    # prevents exported caller functions from redefining this trust path, and the
+    # subshell leaves the caller's shell state untouched.
+    POSIXLY_CORRECT=y
+    export POSIXLY_CORRECT
+    \unset -f command builtin exec unset 2>/dev/null || :
+    _bjp_bash=$(command -p -v bash) || {
+      printf '%s\n' 'cannot locate a trusted Bash for the beads JSONL locator — do NOT write' >&2
+      exit 1
+    }
+    unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE
+    exec "$_bjp_bash" --noprofile --norc -p -s <<'__BJP_TRUSTED_BASH__'
+# Privileged Bash ignores inherited functions. Clear the other startup controls too,
+# then perform every candidate, worktree, provenance, and byte-agreement decision here.
+command unset BASH_ENV ENV BASH_COMPAT BASH_LOADABLES_PATH BASH_XTRACEFD CDPATH GLOBIGNORE || {
+  printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+  exit 1
+}
+while command builtin read -r _ _ _bjp_function; do
+  command unset -f -- "$_bjp_function" || {
+    printf '%s\n' 'cannot sanitize the beads JSONL locator shell environment — do NOT write' >&2
+    exit 1
+  }
+done < <(command builtin declare -F)
+unset _bjp_function
+_bjp_git=$(command -p -v git) || {
+  printf '%s\n' 'cannot locate a trusted Git for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_cmp=$(command -p -v cmp) || {
+  printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+
+BEADS_JSONL_RESOLVER=
+for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
+  "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
+  "$HOME/.agents/skills/beads-jsonl-path"; do
+  case $_bjp_dir in
+    /*) ;;
+    *) printf '%s\n' 'installed beads-jsonl-path target is not absolute — do NOT write' >&2; exit 1 ;;
+  esac
+  _bjp_candidate="$_bjp_dir/scripts/resolve-beads-jsonl"
+  [ -x "$_bjp_candidate" ] || continue
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+    printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_root=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_root_raw" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize the current Git worktree — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate_dir=$(
+    CDPATH=
+    export CDPATH
+    cd -P -- "$_bjp_dir/scripts" 2>/dev/null && pwd -P
+  ) || {
+    printf '%s\n' 'cannot canonicalize installed beads-jsonl-path target — do NOT write' >&2
+    exit 1
+  }
+  _bjp_candidate="$_bjp_candidate_dir/resolve-beads-jsonl"
+  [ ! -L "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  case $_bjp_root:$_bjp_candidate_dir in
+    /:/*|*:"$_bjp_root"|*:"$_bjp_root"/*)
+      printf '%s\n' 'installed beads-jsonl-path target is inside the current Git worktree — do NOT write' >&2
+      exit 1
+      ;;
+  esac
+  unset _bjp_candidate_dir
+  if [ -z "$BEADS_JSONL_RESOLVER" ]; then
+    BEADS_JSONL_RESOLVER=$_bjp_candidate
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
+    exit 1
+  fi
+done
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
+  exit 1
+}
+printf '%s\n' "$BEADS_JSONL_RESOLVER"
+__BJP_TRUSTED_BASH__
+  )
+) || exit 1
+unset _bjp_candidate
+# Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
+# is whatever executable the audited repo planted there, and this snippet would run it.
+# From a checkout, run that checkout's copy by absolute path instead.
+[ -n "$BEADS_JSONL_RESOLVER" ] || {
+  echo "beads-jsonl-path companion unavailable — do NOT flush" >&2
+  exit 1
+}
+# --allow-dirty: do NOT gate on a clean file here. The normal `bead-polish-loop` handoff
+# arrives with the round's intended `br` edits flushed and uncommitted, so the owner's
+# default clean-state mode would block the audit after every non-noop round.
 #
 # The question is not "is it dirty" but "is any of this dirt something the cache will
 # destroy" — i.e. hand-edited bead text, which never advances `updated_at`. Read the diff
@@ -156,8 +258,16 @@ BEADS_JSONL=$(printf '%s' "$_bw" | jq -er .jsonl_path) || { echo "cannot resolve
 # Against HEAD, not the index: a damaged JSONL that is STAGED makes a worktree-vs-index
 # diff empty while HEAD still holds the good bodies, so the operator would acknowledge a
 # clean-looking diff and flush the damage.
-git status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
-git diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
+#
+# `--allow-dirty` retains the owner's tracked stage-0, normal-flag, regular-mode proof and
+# drops byte identity only where the two commands below can still see the difference: it
+# refuses a write a file system monitor's cache is hiding from them, because then the diff
+# you are about to read reports a clean file over changed bead bodies.
+# Run both commands anyway: status distinguishes staged from
+# unstaged intended edits, while the HEAD diff exposes both for review before the flush.
+BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
+git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
+git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
 # Keep a copy of what the worktree held BEFORE the flush. Neither git ref works as the
 # post-flush baseline: if the index holds an earlier damaged export and the worktree holds
 # the good recovery, HEAD-vs-worktree looks fine beforehand, the flush replaces the good
@@ -176,7 +286,7 @@ br sync --flush-only || { echo "flush failed — do not audit an unwritten graph
 # `description` this session did not write, is the tell. Recovery:
 # exact companion skill rb-lite-backlog-drain, step 11:
 # ../../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
-git diff -- "$BEADS_JSONL"
+git --no-replace-objects --literal-pathspecs diff -- "$BEADS_JSONL"
 ```
 
 **Stop the block here.** The line above is a real gate, not a comment: run the snapshot

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -177,6 +177,14 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_git_environment=( "${!GIT_@}" )
+for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
+  command unset -- "$_bjp_git_variable" || {
+    printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
+    exit 1
+  }
+done
+unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -200,7 +200,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     printf '%s\n' 'installed beads-jsonl-path resolver is a symbolic link — do NOT write' >&2
     exit 1
   }
-  _bjp_root_raw=$("$_bjp_git" --no-replace-objects rev-parse --show-toplevel 2>/dev/null) || {
+  _bjp_root_raw=$("$_bjp_git" --no-replace-objects -c core.fsmonitor=false rev-parse --show-toplevel 2>/dev/null) || {
     printf '%s\n' 'cannot resolve the current Git worktree — do NOT write' >&2
     exit 1
   }
@@ -274,8 +274,8 @@ unset _bjp_candidate
 # Run both commands anyway: status distinguishes staged from
 # unstaged intended edits, while the HEAD diff exposes both for review before the flush.
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
-git --no-replace-objects --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
-git --no-replace-objects --literal-pathspecs diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
+git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
+git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
 # Keep a copy of what the worktree held BEFORE the flush. Neither git ref works as the
 # post-flush baseline: if the index holds an earlier damaged export and the worktree holds
 # the good recovery, HEAD-vs-worktree looks fine beforehand, the flush replaces the good
@@ -294,7 +294,7 @@ br sync --flush-only || { echo "flush failed — do not audit an unwritten graph
 # `description` this session did not write, is the tell. Recovery:
 # exact companion skill rb-lite-backlog-drain, step 11:
 # ../../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
-git --no-replace-objects --literal-pathspecs diff -- "$BEADS_JSONL"
+git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff -- "$BEADS_JSONL"
 ```
 
 **Stop the block here.** The line above is a real gate, not a comment: run the snapshot

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -26,6 +26,26 @@ set -euo pipefail
 
 : "${PLAN_PATH:?Set PLAN_PATH to an absolute plan/spec path}"
 : "${AUDIT_SCOPE:?Set AUDIT_SCOPE before capture}"
+# Clear loader injection in this already-running shell before the locator starts
+# any new process. The resolver/git-clean script bodies are too late: a shebang
+# interpreter would already have loaded caller-selected libraries.
+_bjp_posixly_was_set=${POSIXLY_CORRECT+x}
+_bjp_posixly_value=${POSIXLY_CORRECT-}
+POSIXLY_CORRECT=y
+export POSIXLY_CORRECT
+\unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_DEBUG LD_DEBUG_OUTPUT LD_PROFILE \
+  LD_ORIGIN_PATH LD_PRELOAD_32 LD_PRELOAD_64 DYLD_INSERT_LIBRARIES \
+  DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH \
+  DYLD_FALLBACK_FRAMEWORK_PATH LIBPATH SHLIB_PATH GCONV_PATH LOCPATH || {
+  printf '%s\n' 'cannot clear dynamic-loader injection before beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+if [ -n "$_bjp_posixly_was_set" ]; then
+  POSIXLY_CORRECT=$_bjp_posixly_value
+  export POSIXLY_CORRECT
+else
+  \unset POSIXLY_CORRECT
+fi
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -177,6 +177,21 @@ _bjp_cmp=$(command -p -v cmp) || {
   printf '%s\n' 'cannot locate a trusted cmp for beads-jsonl-path — do NOT write' >&2
   exit 1
 }
+_bjp_stat=$(command -p -v stat) || {
+  printf '%s\n' 'cannot locate a trusted stat for beads-jsonl-path — do NOT write' >&2
+  exit 1
+}
+_bjp_regular_link_count() {
+  local path=$1 count
+  if count=$("$_bjp_stat" -c %h "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  elif count=$("$_bjp_stat" -f %l "$path" 2>/dev/null) && [[ $count =~ ^[0-9]+$ ]]; then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
 _bjp_git_environment=( "${!GIT_@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
@@ -231,6 +246,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
@@ -239,7 +263,7 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   fi
 done
-unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp
+unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
 [ -n "$BEADS_JSONL_RESOLVER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -816,7 +816,7 @@ Validate the complete contract, not only whether tags exist:
 
 ```bash
 validate_audit_output() {
-  local file=$1 verdict rationale blockers important nits total closing
+  local file=$1 verdict rationale blockers important nits total closing grep_rc
   local -a closing_lines
   [ -s "$file" ] || return 1
   verdict=$("$BEADS_GIT_RUNNER" run-posix sed -n '1s/^VERDICT: //p' "$file")
@@ -827,9 +827,30 @@ validate_audit_output() {
       <<<"$rationale"; then
     return 1
   fi
-  blockers=$("$BEADS_GIT_RUNNER" grep -cE '^[[:space:]]*\[BLOCKER\]' "$file" || true)
-  important=$("$BEADS_GIT_RUNNER" grep -cE '^[[:space:]]*\[IMPORTANT\]' "$file" || true)
-  nits=$("$BEADS_GIT_RUNNER" grep -cE '^[[:space:]]*\[NIT\]' "$file" || true)
+  if blockers=$("$BEADS_GIT_RUNNER" grep -cE \
+      '^[[:space:]]*\[BLOCKER\]' "$file"); then
+    :
+  else
+    grep_rc=$?
+    [ "$grep_rc" -eq 1 ] || return 1
+    blockers=${blockers:-0}
+  fi
+  if important=$("$BEADS_GIT_RUNNER" grep -cE \
+      '^[[:space:]]*\[IMPORTANT\]' "$file"); then
+    :
+  else
+    grep_rc=$?
+    [ "$grep_rc" -eq 1 ] || return 1
+    important=${important:-0}
+  fi
+  if nits=$("$BEADS_GIT_RUNNER" grep -cE \
+      '^[[:space:]]*\[NIT\]' "$file"); then
+    :
+  else
+    grep_rc=$?
+    [ "$grep_rc" -eq 1 ] || return 1
+    nits=${nits:-0}
+  fi
   total=$((blockers + important + nits))
 
   closing=$("$BEADS_GIT_RUNNER" run-posix tail -n 3 "$file")

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -255,6 +255,15 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_candidate"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate

--- a/skills/second-model-bead-audit/references/reviewer-panel.md
+++ b/skills/second-model-bead-audit/references/reviewer-panel.md
@@ -26,122 +26,6 @@ set -euo pipefail
 
 : "${PLAN_PATH:?Set PLAN_PATH to an absolute plan/spec path}"
 : "${AUDIT_SCOPE:?Set AUDIT_SCOPE before capture}"
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-_PROJECT=$(basename "$REPO_ROOT")
-AUDIT_DIR=$(mktemp -d "/tmp/bead-audit-${_PROJECT}.XXXXXXXX")
-
-AUDIT_PROMPT_FILE="$AUDIT_DIR/audit-prompt.txt"
-CODEX_OUT="$AUDIT_DIR/codex.txt"
-CODEX_TRACE="$AUDIT_DIR/codex.trace.txt"
-CODEX_ERR="$AUDIT_DIR/codex.stderr.txt"
-CLAUDE_RAW="$AUDIT_DIR/claude.raw.json"
-CLAUDE_OUT="$AUDIT_DIR/claude.txt"
-CLAUDE_ERR="$AUDIT_DIR/claude.stderr.txt"
-MERGED_OUT="$AUDIT_DIR/merged.md"
-GRAPH_JSON="$AUDIT_DIR/graph.json"
-GRAPH_JSONL="$AUDIT_DIR/issues.jsonl"
-GRAPH_AFTER_JSONL="$AUDIT_DIR/issues.after.jsonl"
-TRIAGE_OUT="$AUDIT_DIR/triage.txt"
-PLAN_OUT="$AUDIT_DIR/plan.txt"
-SUGGEST_OUT="$AUDIT_DIR/suggest.txt"
-GRAPH_DEPS_JSON="$AUDIT_DIR/graph-dependencies.json"
-ISSUE_DIR="$AUDIT_DIR/issues"
-SOURCE_DIR="$AUDIT_DIR/sources"
-SOURCE_MANIFEST="$AUDIT_DIR/source-manifest.txt"
-SOURCE_STATE_BEFORE="$AUDIT_DIR/source-state.before.txt"
-SOURCE_STATE_AFTER="$AUDIT_DIR/source-state.after.txt"
-mkdir -p "$ISSUE_DIR" "$SOURCE_DIR"
-```
-
-Use a unique directory so retries never overwrite the evidence from a failed or
-ambiguous run.
-
-Run every shell block in this reference in the same Bash process. The initial
-`set -euo pipefail` is part of the safety contract: snapshot capture must stop on
-any failed `br`, `bv`, `jq`, copy, or fingerprint command.
-
-## Shared graph snapshot
-
-Flush before capture, prohibit graph mutations while the panel runs, and give both
-reviewers the same baseline files. First define `SOURCE_FILES` as a Bash array
-containing the authoritative plan/spec, `README.md`, `AGENTS.md` when present,
-approved deltas/waivers, and every linked document needed to interpret the plan.
-The panel must not discover requirement sources live.
-
-```bash
-fingerprint_file() {
-  local raw
-  if command -v sha256sum >/dev/null 2>&1; then
-    raw=$(sha256sum "$1") || return
-    printf '%s\n' "${raw%% *}"
-  elif command -v shasum >/dev/null 2>&1; then
-    raw=$(shasum -a 256 "$1") || return
-    printf '%s\n' "${raw%% *}"
-  else
-    echo "SHA-256 unavailable: install sha256sum or shasum" >&2
-    return 1
-  fi
-}
-
-# Add every authoritative/linked requirement file before capture, without
-# duplicates. Use add_source for approved deltas, waivers, and linked docs.
-SOURCE_FILES=()
-add_source() {
-  local candidate=$1 existing
-  for existing in "${SOURCE_FILES[@]}"; do
-    [ "$existing" != "$candidate" ] || return 0
-  done
-  SOURCE_FILES+=("$candidate")
-}
-add_source "$PLAN_PATH"
-[ ! -f "$REPO_ROOT/README.md" ] || add_source "$REPO_ROOT/README.md"
-# Extend before AGENTS discovery, for example:
-# add_source "$REPO_ROOT/docs/APPROVED-DELTA.md"
-# add_source "$REPO_ROOT/docs/ROLLOUT.md"
-
-# Include every AGENTS.md that governs a source: the file's directory, each
-# ancestor directory, and the repository root.
-governed_sources=("${SOURCE_FILES[@]}")
-for governed in "${governed_sources[@]}"; do
-  dir=$(dirname "$governed")
-  while [ "$dir" = "$REPO_ROOT" ] || [[ "$dir" == "$REPO_ROOT/"* ]]; do
-    [ ! -f "$dir/AGENTS.md" ] || add_source "$dir/AGENTS.md"
-    [ "$dir" != "$REPO_ROOT" ] || break
-    dir=$(dirname "$dir")
-  done
-done
-
-: >"$SOURCE_MANIFEST"
-: >"$SOURCE_STATE_BEFORE"
-source_n=0
-for src in "${SOURCE_FILES[@]}"; do
-  [ -f "$src" ] || {
-    echo "Missing audit source: $src" >&2
-    exit 1
-  }
-  source_n=$((source_n + 1))
-  copy="$SOURCE_DIR/$(printf '%03d' "$source_n")-$(basename "$src")"
-  cp "$src" "$copy"
-  copy_fp=$(fingerprint_file "$copy") || {
-    echo "Could not fingerprint source snapshot: $copy" >&2
-    exit 1
-  }
-  live_fp=$(fingerprint_file "$src") || {
-    echo "Could not fingerprint source: $src" >&2
-    exit 1
-  }
-  [ -n "$copy_fp" ] && [ "$copy_fp" = "$live_fp" ] || {
-    echo "Audit source changed while being snapshotted: $src" >&2
-    exit 1
-  }
-  printf '%s\t%s\n' "$src" "$copy" >>"$SOURCE_MANIFEST"
-  printf '%s\t%s\n' "$live_fp" "$src" >>"$SOURCE_STATE_BEFORE"
-done
-
-# RESOLVE AND INSPECT BEFORE FLUSHING. The flush writes the cache over the tracked file,
-# so an unstaged hand-edit is destroyed HERE — and the diff below then compares the file
-# against an index that already matches it, comes back empty, and the audit snapshots the
-# truncated graph having "checked". The check has to precede the write it guards.
 BEADS_JSONL_RESOLVER=$(
   (
     # Resolve the clean interpreter in a subshell. POSIX special-builtin precedence
@@ -192,7 +76,7 @@ _bjp_regular_link_count() {
   fi
   printf '%s\n' "$count"
 }
-_bjp_git_environment=( "${!GIT_@}" )
+_bjp_git_environment=( "${!GIT@}" )
 for _bjp_git_variable in "${_bjp_git_environment[@]}"; do
   command unset -- "$_bjp_git_variable" || {
     printf '%s\n' 'cannot sanitize the Git environment for beads-jsonl-path — do NOT write' >&2
@@ -202,6 +86,7 @@ done
 unset _bjp_git_variable _bjp_git_environment
 
 BEADS_JSONL_RESOLVER=
+BEADS_GIT_RUNNER=
 for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
   "${CODEX_HOME:-$HOME/.codex}/skills/beads-jsonl-path" \
   "$HOME/.agents/skills/beads-jsonl-path"; do
@@ -246,6 +131,10 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
       exit 1
       ;;
   esac
+  [ -f "$_bjp_candidate" ] || {
+    printf '%s\n' 'installed beads-jsonl-path resolver is not a regular file — do NOT write' >&2
+    exit 1
+  }
   _bjp_link_count=$(_bjp_regular_link_count "$_bjp_candidate") || {
     printf '%s\n' 'cannot inspect installed beads-jsonl-path resolver hard-link count — do NOT write' >&2
     exit 1
@@ -264,16 +153,50 @@ for _bjp_dir in "$HOME/.claude/skills/beads-jsonl-path" \
     exit 1
   }
   unset _bjp_shebang
+  _bjp_runner="$_bjp_candidate_dir/git-clean"
+  [ -x "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner unavailable — do NOT write' >&2
+    exit 1
+  }
+  [ ! -L "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is a symbolic link — do NOT write' >&2
+    exit 1
+  }
+  [ -f "$_bjp_runner" ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner is not a regular file — do NOT write' >&2
+    exit 1
+  }
+  _bjp_link_count=$(_bjp_regular_link_count "$_bjp_runner") || {
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner hard-link count — do NOT write' >&2
+    exit 1
+  }
+  [ "$_bjp_link_count" = 1 ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has multiple hard links — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_link_count
+  if ! IFS= command builtin read -r _bjp_shebang <"$_bjp_runner"; then
+    printf '%s\n' 'cannot inspect installed beads-jsonl-path Git runner interpreter — do NOT write' >&2
+    exit 1
+  fi
+  [ "$_bjp_shebang" = '#!/bin/sh' ] || {
+    printf '%s\n' 'installed beads-jsonl-path Git runner has an unexpected interpreter — do NOT write' >&2
+    exit 1
+  }
+  unset _bjp_shebang
   unset _bjp_candidate_dir
   if [ -z "$BEADS_JSONL_RESOLVER" ]; then
     BEADS_JSONL_RESOLVER=$_bjp_candidate
-  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate"; then
+    BEADS_GIT_RUNNER=$_bjp_runner
+  elif ! "$_bjp_cmp" -s "$BEADS_JSONL_RESOLVER" "$_bjp_candidate" \
+      || ! "$_bjp_cmp" -s "$BEADS_GIT_RUNNER" "$_bjp_runner"; then
     printf '%s\n' 'installed beads-jsonl-path companions disagree — do NOT write' >&2
     exit 1
   fi
+  unset _bjp_runner
 done
 unset _bjp_candidate _bjp_root _bjp_root_raw _bjp_git _bjp_cmp _bjp_stat
-[ -n "$BEADS_JSONL_RESOLVER" ] || {
+[ -n "$BEADS_JSONL_RESOLVER" ] && [ -n "$BEADS_GIT_RUNNER" ] || {
   printf '%s\n' 'beads-jsonl-path companion unavailable — do NOT write' >&2
   exit 1
 }
@@ -281,6 +204,7 @@ printf '%s\n' "$BEADS_JSONL_RESOLVER"
 __BJP_TRUSTED_BASH__
   )
 ) || exit 1
+BEADS_GIT_RUNNER=${BEADS_JSONL_RESOLVER%/*}/git-clean
 unset _bjp_candidate
 # Installed targets only. A relative `skills/beads-jsonl-path/scripts/resolve-beads-jsonl`
 # is whatever executable the audited repo planted there, and this snippet would run it.
@@ -289,6 +213,102 @@ unset _bjp_candidate
   echo "beads-jsonl-path companion unavailable — do NOT flush" >&2
   exit 1
 }
+REPO_ROOT=$("$BEADS_GIT_RUNNER" worktree-root) || exit 1
+_PROJECT=${REPO_ROOT##*/}
+[[ -n "$_PROJECT" ]] || _PROJECT=root
+_PROJECT=${_PROJECT//[^A-Za-z0-9._-]/_}
+AUDIT_DIR=$("$BEADS_GIT_RUNNER" make-temp-dir "bead-audit-${_PROJECT}") || exit 1
+
+AUDIT_PROMPT_FILE="$AUDIT_DIR/audit-prompt.txt"
+CODEX_OUT="$AUDIT_DIR/codex.txt"
+CODEX_TRACE="$AUDIT_DIR/codex.trace.txt"
+CODEX_ERR="$AUDIT_DIR/codex.stderr.txt"
+CLAUDE_RAW="$AUDIT_DIR/claude.raw.json"
+CLAUDE_OUT="$AUDIT_DIR/claude.txt"
+CLAUDE_ERR="$AUDIT_DIR/claude.stderr.txt"
+MERGED_OUT="$AUDIT_DIR/merged.md"
+GRAPH_JSON="$AUDIT_DIR/graph.json"
+GRAPH_JSONL="$AUDIT_DIR/issues.jsonl"
+GRAPH_AFTER_JSONL="$AUDIT_DIR/issues.after.jsonl"
+GRAPH_AFTER_SYNC_JSONL="$AUDIT_DIR/issues.after-sync.jsonl"
+TRIAGE_OUT="$AUDIT_DIR/triage.txt"
+PLAN_OUT="$AUDIT_DIR/plan.txt"
+SUGGEST_OUT="$AUDIT_DIR/suggest.txt"
+GRAPH_DEPS_JSON="$AUDIT_DIR/graph-dependencies.json"
+ISSUE_DIR="$AUDIT_DIR/issues"
+SOURCE_DIR="$AUDIT_DIR/sources"
+SOURCE_MANIFEST="$AUDIT_DIR/source-manifest.txt"
+SOURCE_STATE_BEFORE="$AUDIT_DIR/source-state.before.txt"
+SOURCE_STATE_AFTER="$AUDIT_DIR/source-state.after.txt"
+"$BEADS_GIT_RUNNER" make-dir "$ISSUE_DIR" "$SOURCE_DIR"
+```
+
+Use a unique directory so retries never overwrite the evidence from a failed or
+ambiguous run.
+
+Run every shell block in this reference in the same Bash process. The initial
+`set -euo pipefail` is part of the safety contract: snapshot capture must stop on
+any failed `br`, `bv`, `jq`, copy, or fingerprint command.
+
+## Shared graph snapshot
+
+Flush before capture, prohibit graph mutations while the panel runs, and give both
+reviewers the same baseline files. First define `SOURCE_FILES` as a Bash array
+containing the authoritative plan/spec, `README.md`, `AGENTS.md` when present,
+approved deltas/waivers, and every linked document needed to interpret the plan.
+The panel must not discover requirement sources live.
+
+```bash
+fingerprint_file() {
+  "$BEADS_GIT_RUNNER" hash-file "$1"
+}
+
+# Add every authoritative/linked requirement file before capture, without
+# duplicates. Use add_source for approved deltas, waivers, and linked docs.
+SOURCE_FILES=()
+add_source() {
+  local candidate=$1 existing
+  for existing in "${SOURCE_FILES[@]}"; do
+    [ "$existing" != "$candidate" ] || return 0
+  done
+  SOURCE_FILES+=("$candidate")
+}
+add_source "$PLAN_PATH"
+[ ! -f "$REPO_ROOT/README.md" ] || add_source "$REPO_ROOT/README.md"
+# Extend before AGENTS discovery, for example:
+# add_source "$REPO_ROOT/docs/APPROVED-DELTA.md"
+# add_source "$REPO_ROOT/docs/ROLLOUT.md"
+
+# Include every AGENTS.md that governs a source: the file's directory, each
+# ancestor directory, and the repository root.
+governed_sources=("${SOURCE_FILES[@]}")
+for governed in "${governed_sources[@]}"; do
+  [[ "$governed" == /*/* ]] || {
+    echo "Audit source is not an absolute file path: $governed" >&2
+    exit 1
+  }
+  dir=${governed%/*}
+  [[ -n "$dir" ]] || dir=/
+  while [[ "$REPO_ROOT" == / || "$dir" == "$REPO_ROOT" \
+           || "$dir" == "$REPO_ROOT/"* ]]; do
+    [ ! -f "$dir/AGENTS.md" ] || add_source "$dir/AGENTS.md"
+    [ "$dir" != "$REPO_ROOT" ] || break
+    dir=${dir%/*}
+    [[ -n "$dir" ]] || dir=/
+  done
+done
+
+"$BEADS_GIT_RUNNER" snapshot-files \
+  "$SOURCE_MANIFEST" "$SOURCE_STATE_BEFORE" "$SOURCE_DIR" -- \
+  "${SOURCE_FILES[@]}" || {
+  echo "Could not capture a stable authoritative-source snapshot" >&2
+  exit 1
+}
+
+# RESOLVE AND INSPECT BEFORE FLUSHING. The flush writes the cache over the tracked file,
+# so an unstaged hand-edit is destroyed HERE — and the diff below then compares the file
+# against an index that already matches it, comes back empty, and the audit snapshots the
+# truncated graph having "checked". The check has to precede the write it guards.
 # --allow-dirty: do NOT gate on a clean file here. The normal `bead-polish-loop` handoff
 # arrives with the round's intended `br` edits flushed and uncommitted, so the owner's
 # default clean-state mode would block the audit after every non-noop round.
@@ -301,22 +321,27 @@ unset _bjp_candidate
 # clean-looking diff and flush the damage.
 #
 # `--allow-dirty` retains the owner's tracked stage-0, normal-flag, regular-mode proof and
-# drops byte identity only where the two commands below can still see the difference: it
-# refuses a write a file system monitor's cache is hiding from them, because then the diff
-# you are about to read reports a clean file over changed bead bodies.
-# Run both commands anyway: status distinguishes staged from
-# unstaged intended edits, while the HEAD diff exposes both for review before the flush.
+# drops byte identity only where the HEAD diff below can still expose both staged and
+# unstaged differences. The clean runner disables stale fsmonitor answers, external
+# diff drivers, textconv, and binary attributes.
+unset BEADS_DIFF_REVIEWED
 BEADS_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) || exit 1
-git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs status --porcelain -- "$BEADS_JSONL" || { echo "cannot read the worktree — do NOT flush" >&2; exit 1; }
-git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
+"$BEADS_GIT_RUNNER" --literal-pathspecs diff --no-ext-diff --no-textconv --text HEAD -- "$BEADS_JSONL"          || { echo "cannot diff the JSONL — do NOT flush" >&2; exit 1; }
 # Keep a copy of what the worktree held BEFORE the flush. Neither git ref works as the
 # post-flush baseline: if the index holds an earlier damaged export and the worktree holds
 # the good recovery, HEAD-vs-worktree looks fine beforehand, the flush replaces the good
 # copy with the indexed damage, and a worktree-vs-index diff afterwards is EMPTY because
 # both now hold it. Only the pre-flush bytes can show that.
-cp "$BEADS_JSONL" "$AUDIT_DIR/preflush.jsonl" || { echo "cannot preserve the pre-flush graph" >&2; exit 1; }
-: "${BEADS_DIFF_REVIEWED:?read the two commands above, then set this to how you resolved it}"
-br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
+"$BEADS_GIT_RUNNER" copy-file "$BEADS_JSONL" "$AUDIT_DIR/preflush.jsonl" || { echo "cannot preserve the pre-flush graph" >&2; exit 1; }
+```
+
+**Stop the block here and read the HEAD diff.** Continue in the same Bash process
+only after binding `BEADS_DIFF_REVIEWED` to this audit. A value from an earlier
+skill step or audit was explicitly cleared above and cannot authorize this flush.
+
+```bash
+: "${BEADS_DIFF_REVIEWED:?read the HEAD diff above, then set this to how you resolved it}"
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || { echo "flush failed — do not audit an unwritten graph" >&2; exit 1; }
 
 # STOP HERE AND READ THIS DIFF before snapshotting. The flush just re-exported EVERY bead
 # from the gitignored cache over the tracked JSONL, so any body the cache held a stale copy
@@ -327,7 +352,16 @@ br sync --flush-only || { echo "flush failed — do not audit an unwritten graph
 # `description` this session did not write, is the tell. Recovery:
 # exact companion skill rb-lite-backlog-drain, step 11:
 # ../../rb-lite-backlog-drain/SKILL.md#backlog-step-11.
-git --no-replace-objects -c core.fsmonitor=false --literal-pathspecs diff -- "$BEADS_JSONL"
+unset BEADS_POSTFLUSH_REVIEWED
+if "$BEADS_GIT_RUNNER" diff-files "$AUDIT_DIR/preflush.jsonl" "$BEADS_JSONL"; then
+  _BEADS_POSTFLUSH_DIFF_RC=0
+else
+  _BEADS_POSTFLUSH_DIFF_RC=$?
+fi
+case $_BEADS_POSTFLUSH_DIFF_RC in
+  0|1) ;;
+  *) echo "cannot compare the pre/post-flush JSONL bytes — do NOT audit" >&2; exit 1 ;;
+esac
 ```
 
 **Stop the block here.** The line above is a real gate, not a comment: run the snapshot
@@ -338,11 +372,14 @@ exists to catch. If you must automate it, make the continuation conditional on a
 recorded acknowledgement rather than on the diff having been printed.
 
 ```bash
-# Compare against the PRE-FLUSH bytes, not against the index. This is the only baseline
-# that can show a flush replacing a good worktree copy with an indexed damaged one.
-diff -u "$AUDIT_DIR/preflush.jsonl" "$BEADS_JSONL" \
-  || : "${BEADS_POSTFLUSH_REVIEWED:?the flush changed the graph — read that diff, then set this}"
-cp "$BEADS_JSONL" "$GRAPH_JSONL"
+# The first block accepted only diff statuses 0 (same) and 1 (different). Status
+# 1 needs an acknowledgement bound to this audit after reading that block's output.
+case $_BEADS_POSTFLUSH_DIFF_RC in
+  0) ;;
+  1) : "${BEADS_POSTFLUSH_REVIEWED:?the flush changed the graph — read this audit's diff, then set this}" ;;
+  *) echo "missing a valid pre/post-flush comparison — do NOT audit" >&2; exit 1 ;;
+esac
+"$BEADS_GIT_RUNNER" copy-file "$BEADS_JSONL" "$GRAPH_JSONL"
 GRAPH_FINGERPRINT=$(fingerprint_file "$GRAPH_JSONL") || {
   echo "Could not fingerprint initial graph snapshot" >&2
   exit 1
@@ -352,13 +389,13 @@ GRAPH_FINGERPRINT=$(fingerprint_file "$GRAPH_JSONL") || {
   exit 1
 }
 
-br list --limit 0 --json -a >"$GRAPH_JSON"
-bv --robot-triage >"$TRIAGE_OUT"
-bv --robot-plan >"$PLAN_OUT"
-bv --robot-suggest >"$SUGGEST_OUT"
-br graph --all --json >"$GRAPH_DEPS_JSON"
+"$BEADS_JSONL_RESOLVER" --run-br list --limit 0 --json -a >"$GRAPH_JSON"
+"$BEADS_GIT_RUNNER" run-audit-tool bv --robot-triage >"$TRIAGE_OUT"
+"$BEADS_GIT_RUNNER" run-audit-tool bv --robot-plan >"$PLAN_OUT"
+"$BEADS_GIT_RUNNER" run-audit-tool bv --robot-suggest >"$SUGGEST_OUT"
+"$BEADS_JSONL_RESOLVER" --run-br graph --all --json >"$GRAPH_DEPS_JSON"
 
-if ISSUE_IDS=$(jq -er '(.issues // .)[] | .id' <"$GRAPH_JSON"); then
+if ISSUE_IDS=$("$BEADS_JSONL_RESOLVER" --run-jq -er '(.issues // .)[] | .id' <"$GRAPH_JSON"); then
   :
 else
   echo "Could not extract issue IDs from graph snapshot" >&2
@@ -366,13 +403,13 @@ else
 fi
 
 while IFS= read -r id; do
-  safe_id=$(printf '%s' "$id" | tr -c 'A-Za-z0-9._-' '_')
-  br show "$id" --json >"$ISSUE_DIR/$safe_id.json"
+  safe_id=${id//[^A-Za-z0-9._-]/_}
+  "$BEADS_JSONL_RESOLVER" --run-br show "$id" --json >"$ISSUE_DIR/$safe_id.json"
 done <<<"$ISSUE_IDS"
 
-br sync --flush-only
+"$BEADS_JSONL_RESOLVER" --run-br sync --flush-only
 CAPTURE_AFTER_JSONL="$AUDIT_DIR/issues.capture-after.jsonl"
-cp "$BEADS_JSONL" "$CAPTURE_AFTER_JSONL"
+"$BEADS_GIT_RUNNER" copy-file "$BEADS_JSONL" "$CAPTURE_AFTER_JSONL"
 CAPTURE_AFTER_FINGERPRINT=$(fingerprint_file "$CAPTURE_AFTER_JSONL") || {
   echo "Could not fingerprint graph after capture" >&2
   exit 1
@@ -410,7 +447,7 @@ instructions and shell quoting cannot truncate the rubric.
   printf 'Shared suggest output: %s\n' "$SUGGEST_OUT"
   printf 'Shared dependency graph: %s\n' "$GRAPH_DEPS_JSON"
   printf 'Per-issue JSON directory: %s\n\n' "$ISSUE_DIR"
-  cat <<'EOF'
+  "$BEADS_GIT_RUNNER" run-posix sed -n 'p' <<'EOF'
 This is the final read-only launch-readiness gate after bead polishing. Independently
 derive your judgment from the plan and graph. Do not trust or search for another
 reviewer's conclusions.
@@ -530,12 +567,50 @@ if [ -n "$CLAUDE_MODEL_PIN" ]; then export CLAUDE_REVIEWER_MODELS="$CLAUDE_MODEL
 not pay for a probe of a reviewer it excluded — up to 90 seconds per unreachable rung,
 and a real model call.
 
-Run the bounded probe in
-[multi-reviewer-loop/references/reviewer-panel.md](../../multi-reviewer-loop/references/reviewer-panel.md)
-§ Resolving the Claude reviewer's model — same ladder, same acceptance rule, reading the
-`CLAUDE_REVIEWER_MODELS` just set. An unreachable model hangs rather than erroring, so
-without the probe the 900s `timeout` is the first thing that notices, and it reports the
-auditor as `failed` after fifteen minutes rather than as `substituted` after one.
+Use this audit's already validated tool boundary for the probe. Do **not** run the
+ambient-tool probe from `multi-reviewer-loop`: its caller-PATH lookup would cross
+the trust boundary before this panel's hardened dispatch.
+
+```bash
+CLAUDE_MODEL=""
+CLAUDE_MODEL_LADDER="${CLAUDE_REVIEWER_MODELS:-fable opus}"
+_CLAUDE_PROBE="$AUDIT_DIR/claude-model-probe.json"
+_CLAUDE_PROBE_TIMEOUT=
+if "$BEADS_GIT_RUNNER" run-audit-tool timeout \
+     --kill-after=1s 1s true >/dev/null 2>&1; then
+  _CLAUDE_PROBE_TIMEOUT=timeout
+elif "$BEADS_GIT_RUNNER" run-audit-tool gtimeout \
+     --kill-after=1s 1s true >/dev/null 2>&1; then
+  _CLAUDE_PROBE_TIMEOUT=gtimeout
+fi
+if [ -n "$_CLAUDE_PROBE_TIMEOUT" ] \
+    && CLAUDE_BIN=$("$BEADS_GIT_RUNNER" resolve-tool claude); then
+  for _m in $CLAUDE_MODEL_LADDER; do
+    _rc=0
+    "$BEADS_GIT_RUNNER" run-audit-tool "$_CLAUDE_PROBE_TIMEOUT" \
+      --kill-after=15 90 "$CLAUDE_BIN" -p 'Reply with exactly: PANEL_OK' \
+      --model "$_m" --output-format json \
+      --no-session-persistence --safe-mode --strict-mcp-config \
+      --mcp-config '{"mcpServers":{}}' \
+      --tools "Read" --allowedTools "Read" \
+      --disallowedTools "Edit,Write,NotebookEdit" \
+      </dev/null >"$_CLAUDE_PROBE" 2>/dev/null || _rc=$?
+    if [ "$_rc" -eq 0 ] \
+       && "$BEADS_JSONL_RESOLVER" --run-jq -e \
+          '(.is_error | not) and ((.result // "") != "")' \
+          <"$_CLAUDE_PROBE" >/dev/null 2>&1; then
+      CLAUDE_MODEL=$_m
+      break
+    fi
+    echo "claude auditor: '$_m' did not answer (exit $_rc)"
+  done
+fi
+unset _CLAUDE_PROBE_TIMEOUT _rc
+```
+
+An unreachable model hangs rather than erroring, so without the bounded probe
+the 900s audit timeout is the first thing that notices and reports a failure
+after fifteen minutes rather than a substitution after one.
 
 If no candidate answers, **drop `claude` from `PANEL_REVIEWERS`** and record why —
 rebuilding the list rather than deleting a token, since `codex,claude` minus a token
@@ -574,12 +649,12 @@ fi
 
 ```bash
 # $PANEL_REVIEWERS was defaulted and normalized in step 1 — do not re-default it here.
-if command -v timeout >/dev/null 2>&1 &&
-   timeout --kill-after=1s 1s true >/dev/null 2>&1; then
-  TIMEOUT_BIN=$(command -v timeout)
-elif command -v gtimeout >/dev/null 2>&1 &&
-     gtimeout --kill-after=1s 1s true >/dev/null 2>&1; then
-  TIMEOUT_BIN=$(command -v gtimeout)
+if "$BEADS_GIT_RUNNER" run-audit-tool timeout \
+     --kill-after=1s 1s true >/dev/null 2>&1; then
+  TIMEOUT_TOOL=timeout
+elif "$BEADS_GIT_RUNNER" run-audit-tool gtimeout \
+     --kill-after=1s 1s true >/dev/null 2>&1; then
+  TIMEOUT_TOOL=gtimeout
 else
   echo "GNU timeout is required (timeout or gtimeout)" >&2
   exit 1
@@ -595,7 +670,9 @@ case "$PANEL_REVIEWERS" in
 esac
 
 if $RUN_CODEX; then
-  "$TIMEOUT_BIN" --kill-after=30s 900s codex exec \
+  CODEX_BIN=$("$BEADS_GIT_RUNNER" resolve-tool codex) || exit 1
+  "$BEADS_GIT_RUNNER" run-audit-tool "$TIMEOUT_TOOL" \
+    --kill-after=30s 900s "$CODEX_BIN" exec \
     -C "$REPO_ROOT" \
     --sandbox read-only \
     --ephemeral \
@@ -604,15 +681,16 @@ if $RUN_CODEX; then
     -m gpt-5.6-sol \
     -c 'model_reasoning_effort="xhigh"' \
     --output-last-message "$CODEX_OUT" \
-    "$(cat "$AUDIT_PROMPT_FILE")" \
+    "$(<"$AUDIT_PROMPT_FILE")" \
     </dev/null >"$CODEX_TRACE" 2>"$CODEX_ERR" &
   CODEX_PID=$!
 fi
 
 if $RUN_CLAUDE; then
+  CLAUDE_BIN=$("$BEADS_GIT_RUNNER" resolve-tool claude) || exit 1
   (
-    cd "$REPO_ROOT"
-    "$TIMEOUT_BIN" --kill-after=30s 900s claude -p "$(cat "$AUDIT_PROMPT_FILE")" \
+    "$BEADS_GIT_RUNNER" run-audit-tool "$TIMEOUT_TOOL" \
+      --kill-after=30s 900s "$CLAUDE_BIN" -p "$(<"$AUDIT_PROMPT_FILE")" \
       --model "$CLAUDE_MODEL" \
       --effort high \
       --output-format json \
@@ -668,8 +746,9 @@ Keep both facts true together: any future read of these variables that is *not* 
 `$RUN_CLAUDE` needs them initialised here or it aborts.
 
 ```bash
-if jq -er 'if .is_error then error(.result // "claude auditor returned is_error")
-           else (.result // empty) end' <"$CLAUDE_RAW" >"$CLAUDE_OUT"; then
+if "$BEADS_JSONL_RESOLVER" --run-jq -er \
+     'if .is_error then error(.result // "claude auditor returned is_error")
+      else (.result // empty) end' <"$CLAUDE_RAW" >"$CLAUDE_OUT"; then
   JQ_RC=0
 else
   JQ_RC=$?
@@ -683,10 +762,19 @@ into reviewer state:
 CLAUDE_DENIALS=
 CLAUDE_INSPECTION_BLOCKED=false
 if [ "$JQ_RC" -eq 0 ]; then
-  if CLAUDE_DENIALS=$(jq -r '.permission_denials[]?.tool_name' <"$CLAUDE_RAW"); then
-    if printf '%s\n' "$CLAUDE_DENIALS" |
-       grep -qE '^(Read|Glob|Grep)$'; then
+  if CLAUDE_DENIALS=$("$BEADS_JSONL_RESOLVER" --run-jq -r \
+      '.permission_denials[]?.tool_name' <"$CLAUDE_RAW"); then
+    if "$BEADS_JSONL_RESOLVER" --run-jq -e \
+         'any(.permission_denials[]?.tool_name;
+              . == "Read" or . == "Glob" or . == "Grep")' \
+         <"$CLAUDE_RAW" >/dev/null; then
       CLAUDE_INSPECTION_BLOCKED=true
+    else
+      _CLAUDE_DENIAL_PREDICATE_RC=$?
+      if [ "$_CLAUDE_DENIAL_PREDICATE_RC" -ne 1 ]; then
+        JQ_RC=$_CLAUDE_DENIAL_PREDICATE_RC
+      fi
+      unset _CLAUDE_DENIAL_PREDICATE_RC
     fi
   else
     JQ_RC=$?
@@ -705,7 +793,7 @@ Optionally confirm the actual model:
 
 ```bash
 if [ "$JQ_RC" -eq 0 ]; then
-  jq -r '.modelUsage | keys[]' <"$CLAUDE_RAW" || true
+  "$BEADS_JSONL_RESOLVER" --run-jq -r '.modelUsage | keys[]' <"$CLAUDE_RAW" || true
 fi
 ```
 
@@ -729,26 +817,30 @@ Validate the complete contract, not only whether tags exist:
 ```bash
 validate_audit_output() {
   local file=$1 verdict rationale blockers important nits total closing
+  local -a closing_lines
   [ -s "$file" ] || return 1
-  verdict=$(sed -n '1s/^VERDICT: //p' "$file")
-  rationale=$(sed -n '2p' "$file")
+  verdict=$("$BEADS_GIT_RUNNER" run-posix sed -n '1s/^VERDICT: //p' "$file")
+  rationale=$("$BEADS_GIT_RUNNER" run-posix sed -n '2p' "$file")
   [ -n "$rationale" ] || return 1
-  if printf '%s\n' "$rationale" |
-     grep -qE '^(\[(BLOCKER|IMPORTANT|NIT)\]|No findings\.|COVERAGE:|DEPENDENCIES:|VERIFICATION:)'; then
+  if "$BEADS_GIT_RUNNER" grep -qE \
+      '^(\[(BLOCKER|IMPORTANT|NIT)\]|No findings\.|COVERAGE:|DEPENDENCIES:|VERIFICATION:)' \
+      <<<"$rationale"; then
     return 1
   fi
-  blockers=$(grep -cE '^[[:space:]]*\[BLOCKER\]' "$file" || true)
-  important=$(grep -cE '^[[:space:]]*\[IMPORTANT\]' "$file" || true)
-  nits=$(grep -cE '^[[:space:]]*\[NIT\]' "$file" || true)
+  blockers=$("$BEADS_GIT_RUNNER" grep -cE '^[[:space:]]*\[BLOCKER\]' "$file" || true)
+  important=$("$BEADS_GIT_RUNNER" grep -cE '^[[:space:]]*\[IMPORTANT\]' "$file" || true)
+  nits=$("$BEADS_GIT_RUNNER" grep -cE '^[[:space:]]*\[NIT\]' "$file" || true)
   total=$((blockers + important + nits))
 
-  closing=$(tail -n 3 "$file")
-  printf '%s\n' "$closing" | sed -n '1p' | grep -q '^COVERAGE:' || return 1
-  printf '%s\n' "$closing" | sed -n '2p' | grep -q '^DEPENDENCIES:' || return 1
-  printf '%s\n' "$closing" | sed -n '3p' | grep -q '^VERIFICATION:' || return 1
+  closing=$("$BEADS_GIT_RUNNER" run-posix tail -n 3 "$file")
+  mapfile -t closing_lines <<<"$closing"
+  [ "${#closing_lines[@]}" -eq 3 ] || return 1
+  [[ "${closing_lines[0]}" == COVERAGE:* ]] || return 1
+  [[ "${closing_lines[1]}" == DEPENDENCIES:* ]] || return 1
+  [[ "${closing_lines[2]}" == VERIFICATION:* ]] || return 1
 
   # Every finding must carry all three support fields before the next finding.
-  awk '
+  "$BEADS_GIT_RUNNER" run-posix awk '
     function finish() {
       if (in_item && !(have_evidence && have_why && have_fix)) exit 1
     }
@@ -773,9 +865,9 @@ validate_audit_output() {
   fi
 
   if [ "$total" -eq 0 ]; then
-    grep -qx 'No findings\.' "$file" || return 1
+    "$BEADS_GIT_RUNNER" grep -qx 'No findings\.' "$file" || return 1
   else
-    ! grep -qx 'No findings\.' "$file" || return 1
+    ! "$BEADS_GIT_RUNNER" grep -qx 'No findings\.' "$file" || return 1
   fi
 }
 
@@ -809,37 +901,44 @@ After both reviewers finish:
 ```bash
 PANEL_INVALID=false
 
-br sync --flush-only
-cp "$BEADS_JSONL" "$GRAPH_AFTER_JSONL"
-GRAPH_AFTER_FINGERPRINT=$(fingerprint_file "$GRAPH_AFTER_JSONL") || {
-  echo "Could not fingerprint graph after audit" >&2
-  exit 1
-}
-[ -n "$GRAPH_AFTER_FINGERPRINT" ] || {
-  echo "Post-audit graph fingerprint is empty" >&2
-  exit 1
-}
-if [ "$GRAPH_FINGERPRINT" != "$GRAPH_AFTER_FINGERPRINT" ]; then
-  printf 'Graph changed during audit: before=%s after=%s\n' \
+# Read and preserve the live JSONL BEFORE any flush can overwrite a concurrent
+# hand edit. Only an unchanged live snapshot may proceed to the cache-drift
+# flush below.
+if BEADS_CURRENT_JSONL=$("$BEADS_JSONL_RESOLVER" --allow-dirty) \
+    && [ "$BEADS_CURRENT_JSONL" = "$BEADS_JSONL" ] \
+    && "$BEADS_GIT_RUNNER" copy-file "$BEADS_CURRENT_JSONL" "$GRAPH_AFTER_JSONL" \
+    && GRAPH_AFTER_FINGERPRINT=$(fingerprint_file "$GRAPH_AFTER_JSONL") \
+    && [ -n "$GRAPH_AFTER_FINGERPRINT" ]; then
+  :
+else
+  echo "Could not preserve the live graph before the final drift check" >&2
+  PANEL_INVALID=true
+fi
+if ! $PANEL_INVALID && [ "$GRAPH_FINGERPRINT" != "$GRAPH_AFTER_FINGERPRINT" ]; then
+  printf 'Graph changed during audit before any final flush: before=%s after=%s\n' \
     "$GRAPH_FINGERPRINT" "$GRAPH_AFTER_FINGERPRINT" >&2
   PANEL_INVALID=true
 fi
 
-: >"$SOURCE_STATE_AFTER"
-for src in "${SOURCE_FILES[@]}"; do
-  [ -f "$src" ] || {
-    echo "Audit source disappeared during panel: $src" >&2
-    PANEL_INVALID=true
-    continue
+if ! $PANEL_INVALID; then
+  "$BEADS_JSONL_RESOLVER" --run-br sync --flush-only || {
+    echo "Could not flush for the final cache-drift check" >&2
+    exit 1
   }
-  if source_fp=$(fingerprint_file "$src") && [ -n "$source_fp" ]; then
-    printf '%s\t%s\n' "$source_fp" "$src" >>"$SOURCE_STATE_AFTER"
-  else
-    echo "Could not fingerprint audit source after panel: $src" >&2
+  "$BEADS_GIT_RUNNER" copy-file "$BEADS_CURRENT_JSONL" "$GRAPH_AFTER_SYNC_JSONL"
+  GRAPH_AFTER_SYNC_FINGERPRINT=$(fingerprint_file "$GRAPH_AFTER_SYNC_JSONL") || {
+    echo "Could not fingerprint graph after final cache flush" >&2
+    exit 1
+  }
+  if [ "$GRAPH_FINGERPRINT" != "$GRAPH_AFTER_SYNC_FINGERPRINT" ]; then
+    printf 'Beads cache changed during audit: before=%s after-sync=%s\n' \
+      "$GRAPH_FINGERPRINT" "$GRAPH_AFTER_SYNC_FINGERPRINT" >&2
     PANEL_INVALID=true
   fi
-done
-if ! cmp -s "$SOURCE_STATE_BEFORE" "$SOURCE_STATE_AFTER"; then
+fi
+
+if ! "$BEADS_GIT_RUNNER" verify-files \
+    "$SOURCE_STATE_BEFORE" "$SOURCE_STATE_AFTER" -- "${SOURCE_FILES[@]}"; then
   echo "One or more requirement sources changed during audit" >&2
   PANEL_INVALID=true
 fi
@@ -900,18 +999,18 @@ must fail closed:
   echo "Audit BLOCKED: merged report was not created" >&2
   exit 1
 }
-grep -q '^# Bead Graph Audit$' "$MERGED_OUT"
-grep -q '^## Panel$' "$MERGED_OUT"
-grep -q '^## Launch verdict$' "$MERGED_OUT"
-grep -q '^## Logs$' "$MERGED_OUT"
+"$BEADS_GIT_RUNNER" grep -q '^# Bead Graph Audit$' "$MERGED_OUT"
+"$BEADS_GIT_RUNNER" grep -q '^## Panel$' "$MERGED_OUT"
+"$BEADS_GIT_RUNNER" grep -q '^## Launch verdict$' "$MERGED_OUT"
+"$BEADS_GIT_RUNNER" grep -q '^## Logs$' "$MERGED_OUT"
 
 if $RUN_CODEX && [ "${CODEX_STATE:-failed}" = usable ]; then
   [ -s "$CODEX_OUT" ]
-  cp "$CODEX_OUT" "$AUDIT_DIR/audit.codex.txt"
+  "$BEADS_GIT_RUNNER" copy-file "$CODEX_OUT" "$AUDIT_DIR/audit.codex.txt"
 fi
 if $RUN_CLAUDE && [ "${CLAUDE_STATE:-failed}" = usable ]; then
   [ -s "$CLAUDE_OUT" ]
-  cp "$CLAUDE_OUT" "$AUDIT_DIR/audit.claude.txt"
+  "$BEADS_GIT_RUNNER" copy-file "$CLAUDE_OUT" "$AUDIT_DIR/audit.claude.txt"
 fi
-cp "$MERGED_OUT" "$AUDIT_DIR/audit.merged.md"
+"$BEADS_GIT_RUNNER" copy-file "$MERGED_OUT" "$AUDIT_DIR/audit.merged.md"
 ```


### PR DESCRIPTION
## Summary
- add the `beads-jsonl-path` companion skill and a fail-closed, read-only resolver for the actual Beads JSONL
- migrate all Beads-writing workflows to the synchronized installed-companion locator and add selective-install dependencies
- prove clean, dirty-audit, and recovery boundaries with adversarial fixtures wired into `check.sh`

## Lineage / context
Implements backlog bead `skills-iog` (E1) from `docs/specs/backlog-execution-plan.md`. The implementation was developed through rb-lite (`codex,claude`) and then bounded Codex + Claude Opus security reviews after rb-lite reached its round cap.

## Trade-offs accepted
- no repository-relative automatic fallback: an operator must explicitly provide a trusted absolute checkout-owner path when installed companions are unavailable
- PATH-selected `br` and `jq` are allowed only outside the driven worktree after complete symlink-chain canonicalization; standard proof tools are pinned to Bash's POSIX utility path
- `--allow-dirty` and `--recovery` are narrow read-only resolution modes, not authorization to query, mutate, or flush Beads

## Test plan
- [x] `skills/beads-jsonl-path/scripts/resolve-beads-jsonl.test` — 71 passed, 0 failed
- [x] `./install.test` — 39 passed, 0 failed
- [x] `./check.sh` — resolver 71, installer 39, bot-gate 124, drive-status 70; all clean
- [x] `git diff --check`
- [x] Red mutants killed for ambient proof tools, worktree `br`/`jq`, linked-worktree `.git`, outside symlink targets, the exact 40-hop boundary, and locator PATH spoofing
- [x] Local review (Codex gpt-5.6-sol xhigh + Claude Opus 4.6 high): current tip clean, no P0/P1/P2 findings
- [ ] CI green
- [ ] Codex bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure Beads JSONL path resolution with clean, dirty-inspection, and recovery modes.
  * Added trusted Git execution and isolated repository-operation safeguards.
  * Updated workflows to use validated resolution and post-write verification.

* **Bug Fixes**
  * Improved protection against unsafe paths, conflicting installations, malformed data, and hostile environments.
  * Added safeguards against unintended Beads or Git modifications.

* **Tests**
  * Expanded regression coverage for resolution, recovery, security, and workflow compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->