### PR TITLE
docs(drive): record the pre-0.3.0 rb-lite fallback in Guard 2

### DIFF
--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -581,6 +581,12 @@ unaffected (on 0.3.x it was filtered out too). Stop the loop and merge instead. 
 checkpoint to assess and relaunch, not a finish line. (See
 `references/autonomy-contract.md` § 4.)
 
+Check `rb-lite --version` before relying on any of this. The mechanical guards arrived in
+0.3.0; older builds have no skeptic and reject `--max-production-lines` as a usage error.
+On those, pass neither flag, hold the budget yourself by watching each round, and say in
+your report that the mechanical guards were unavailable — an unenforced budget reported as
+enforced is worse than none, because the reader stops watching.
+
 ### Guard 3 — Transitions fire their own gates
 
 Committing, pushing, reviewing, and opening the PR are **parts of a phase transition**,


### PR DESCRIPTION
## Summary

Guard 2 documents `--max-production-lines`, the P2 severity floor, and the 0.4.0 off-floor skeptic, but never says what to do when `rb-lite` predates any of it. The pre-0.3.0 case was living only in a personal harness prompt fragment — invisible to anyone else running the skill, and impossible to revise alongside the guidance it qualifies.

## Changes

- `skills/drive/SKILL.md`, Guard 2: six lines after the `--min-findings-severity` paragraph, covering the version check and the pre-0.3.0 fallback.

Older builds have no skeptic and reject `--max-production-lines` as a usage error. A driver that passes the flag on faith gets a usage failure instead of a budget; one that assumes the skeptic ran gets a panel that can only argue for adding.

The text also names the failure the fallback exists to prevent: an unenforced budget reported as enforced is worse than none, because the reader stops watching for the overrun the guard was supposed to catch.

## Test Plan

- [x] `bash check.sh` — exit 0, 135 passed, 0 failed
- [x] Documentation-only; no script or behavior change
- [x] Branched from `origin/master` (`91a766e`), single file, +6 lines

## Breaking Changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling older `rb-lite` versions, including unavailable validation options and the need for manual budget monitoring.
  * Documented the limitation when those options are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->